### PR TITLE
[CMS] Add read-only relation graph views

### DIFF
--- a/app/ponix/_components/cms-detail.tsx
+++ b/app/ponix/_components/cms-detail.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link"
+import type { ReactNode } from "react"
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Badge } from "@/components/ui/badge"
@@ -38,10 +39,12 @@ export function CmsDetailPage({
   detail,
   backHref,
   backLabel,
+  children,
 }: {
   detail: CmsContentDetail
   backHref: string
   backLabel: string
+  children?: ReactNode
 }) {
   const schema = getCmsSchema(detail.schemaKey)
   const fieldCount = schema?.fields.length ?? 0
@@ -160,6 +163,8 @@ export function CmsDetailPage({
             </Card>
           </div>
         </div>
+
+        {children && <div className="mt-6 space-y-6">{children}</div>}
       </section>
     </main>
   )

--- a/app/ponix/_components/cms-relations.tsx
+++ b/app/ponix/_components/cms-relations.tsx
@@ -1,0 +1,496 @@
+import Link from "next/link"
+import type { ReactNode } from "react"
+
+import { Badge } from "@/components/ui/badge"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import type {
+  CmsEntityRelation,
+  CmsLinkedEntity,
+  CmsLinkedPage,
+  CmsLinkedSection,
+  CmsPageSectionRelation,
+  CmsRelationList,
+  CmsSectionEntityRelation,
+} from "@/lib/cms/content"
+
+import { SchemaBadge } from "./cms-list"
+
+export function RelationCount({
+  visible,
+  count,
+  limit,
+}: {
+  visible: number
+  count: number | null
+  limit?: number
+}) {
+  const total = count ?? visible
+
+  return (
+    <p className="caps text-muted-foreground">
+      {limit && total > limit ? `${visible} of ${total}` : `${visible}`} records
+    </p>
+  )
+}
+
+export function PageSectionRelationsCard({
+  title = "Page sections",
+  description = "Ordered section placement for pages.",
+  relationList,
+  relations,
+}: {
+  title?: string
+  description?: string
+  relationList?: CmsRelationList<CmsPageSectionRelation>
+  relations?: CmsPageSectionRelation[]
+}) {
+  const rows = relationList?.relations ?? relations ?? []
+
+  return (
+    <RelationCard
+      title={title}
+      description={description}
+      visible={rows.length}
+      count={relationList?.count ?? rows.length}
+      limit={relationList?.limit}
+    >
+      <PageSectionRelationsTable relations={rows} />
+    </RelationCard>
+  )
+}
+
+export function SectionEntityRelationsCard({
+  title = "Section entities",
+  description = "Ordered entity curation inside sections.",
+  relationList,
+  relations,
+}: {
+  title?: string
+  description?: string
+  relationList?: CmsRelationList<CmsSectionEntityRelation>
+  relations?: CmsSectionEntityRelation[]
+}) {
+  const rows = relationList?.relations ?? relations ?? []
+
+  return (
+    <RelationCard
+      title={title}
+      description={description}
+      visible={rows.length}
+      count={relationList?.count ?? rows.length}
+      limit={relationList?.limit}
+    >
+      <SectionEntityRelationsTable relations={rows} />
+    </RelationCard>
+  )
+}
+
+export function EntityRelationsCard({
+  title = "Entity relations",
+  description = "Domain links between reusable entities.",
+  relationList,
+  relations,
+}: {
+  title?: string
+  description?: string
+  relationList?: CmsRelationList<CmsEntityRelation>
+  relations?: CmsEntityRelation[]
+}) {
+  const rows = relationList?.relations ?? relations ?? []
+
+  return (
+    <RelationCard
+      title={title}
+      description={description}
+      visible={rows.length}
+      count={relationList?.count ?? rows.length}
+      limit={relationList?.limit}
+    >
+      <EntityRelationsTable relations={rows} />
+    </RelationCard>
+  )
+}
+
+function RelationCard({
+  title,
+  description,
+  visible,
+  count,
+  limit,
+  children,
+}: {
+  title: string
+  description: string
+  visible: number
+  count: number | null
+  limit?: number
+  children: ReactNode
+}) {
+  return (
+    <Card className="rounded-md bg-card/95 shadow-xl">
+      <CardHeader className="border-b">
+        <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+          <div>
+            <CardTitle className="font-serif text-3xl italic">
+              {title}
+            </CardTitle>
+            <CardDescription>{description}</CardDescription>
+          </div>
+          <RelationCount visible={visible} count={count} limit={limit} />
+        </div>
+      </CardHeader>
+      <CardContent className="p-0">{children}</CardContent>
+    </Card>
+  )
+}
+
+function PageSectionRelationsTable({
+  relations,
+}: {
+  relations: CmsPageSectionRelation[]
+}) {
+  if (relations.length === 0) {
+    return <EmptyRelationRows message="No page-section relations." />
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Page</TableHead>
+          <TableHead>Order</TableHead>
+          <TableHead>Section</TableHead>
+          <TableHead>Renderer</TableHead>
+          <TableHead>Schema</TableHead>
+          <TableHead>Status</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {relations.map((relation) => (
+          <TableRow key={relation.id}>
+            <TableCell>
+              <PageLink page={relation.page} fallbackId={relation.pageId} />
+            </TableCell>
+            <TableCell className="font-mono text-xs">
+              {relation.sortOrder}
+            </TableCell>
+            <TableCell>
+              <SectionLink
+                section={relation.section}
+                fallbackId={relation.sectionId}
+              />
+            </TableCell>
+            <TableCell className="font-mono text-xs text-muted-foreground">
+              {relation.section?.sectionType ?? "missing"}
+            </TableCell>
+            <TableCell>
+              {relation.section ? (
+                <SchemaBadge
+                  label={relation.section.schemaLabel}
+                  registered={relation.section.schemaRegistered}
+                />
+              ) : (
+                <BrokenBadge />
+              )}
+            </TableCell>
+            <TableCell>
+              <PageSectionStatus relation={relation} />
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}
+
+function SectionEntityRelationsTable({
+  relations,
+}: {
+  relations: CmsSectionEntityRelation[]
+}) {
+  if (relations.length === 0) {
+    return <EmptyRelationRows message="No section-entity relations." />
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Section</TableHead>
+          <TableHead>Slot</TableHead>
+          <TableHead>Order</TableHead>
+          <TableHead>Entity</TableHead>
+          <TableHead>Type</TableHead>
+          <TableHead>Status</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {relations.map((relation) => (
+          <TableRow key={relation.id}>
+            <TableCell>
+              <SectionLink
+                section={relation.section}
+                fallbackId={relation.sectionId}
+              />
+            </TableCell>
+            <TableCell className="font-mono text-xs">{relation.slot}</TableCell>
+            <TableCell className="font-mono text-xs">
+              {relation.sortOrder}
+            </TableCell>
+            <TableCell>
+              <EntityLink entity={relation.entity} fallbackId={relation.entityId} />
+            </TableCell>
+            <TableCell className="font-mono text-xs text-muted-foreground">
+              {relation.relationType}
+            </TableCell>
+            <TableCell>
+              <SectionEntityStatus relation={relation} />
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}
+
+function EntityRelationsTable({
+  relations,
+}: {
+  relations: CmsEntityRelation[]
+}) {
+  if (relations.length === 0) {
+    return <EmptyRelationRows message="No entity relations." />
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>From</TableHead>
+          <TableHead>Type</TableHead>
+          <TableHead>Slot</TableHead>
+          <TableHead>Order</TableHead>
+          <TableHead>To</TableHead>
+          <TableHead>Status</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {relations.map((relation) => (
+          <TableRow key={relation.id}>
+            <TableCell>
+              <EntityLink
+                entity={relation.fromEntity}
+                fallbackId={relation.fromEntityId}
+              />
+            </TableCell>
+            <TableCell className="font-mono text-xs text-muted-foreground">
+              {relation.relationType}
+            </TableCell>
+            <TableCell className="font-mono text-xs">{relation.slot}</TableCell>
+            <TableCell className="font-mono text-xs">
+              {relation.sortOrder}
+            </TableCell>
+            <TableCell>
+              <EntityLink
+                entity={relation.toEntity}
+                fallbackId={relation.toEntityId}
+              />
+            </TableCell>
+            <TableCell>
+              <EntityRelationStatus relation={relation} />
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}
+
+function PageLink({
+  page,
+  fallbackId,
+}: {
+  page: CmsLinkedPage | null
+  fallbackId: string
+}) {
+  if (!page) {
+    return <MissingLink label={fallbackId} />
+  }
+
+  return (
+    <div>
+      <Link
+        href={`/ponix/pages/${page.id}`}
+        className="font-medium underline-offset-4 hover:underline"
+      >
+        {page.title}
+      </Link>
+      <div className="font-mono text-xs text-muted-foreground">{page.slug}</div>
+    </div>
+  )
+}
+
+function SectionLink({
+  section,
+  fallbackId,
+}: {
+  section: CmsLinkedSection | null
+  fallbackId: string
+}) {
+  if (!section) {
+    return <MissingLink label={fallbackId} />
+  }
+
+  return (
+    <div>
+      <Link
+        href={`/ponix/sections/${section.id}`}
+        className="font-medium underline-offset-4 hover:underline"
+      >
+        {section.title ?? section.key}
+      </Link>
+      <div className="font-mono text-xs text-muted-foreground">{section.key}</div>
+    </div>
+  )
+}
+
+function EntityLink({
+  entity,
+  fallbackId,
+}: {
+  entity: CmsLinkedEntity | null
+  fallbackId: string
+}) {
+  if (!entity) {
+    return <MissingLink label={fallbackId} />
+  }
+
+  return (
+    <div>
+      <Link
+        href={`/ponix/entities/${entity.id}`}
+        className="font-medium underline-offset-4 hover:underline"
+      >
+        {entity.title}
+      </Link>
+      <div className="font-mono text-xs text-muted-foreground">
+        {entity.slug ?? entity.entityType}
+      </div>
+    </div>
+  )
+}
+
+function MissingLink({ label }: { label: string }) {
+  return (
+    <div>
+      <div className="font-medium text-destructive">Missing target</div>
+      <div className="break-all font-mono text-xs text-muted-foreground">
+        {label}
+      </div>
+    </div>
+  )
+}
+
+function PageSectionStatus({
+  relation,
+}: {
+  relation: CmsPageSectionRelation
+}) {
+  return (
+    <StatusBadges
+      missing={!relation.page || !relation.section}
+      draft={!relation.page?.published || !relation.section?.published}
+      unregistered={!relation.section?.schemaRegistered}
+    />
+  )
+}
+
+function SectionEntityStatus({
+  relation,
+}: {
+  relation: CmsSectionEntityRelation
+}) {
+  return (
+    <StatusBadges
+      missing={!relation.section || !relation.entity}
+      draft={!relation.section?.published || !relation.entity?.published}
+      unregistered={
+        !relation.section?.schemaRegistered || !relation.entity?.schemaRegistered
+      }
+    />
+  )
+}
+
+function EntityRelationStatus({ relation }: { relation: CmsEntityRelation }) {
+  return (
+    <StatusBadges
+      missing={!relation.fromEntity || !relation.toEntity}
+      draft={!relation.fromEntity?.published || !relation.toEntity?.published}
+      unregistered={
+        !relation.fromEntity?.schemaRegistered ||
+        !relation.toEntity?.schemaRegistered
+      }
+    />
+  )
+}
+
+function StatusBadges({
+  missing,
+  draft,
+  unregistered,
+}: {
+  missing: boolean
+  draft: boolean
+  unregistered: boolean
+}) {
+  const healthy = !missing && !draft && !unregistered
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {missing && <BrokenBadge />}
+      {draft && (
+        <Badge variant="outline" className="rounded-full">
+          Draft target
+        </Badge>
+      )}
+      {unregistered && (
+        <Badge variant="outline" className="rounded-full border-destructive/40">
+          Unregistered schema
+        </Badge>
+      )}
+      {healthy && (
+        <Badge variant="secondary" className="rounded-full">
+          Ready
+        </Badge>
+      )}
+    </div>
+  )
+}
+
+function BrokenBadge() {
+  return (
+    <Badge variant="destructive" className="rounded-full">
+      Broken
+    </Badge>
+  )
+}
+
+function EmptyRelationRows({ message }: { message: string }) {
+  return (
+    <div className="px-6 py-10 text-sm text-muted-foreground">{message}</div>
+  )
+}

--- a/app/ponix/entities/[id]/page.tsx
+++ b/app/ponix/entities/[id]/page.tsx
@@ -2,8 +2,15 @@ import type { Metadata } from "next"
 import { notFound } from "next/navigation"
 
 import { CmsDetailPage } from "@/app/ponix/_components/cms-detail"
+import {
+  EntityRelationsCard,
+  SectionEntityRelationsCard,
+} from "@/app/ponix/_components/cms-relations"
 import { requireCmsAdmin } from "@/lib/cms/auth"
-import { loadCmsEntityDetail } from "@/lib/cms/content"
+import {
+  loadCmsEntityDetail,
+  loadCmsEntityRelations,
+} from "@/lib/cms/content"
 
 export const metadata: Metadata = {
   title: "PONIX Entity Detail | 브레멘 Bremen",
@@ -23,7 +30,10 @@ export default async function PonixEntityRecordPage({
   const { id } = await params
 
   await requireCmsAdmin(`/ponix/entities/${id}`)
-  const detail = await loadCmsEntityDetail(id)
+  const [detail, relations] = await Promise.all([
+    loadCmsEntityDetail(id),
+    loadCmsEntityRelations(id),
+  ])
 
   if (!detail) {
     notFound()
@@ -34,6 +44,22 @@ export default async function PonixEntityRecordPage({
       detail={detail}
       backHref="/ponix/entities"
       backLabel="All entities"
-    />
+    >
+      <SectionEntityRelationsCard
+        title="Section placements"
+        description="Sections that curate this entity."
+        relations={relations.sectionEntities}
+      />
+      <EntityRelationsCard
+        title="Outgoing relations"
+        description="Entities linked from this record."
+        relations={relations.outgoingEntityRelations}
+      />
+      <EntityRelationsCard
+        title="Incoming relations"
+        description="Entities that link to this record."
+        relations={relations.incomingEntityRelations}
+      />
+    </CmsDetailPage>
   )
 }

--- a/app/ponix/page.tsx
+++ b/app/ponix/page.tsx
@@ -51,7 +51,7 @@ export default async function PonixPage() {
       kind: "relation",
       title: "Relations",
       body: "Section curation and entity-to-entity domain links.",
-      href: null,
+      href: "/ponix/relations",
     },
   ]
 

--- a/app/ponix/pages/[id]/page.tsx
+++ b/app/ponix/pages/[id]/page.tsx
@@ -2,8 +2,9 @@ import type { Metadata } from "next"
 import { notFound } from "next/navigation"
 
 import { CmsDetailPage } from "@/app/ponix/_components/cms-detail"
+import { PageSectionRelationsCard } from "@/app/ponix/_components/cms-relations"
 import { requireCmsAdmin } from "@/lib/cms/auth"
-import { loadCmsPageDetail } from "@/lib/cms/content"
+import { loadCmsPageDetail, loadCmsPageRelations } from "@/lib/cms/content"
 
 export const metadata: Metadata = {
   title: "PONIX Page Detail | 브레멘 Bremen",
@@ -23,7 +24,10 @@ export default async function PonixPageRecordPage({
   const { id } = await params
 
   await requireCmsAdmin(`/ponix/pages/${id}`)
-  const detail = await loadCmsPageDetail(id)
+  const [detail, relations] = await Promise.all([
+    loadCmsPageDetail(id),
+    loadCmsPageRelations(id),
+  ])
 
   if (!detail) {
     notFound()
@@ -34,6 +38,12 @@ export default async function PonixPageRecordPage({
       detail={detail}
       backHref="/ponix/pages"
       backLabel="All pages"
-    />
+    >
+      <PageSectionRelationsCard
+        title="Page structure"
+        description="Sections attached to this page in render order."
+        relations={relations.pageSections}
+      />
+    </CmsDetailPage>
   )
 }

--- a/app/ponix/relations/page.tsx
+++ b/app/ponix/relations/page.tsx
@@ -1,0 +1,37 @@
+import type { Metadata } from "next"
+
+import {
+  EntityRelationsCard,
+  PageSectionRelationsCard,
+  SectionEntityRelationsCard,
+} from "@/app/ponix/_components/cms-relations"
+import { CmsListPage } from "@/app/ponix/_components/cms-list"
+import { requireCmsAdmin } from "@/lib/cms/auth"
+import { loadCmsRelationGraph } from "@/lib/cms/content"
+
+export const metadata: Metadata = {
+  title: "PONIX Relations | 브레멘 Bremen",
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
+
+export default async function PonixRelationsPage() {
+  await requireCmsAdmin("/ponix/relations")
+  const graph = await loadCmsRelationGraph()
+
+  return (
+    <CmsListPage
+      eyebrow="PONIX / Relations"
+      title="Relations"
+      description="The content graph that connects pages, sections, and reusable entities."
+    >
+      <div className="space-y-6">
+        <PageSectionRelationsCard relationList={graph.pageSections} />
+        <SectionEntityRelationsCard relationList={graph.sectionEntities} />
+        <EntityRelationsCard relationList={graph.entityRelations} />
+      </div>
+    </CmsListPage>
+  )
+}

--- a/app/ponix/sections/[id]/page.tsx
+++ b/app/ponix/sections/[id]/page.tsx
@@ -2,8 +2,15 @@ import type { Metadata } from "next"
 import { notFound } from "next/navigation"
 
 import { CmsDetailPage } from "@/app/ponix/_components/cms-detail"
+import {
+  PageSectionRelationsCard,
+  SectionEntityRelationsCard,
+} from "@/app/ponix/_components/cms-relations"
 import { requireCmsAdmin } from "@/lib/cms/auth"
-import { loadCmsSectionDetail } from "@/lib/cms/content"
+import {
+  loadCmsSectionDetail,
+  loadCmsSectionRelations,
+} from "@/lib/cms/content"
 
 export const metadata: Metadata = {
   title: "PONIX Section Detail | 브레멘 Bremen",
@@ -23,7 +30,10 @@ export default async function PonixSectionRecordPage({
   const { id } = await params
 
   await requireCmsAdmin(`/ponix/sections/${id}`)
-  const detail = await loadCmsSectionDetail(id)
+  const [detail, relations] = await Promise.all([
+    loadCmsSectionDetail(id),
+    loadCmsSectionRelations(id),
+  ])
 
   if (!detail) {
     notFound()
@@ -34,6 +44,17 @@ export default async function PonixSectionRecordPage({
       detail={detail}
       backHref="/ponix/sections"
       backLabel="All sections"
-    />
+    >
+      <PageSectionRelationsCard
+        title="Page placements"
+        description="Pages that include this section."
+        relations={relations.pageSections}
+      />
+      <SectionEntityRelationsCard
+        title="Curated entities"
+        description="Entities attached to this section by slot and order."
+        relations={relations.sectionEntities}
+      />
+    </CmsDetailPage>
   )
 }

--- a/lib/cms/content.ts
+++ b/lib/cms/content.ts
@@ -1,13 +1,52 @@
 import { createClient } from "@/lib/supabase/server"
-import type { Database } from "@/lib/supabase/types"
+import type { Database, Json } from "@/lib/supabase/types"
 
 import { getCmsSchema } from "./schema-registry"
 
 const ENTITY_LIST_LIMIT = 200
+const RELATION_LIST_LIMIT = 300
 
 type PageRow = Database["public"]["Tables"]["pages"]["Row"]
 type SectionRow = Database["public"]["Tables"]["sections"]["Row"]
 type EntityRow = Database["public"]["Tables"]["entities"]["Row"]
+type SupabaseClient = Awaited<ReturnType<typeof createClient>>
+
+const PAGE_SECTION_RELATION_SELECT = `
+  id,
+  page_id,
+  section_id,
+  sort_order,
+  props,
+  updated_at,
+  page:pages!page_sections_page_id_fkey(id, slug, title, published),
+  section:sections!page_sections_section_id_fkey(id, key, title, section_type, schema_key, published)
+`
+
+const SECTION_ENTITY_RELATION_SELECT = `
+  id,
+  section_id,
+  entity_id,
+  relation_type,
+  slot,
+  sort_order,
+  props,
+  updated_at,
+  section:sections!section_entities_section_id_fkey(id, key, title, section_type, schema_key, published),
+  entity:entities!section_entities_entity_id_fkey(id, entity_type, slug, title, schema_key, published, sort_at)
+`
+
+const ENTITY_RELATION_SELECT = `
+  id,
+  from_entity_id,
+  to_entity_id,
+  relation_type,
+  slot,
+  sort_order,
+  props,
+  updated_at,
+  fromEntity:entities!entity_relations_from_entity_id_fkey(id, entity_type, slug, title, schema_key, published, sort_at),
+  toEntity:entities!entity_relations_to_entity_id_fkey(id, entity_type, slug, title, schema_key, published, sort_at)
+`
 
 type SchemaSummary = {
   schemaKey: string
@@ -52,6 +91,94 @@ export type CmsEntityList = {
   limit: number
 }
 
+export type CmsRelationList<T> = {
+  relations: T[]
+  count: number | null
+  limit: number
+}
+
+export type CmsLinkedPage = {
+  id: string
+  slug: string
+  title: string
+  published: boolean
+}
+
+export type CmsLinkedSection = SchemaSummary & {
+  id: string
+  key: string
+  title: string | null
+  sectionType: string
+  published: boolean
+}
+
+export type CmsLinkedEntity = SchemaSummary & {
+  id: string
+  entityType: string
+  slug: string | null
+  title: string
+  published: boolean
+  sortAt: string
+}
+
+export type CmsPageSectionRelation = {
+  id: string
+  pageId: string
+  sectionId: string
+  sortOrder: number
+  props: Json
+  updatedAt: string
+  page: CmsLinkedPage | null
+  section: CmsLinkedSection | null
+}
+
+export type CmsSectionEntityRelation = {
+  id: string
+  sectionId: string
+  entityId: string
+  relationType: string
+  slot: string
+  sortOrder: number
+  props: Json
+  updatedAt: string
+  section: CmsLinkedSection | null
+  entity: CmsLinkedEntity | null
+}
+
+export type CmsEntityRelation = {
+  id: string
+  fromEntityId: string
+  toEntityId: string
+  relationType: string
+  slot: string
+  sortOrder: number
+  props: Json
+  updatedAt: string
+  fromEntity: CmsLinkedEntity | null
+  toEntity: CmsLinkedEntity | null
+}
+
+export type CmsRelationGraph = {
+  pageSections: CmsRelationList<CmsPageSectionRelation>
+  sectionEntities: CmsRelationList<CmsSectionEntityRelation>
+  entityRelations: CmsRelationList<CmsEntityRelation>
+}
+
+export type CmsPageRelationContext = {
+  pageSections: CmsPageSectionRelation[]
+}
+
+export type CmsSectionRelationContext = {
+  pageSections: CmsPageSectionRelation[]
+  sectionEntities: CmsSectionEntityRelation[]
+}
+
+export type CmsEntityRelationContext = {
+  sectionEntities: CmsSectionEntityRelation[]
+  outgoingEntityRelations: CmsEntityRelation[]
+  incomingEntityRelations: CmsEntityRelation[]
+}
+
 export type CmsContentDetail =
   | {
       kind: "page"
@@ -89,6 +216,206 @@ function schemaSummary(schemaKey: string): SchemaSummary {
     schemaLabel: schema?.label ?? "Unregistered schema",
     schemaRegistered: Boolean(schema),
   }
+}
+
+function relationList<T>(
+  relations: T[],
+  count: number | null,
+  limit = RELATION_LIST_LIMIT,
+): CmsRelationList<T> {
+  return {
+    relations,
+    count,
+    limit,
+  }
+}
+
+function linkedPage(page: RawPageLink | null): CmsLinkedPage | null {
+  if (!page) {
+    return null
+  }
+
+  return {
+    id: page.id,
+    slug: page.slug,
+    title: page.title,
+    published: page.published,
+  }
+}
+
+function linkedSection(
+  section: RawSectionLink | null,
+): CmsLinkedSection | null {
+  if (!section) {
+    return null
+  }
+
+  return {
+    ...schemaSummary(section.schema_key),
+    id: section.id,
+    key: section.key,
+    title: section.title,
+    sectionType: section.section_type,
+    published: section.published,
+  }
+}
+
+function linkedEntity(entity: RawEntityLink | null): CmsLinkedEntity | null {
+  if (!entity) {
+    return null
+  }
+
+  return {
+    ...schemaSummary(entity.schema_key),
+    id: entity.id,
+    entityType: entity.entity_type,
+    slug: entity.slug,
+    title: entity.title,
+    published: entity.published,
+    sortAt: entity.sort_at,
+  }
+}
+
+type RawPageLink = Pick<PageRow, "id" | "slug" | "title" | "published">
+type RawSectionLink = Pick<
+  SectionRow,
+  "id" | "key" | "title" | "section_type" | "schema_key" | "published"
+>
+type RawEntityLink = Pick<
+  EntityRow,
+  | "id"
+  | "entity_type"
+  | "slug"
+  | "title"
+  | "schema_key"
+  | "published"
+  | "sort_at"
+>
+
+type RawPageSectionRelation = {
+  id: string
+  page_id: string
+  section_id: string
+  sort_order: number
+  props: Json
+  updated_at: string
+  page: RawPageLink | null
+  section: RawSectionLink | null
+}
+
+type RawSectionEntityRelation = {
+  id: string
+  section_id: string
+  entity_id: string
+  relation_type: string
+  slot: string
+  sort_order: number
+  props: Json
+  updated_at: string
+  section: RawSectionLink | null
+  entity: RawEntityLink | null
+}
+
+type RawEntityRelation = {
+  id: string
+  from_entity_id: string
+  to_entity_id: string
+  relation_type: string
+  slot: string
+  sort_order: number
+  props: Json
+  updated_at: string
+  fromEntity: RawEntityLink | null
+  toEntity: RawEntityLink | null
+}
+
+function mapPageSectionRelation(
+  relation: RawPageSectionRelation,
+): CmsPageSectionRelation {
+  return {
+    id: relation.id,
+    pageId: relation.page_id,
+    sectionId: relation.section_id,
+    sortOrder: relation.sort_order,
+    props: relation.props,
+    updatedAt: relation.updated_at,
+    page: linkedPage(relation.page),
+    section: linkedSection(relation.section),
+  }
+}
+
+function mapSectionEntityRelation(
+  relation: RawSectionEntityRelation,
+): CmsSectionEntityRelation {
+  return {
+    id: relation.id,
+    sectionId: relation.section_id,
+    entityId: relation.entity_id,
+    relationType: relation.relation_type,
+    slot: relation.slot,
+    sortOrder: relation.sort_order,
+    props: relation.props,
+    updatedAt: relation.updated_at,
+    section: linkedSection(relation.section),
+    entity: linkedEntity(relation.entity),
+  }
+}
+
+function mapEntityRelation(relation: RawEntityRelation): CmsEntityRelation {
+  return {
+    id: relation.id,
+    fromEntityId: relation.from_entity_id,
+    toEntityId: relation.to_entity_id,
+    relationType: relation.relation_type,
+    slot: relation.slot,
+    sortOrder: relation.sort_order,
+    props: relation.props,
+    updatedAt: relation.updated_at,
+    fromEntity: linkedEntity(relation.fromEntity),
+    toEntity: linkedEntity(relation.toEntity),
+  }
+}
+
+function byPageSectionOrder(
+  left: CmsPageSectionRelation,
+  right: CmsPageSectionRelation,
+) {
+  return (
+    (left.page?.slug ?? left.pageId).localeCompare(right.page?.slug ?? right.pageId) ||
+    left.sortOrder - right.sortOrder ||
+    (left.section?.key ?? left.sectionId).localeCompare(
+      right.section?.key ?? right.sectionId,
+    )
+  )
+}
+
+function bySectionEntityOrder(
+  left: CmsSectionEntityRelation,
+  right: CmsSectionEntityRelation,
+) {
+  return (
+    (left.section?.key ?? left.sectionId).localeCompare(
+      right.section?.key ?? right.sectionId,
+    ) ||
+    left.slot.localeCompare(right.slot) ||
+    left.sortOrder - right.sortOrder ||
+    (left.entity?.title ?? left.entityId).localeCompare(
+      right.entity?.title ?? right.entityId,
+    )
+  )
+}
+
+function byEntityRelationOrder(left: CmsEntityRelation, right: CmsEntityRelation) {
+  return (
+    (left.fromEntity?.title ?? left.fromEntityId).localeCompare(
+      right.fromEntity?.title ?? right.fromEntityId,
+    ) ||
+    left.slot.localeCompare(right.slot) ||
+    left.sortOrder - right.sortOrder ||
+    (left.toEntity?.title ?? left.toEntityId).localeCompare(
+      right.toEntity?.title ?? right.toEntityId,
+    )
+  )
 }
 
 export async function loadCmsPages(): Promise<CmsPageSummary[]> {
@@ -256,5 +583,183 @@ export async function loadCmsEntityDetail(
     published: data.published,
     updatedAt: data.updated_at,
     row: data,
+  }
+}
+
+async function loadPageSectionRelations({
+  supabase,
+  pageId,
+  sectionId,
+  limit = RELATION_LIST_LIMIT,
+}: {
+  supabase: SupabaseClient
+  pageId?: string
+  sectionId?: string
+  limit?: number
+}): Promise<CmsRelationList<CmsPageSectionRelation>> {
+  let query = supabase
+    .from("page_sections")
+    .select(PAGE_SECTION_RELATION_SELECT, { count: "exact" })
+
+  if (pageId) {
+    query = query.eq("page_id", pageId)
+  }
+
+  if (sectionId) {
+    query = query.eq("section_id", sectionId)
+  }
+
+  const { data, error, count } = await query
+    .order("page_id", { ascending: true })
+    .order("sort_order", { ascending: true })
+    .range(0, limit - 1)
+
+  if (error) {
+    throw new Error(`Failed to load page-section relations: ${error.message}`)
+  }
+
+  const relations = ((data ?? []) as unknown as RawPageSectionRelation[])
+    .map(mapPageSectionRelation)
+    .sort(byPageSectionOrder)
+
+  return relationList(relations, count, limit)
+}
+
+async function loadSectionEntityRelations({
+  supabase,
+  sectionId,
+  entityId,
+  limit = RELATION_LIST_LIMIT,
+}: {
+  supabase: SupabaseClient
+  sectionId?: string
+  entityId?: string
+  limit?: number
+}): Promise<CmsRelationList<CmsSectionEntityRelation>> {
+  let query = supabase
+    .from("section_entities")
+    .select(SECTION_ENTITY_RELATION_SELECT, { count: "exact" })
+
+  if (sectionId) {
+    query = query.eq("section_id", sectionId)
+  }
+
+  if (entityId) {
+    query = query.eq("entity_id", entityId)
+  }
+
+  const { data, error, count } = await query
+    .order("section_id", { ascending: true })
+    .order("slot", { ascending: true })
+    .order("sort_order", { ascending: true })
+    .range(0, limit - 1)
+
+  if (error) {
+    throw new Error(`Failed to load section-entity relations: ${error.message}`)
+  }
+
+  const relations = ((data ?? []) as unknown as RawSectionEntityRelation[])
+    .map(mapSectionEntityRelation)
+    .sort(bySectionEntityOrder)
+
+  return relationList(relations, count, limit)
+}
+
+async function loadEntityRelations({
+  supabase,
+  fromEntityId,
+  toEntityId,
+  limit = RELATION_LIST_LIMIT,
+}: {
+  supabase: SupabaseClient
+  fromEntityId?: string
+  toEntityId?: string
+  limit?: number
+}): Promise<CmsRelationList<CmsEntityRelation>> {
+  let query = supabase
+    .from("entity_relations")
+    .select(ENTITY_RELATION_SELECT, { count: "exact" })
+
+  if (fromEntityId) {
+    query = query.eq("from_entity_id", fromEntityId)
+  }
+
+  if (toEntityId) {
+    query = query.eq("to_entity_id", toEntityId)
+  }
+
+  const { data, error, count } = await query
+    .order("from_entity_id", { ascending: true })
+    .order("slot", { ascending: true })
+    .order("sort_order", { ascending: true })
+    .range(0, limit - 1)
+
+  if (error) {
+    throw new Error(`Failed to load entity relations: ${error.message}`)
+  }
+
+  const relations = ((data ?? []) as unknown as RawEntityRelation[])
+    .map(mapEntityRelation)
+    .sort(byEntityRelationOrder)
+
+  return relationList(relations, count, limit)
+}
+
+export async function loadCmsRelationGraph(): Promise<CmsRelationGraph> {
+  const supabase = await createClient()
+  const [pageSections, sectionEntities, entityRelations] = await Promise.all([
+    loadPageSectionRelations({ supabase }),
+    loadSectionEntityRelations({ supabase }),
+    loadEntityRelations({ supabase }),
+  ])
+
+  return {
+    pageSections,
+    sectionEntities,
+    entityRelations,
+  }
+}
+
+export async function loadCmsPageRelations(
+  pageId: string,
+): Promise<CmsPageRelationContext> {
+  const supabase = await createClient()
+  const pageSections = await loadPageSectionRelations({ supabase, pageId })
+
+  return {
+    pageSections: pageSections.relations,
+  }
+}
+
+export async function loadCmsSectionRelations(
+  sectionId: string,
+): Promise<CmsSectionRelationContext> {
+  const supabase = await createClient()
+  const [pageSections, sectionEntities] = await Promise.all([
+    loadPageSectionRelations({ supabase, sectionId }),
+    loadSectionEntityRelations({ supabase, sectionId }),
+  ])
+
+  return {
+    pageSections: pageSections.relations,
+    sectionEntities: sectionEntities.relations,
+  }
+}
+
+export async function loadCmsEntityRelations(
+  entityId: string,
+): Promise<CmsEntityRelationContext> {
+  const supabase = await createClient()
+  const [sectionEntities, outgoingEntityRelations, incomingEntityRelations] =
+    await Promise.all([
+      loadSectionEntityRelations({ supabase, entityId }),
+      loadEntityRelations({ supabase, fromEntityId: entityId }),
+      loadEntityRelations({ supabase, toEntityId: entityId }),
+    ])
+
+  return {
+    sectionEntities: sectionEntities.relations,
+    outgoingEntityRelations: outgoingEntityRelations.relations,
+    incomingEntityRelations: incomingEntityRelations.relations,
   }
 }


### PR DESCRIPTION
Closes #6

Summary
- Adds `/ponix/relations` as a read-only graph view for page-section, section-entity, and entity-entity relations.
- Links the PONIX Relations card to the new route.
- Adds relation panels to page, section, and entity detail views.
- Marks broken targets, draft linked records, and unregistered linked schemas.

Checks
- git diff --check
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm run build

Notes
- This is stacked on the read-only detail views branch, so the PR base is `cms/4-read-only-detail-views`.
- No Supabase schema, RLS, storage, or content rows were changed.
