### PR TITLE
[CMS] Add guarded section copy editor

### DIFF
--- a/app/ponix/_components/cms-detail.tsx
+++ b/app/ponix/_components/cms-detail.tsx
@@ -39,11 +39,13 @@ export function CmsDetailPage({
   detail,
   backHref,
   backLabel,
+  actions,
   children,
 }: {
   detail: CmsContentDetail
   backHref: string
   backLabel: string
+  actions?: ReactNode
   children?: ReactNode
 }) {
   const schema = getCmsSchema(detail.schemaKey)
@@ -79,9 +81,12 @@ export function CmsDetailPage({
               </Badge>
             </div>
           </div>
-          <Button asChild variant="outline" className="w-fit rounded-full">
-            <Link href={backHref}>{backLabel}</Link>
-          </Button>
+          <div className="flex flex-wrap gap-2">
+            <Button asChild variant="outline" className="w-fit rounded-full">
+              <Link href={backHref}>{backLabel}</Link>
+            </Button>
+            {actions}
+          </div>
         </div>
 
         {!schema && (

--- a/app/ponix/_components/cms-section-form.tsx
+++ b/app/ponix/_components/cms-section-form.tsx
@@ -1,0 +1,315 @@
+import Link from "next/link"
+
+import { updateCmsSectionAction } from "@/app/ponix/sections/actions"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import type { CmsContentDetail } from "@/lib/cms/content"
+import {
+  cmsFieldInputName,
+  getEditableSectionFields,
+  getSectionEditorSchema,
+  getSectionFieldValue,
+  type CmsEditableSectionField,
+} from "@/lib/cms/section-editor"
+
+type CmsSectionDetail = Extract<CmsContentDetail, { kind: "section" }>
+
+export function CmsSectionEditorPage({
+  detail,
+  error,
+}: {
+  detail: CmsSectionDetail
+  error?: string
+}) {
+  const schema = getSectionEditorSchema(detail.schemaKey)
+  const editableFields = getEditableSectionFields(detail.schemaKey)
+  const columnFields = editableFields.filter((field) => field.source === "column")
+  const propsFields = editableFields.filter((field) => field.source === "props")
+
+  return (
+    <main className="relative min-h-[calc(100vh-5rem)] overflow-hidden">
+      <div className="pointer-events-none absolute inset-0 -z-10">
+        <div className="absolute right-[-10rem] top-10 h-96 w-96 rounded-full bg-accent/10 blur-3xl" />
+        <div className="absolute left-[-8rem] bottom-0 h-80 w-80 rounded-full bg-muted blur-3xl" />
+      </div>
+
+      <section className="mx-auto max-w-6xl px-6 py-16 md:px-8 md:py-24">
+        <div className="mb-10 flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+          <div>
+            <p className="caps mb-5">PONIX / Edit section</p>
+            <h1 className="font-serif text-[clamp(3.25rem,8vw,6.5rem)] italic leading-[0.84] tracking-tight">
+              {detail.title}
+            </h1>
+            <p className="mt-5 max-w-2xl text-sm leading-relaxed text-muted-foreground md:text-base">
+              Edit only the fields registered for this section schema.
+            </p>
+            <div className="mt-6 flex flex-wrap items-center gap-2">
+              <Badge variant="outline" className="rounded-full font-mono">
+                {detail.row.key}
+              </Badge>
+              <Badge variant="secondary" className="rounded-full">
+                {schema?.label ?? "Unregistered schema"}
+              </Badge>
+            </div>
+          </div>
+          <Button asChild variant="outline" className="w-fit rounded-full">
+            <Link href={`/ponix/sections/${detail.row.id}`}>Back to section</Link>
+          </Button>
+        </div>
+
+        {!schema ? (
+          <Alert variant="destructive">
+            <AlertTitle>Schema is not editable</AlertTitle>
+            <AlertDescription>
+              This section uses <code>{detail.schemaKey}</code>, which is not
+              registered as a section editor schema.
+            </AlertDescription>
+          </Alert>
+        ) : (
+          <form action={updateCmsSectionAction} className="space-y-6">
+            <input type="hidden" name="section_id" value={detail.row.id} />
+
+            {error && (
+              <Alert variant="destructive">
+                <AlertTitle>Save failed</AlertTitle>
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+
+            <Card className="rounded-md bg-card/95 shadow-xl">
+              <CardHeader className="border-b">
+                <CardTitle className="font-serif text-3xl italic">
+                  Locked identity
+                </CardTitle>
+                <CardDescription>
+                  These values define routing and renderer behavior and are not
+                  editable in this slice.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="grid gap-4 px-6 py-6 md:grid-cols-3">
+                <ReadonlyMeta label="Key" value={detail.row.key} />
+                <ReadonlyMeta label="Renderer" value={detail.row.section_type} />
+                <ReadonlyMeta label="Schema" value={detail.row.schema_key} />
+              </CardContent>
+            </Card>
+
+            <EditorCard
+              title="Section copy"
+              description="Column fields shared by section renderers."
+              fields={columnFields}
+              detail={detail}
+            />
+
+            <EditorCard
+              title="Renderer props"
+              description="Schema-registered JSON props for this section renderer."
+              fields={propsFields}
+              detail={detail}
+            />
+
+            <div className="flex flex-col gap-3 rounded-md border bg-card/95 p-4 shadow-xl sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-sm text-muted-foreground">
+                Saving updates this section row only. Relations and entities stay untouched.
+              </p>
+              <div className="flex gap-2">
+                <Button asChild type="button" variant="outline">
+                  <Link href={`/ponix/sections/${detail.row.id}`}>Cancel</Link>
+                </Button>
+                <Button type="submit">Save section</Button>
+              </div>
+            </div>
+          </form>
+        )}
+      </section>
+    </main>
+  )
+}
+
+function EditorCard({
+  title,
+  description,
+  fields,
+  detail,
+}: {
+  title: string
+  description: string
+  fields: CmsEditableSectionField[]
+  detail: CmsSectionDetail
+}) {
+  return (
+    <Card className="rounded-md bg-card/95 shadow-xl">
+      <CardHeader className="border-b">
+        <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+          <div>
+            <CardTitle className="font-serif text-3xl italic">{title}</CardTitle>
+            <CardDescription>{description}</CardDescription>
+          </div>
+          <p className="caps text-muted-foreground">{fields.length} fields</p>
+        </div>
+      </CardHeader>
+      <CardContent className="grid gap-5 px-6 py-6 md:grid-cols-2">
+        {fields.length > 0 ? (
+          fields.map((field) => (
+            <EditorField key={`${field.source}:${field.key}`} field={field} detail={detail} />
+          ))
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            No editable fields in this group.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function EditorField({
+  field,
+  detail,
+}: {
+  field: CmsEditableSectionField
+  detail: CmsSectionDetail
+}) {
+  const id = `section-${field.source}-${field.key}`
+  const name = cmsFieldInputName(field)
+  const value = getSectionFieldValue(detail.row, field)
+  const wide = field.type === "textarea" || field.type === "json" || field.type === "string-list"
+
+  return (
+    <div className={wide ? "space-y-2 md:col-span-2" : "space-y-2"}>
+      <div className="flex items-center gap-2">
+        <Label htmlFor={id}>{field.label}</Label>
+        {field.required && (
+          <Badge variant="outline" className="rounded-full">
+            Required
+          </Badge>
+        )}
+      </div>
+      {renderFieldInput({ field, id, name, value })}
+      <p className="font-mono text-xs text-muted-foreground">
+        {field.source}.{field.key}
+      </p>
+      {field.description && (
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          {field.description}
+        </p>
+      )}
+    </div>
+  )
+}
+
+function renderFieldInput({
+  field,
+  id,
+  name,
+  value,
+}: {
+  field: CmsEditableSectionField
+  id: string
+  name: string
+  value: unknown
+}) {
+  if (field.type === "boolean") {
+    return (
+      <div className="flex h-11 items-center gap-3 rounded-md border bg-background/70 px-3">
+        <input type="hidden" name={name} value="false" />
+        <Checkbox
+          id={id}
+          name={name}
+          value="true"
+          defaultChecked={Boolean(value)}
+        />
+        <Label htmlFor={id} className="text-sm font-normal">
+          Enabled
+        </Label>
+      </div>
+    )
+  }
+
+  if (field.type === "textarea" || field.type === "string-list" || field.type === "json") {
+    return (
+      <Textarea
+        id={id}
+        name={name}
+        defaultValue={fieldDefaultText(field, value)}
+        rows={field.type === "json" ? 10 : 5}
+        className="bg-background/70"
+      />
+    )
+  }
+
+  if (field.type === "select") {
+    return (
+      <select
+        id={id}
+        name={name}
+        defaultValue={fieldDefaultText(field, value)}
+        className="border-input h-11 w-full rounded-md border bg-background/70 px-3 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+      >
+        {!field.required && <option value="">Empty</option>}
+        {(field.options ?? []).map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    )
+  }
+
+  return (
+    <Input
+      id={id}
+      name={name}
+      type={inputType(field)}
+      defaultValue={fieldDefaultText(field, value)}
+      className="h-11 bg-background/70"
+    />
+  )
+}
+
+function inputType(field: CmsEditableSectionField) {
+  if (field.type === "number") return "number"
+  if (field.type === "date") return "date"
+  if (field.type === "datetime") return "datetime-local"
+  return "text"
+}
+
+function fieldDefaultText(field: CmsEditableSectionField, value: unknown) {
+  if (value === null || value === undefined) {
+    return ""
+  }
+
+  if (field.type === "string-list") {
+    return Array.isArray(value) ? value.join("\n") : String(value)
+  }
+
+  if (field.type === "json") {
+    return JSON.stringify(value, null, 2)
+  }
+
+  if (field.type === "datetime" && typeof value === "string") {
+    return value.slice(0, 16)
+  }
+
+  return String(value)
+}
+
+function ReadonlyMeta({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border bg-background/60 p-4">
+      <p className="caps mb-2 text-muted-foreground">{label}</p>
+      <p className="break-all font-mono text-xs">{value}</p>
+    </div>
+  )
+}

--- a/app/ponix/sections/[id]/edit/page.tsx
+++ b/app/ponix/sections/[id]/edit/page.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from "next"
+import { notFound } from "next/navigation"
+
+import { CmsSectionEditorPage } from "@/app/ponix/_components/cms-section-form"
+import { requireCmsAdmin } from "@/lib/cms/auth"
+import { loadCmsSectionDetail } from "@/lib/cms/content"
+
+export const metadata: Metadata = {
+  title: "Edit PONIX Section | 브레멘 Bremen",
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
+
+type PonixSectionEditPageProps = {
+  params: Promise<{ id: string }>
+  searchParams?: Promise<Record<string, string | string[] | undefined>>
+}
+
+function firstParam(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value
+}
+
+export default async function PonixSectionEditPage({
+  params,
+  searchParams,
+}: PonixSectionEditPageProps) {
+  const { id } = await params
+  const query = (await searchParams) ?? {}
+
+  await requireCmsAdmin(`/ponix/sections/${id}/edit`)
+  const detail = await loadCmsSectionDetail(id)
+
+  if (!detail || detail.kind !== "section") {
+    notFound()
+  }
+
+  return (
+    <CmsSectionEditorPage detail={detail} error={firstParam(query.error)} />
+  )
+}

--- a/app/ponix/sections/[id]/page.tsx
+++ b/app/ponix/sections/[id]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next"
+import Link from "next/link"
 import { notFound } from "next/navigation"
 
 import { CmsDetailPage } from "@/app/ponix/_components/cms-detail"
@@ -44,6 +45,14 @@ export default async function PonixSectionRecordPage({
       detail={detail}
       backHref="/ponix/sections"
       backLabel="All sections"
+      actions={
+        <Link
+          href={`/ponix/sections/${id}/edit`}
+          className="inline-flex h-9 items-center justify-center rounded-full bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-xs transition-colors hover:bg-primary/90"
+        >
+          Edit section
+        </Link>
+      }
     >
       <PageSectionRelationsCard
         title="Page placements"

--- a/app/ponix/sections/actions.ts
+++ b/app/ponix/sections/actions.ts
@@ -1,0 +1,301 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+import { redirect } from "next/navigation"
+
+import { requireCmsAdmin } from "@/lib/cms/auth"
+import {
+  cmsFieldInputName,
+  getEditableSectionFields,
+  getSectionEditorSchema,
+  jsonObject,
+  type CmsEditableSectionField,
+  type CmsJsonObject,
+} from "@/lib/cms/section-editor"
+import { createClient } from "@/lib/supabase/server"
+import type { Database, Json } from "@/lib/supabase/types"
+
+type SectionUpdate = Database["public"]["Tables"]["sections"]["Update"]
+
+type ParsedValue =
+  | {
+      ok: true
+      empty: boolean
+      value: Json
+    }
+  | {
+      ok: false
+      error: string
+    }
+
+function stringField(formData: FormData, key: string) {
+  const value = formData.get(key)
+  return typeof value === "string" ? value.trim() : ""
+}
+
+function redirectWithParams(path: string, params: Record<string, string>): never {
+  const search = new URLSearchParams(params)
+  redirect(`${path}?${search.toString()}`)
+}
+
+function isSafeUrl(value: string) {
+  if (value.startsWith("/") && !value.startsWith("//")) {
+    return true
+  }
+
+  try {
+    const url = new URL(value)
+    return url.protocol === "http:" || url.protocol === "https:"
+  } catch {
+    return false
+  }
+}
+
+function parseBoolean(formData: FormData, field: CmsEditableSectionField): ParsedValue {
+  const values = formData.getAll(cmsFieldInputName(field))
+
+  return {
+    ok: true,
+    empty: false,
+    value: values.includes("true"),
+  }
+}
+
+function parseStringList(
+  formData: FormData,
+  field: CmsEditableSectionField,
+): ParsedValue {
+  const value = stringField(formData, cmsFieldInputName(field))
+  const items = value
+    .split("\n")
+    .map((item) => item.trim())
+    .filter(Boolean)
+
+  if (field.required && items.length === 0) {
+    return { ok: false, error: `${field.label} is required.` }
+  }
+
+  return {
+    ok: true,
+    empty: items.length === 0,
+    value: items,
+  }
+}
+
+function parseJson(formData: FormData, field: CmsEditableSectionField): ParsedValue {
+  const value = stringField(formData, cmsFieldInputName(field))
+
+  if (!value) {
+    if (field.required) {
+      return { ok: false, error: `${field.label} is required.` }
+    }
+
+    return { ok: true, empty: true, value: null }
+  }
+
+  try {
+    return {
+      ok: true,
+      empty: false,
+      value: JSON.parse(value) as Json,
+    }
+  } catch {
+    return { ok: false, error: `${field.label} must be valid JSON.` }
+  }
+}
+
+function parseNumber(formData: FormData, field: CmsEditableSectionField): ParsedValue {
+  const value = stringField(formData, cmsFieldInputName(field))
+
+  if (!value) {
+    if (field.required) {
+      return { ok: false, error: `${field.label} is required.` }
+    }
+
+    return { ok: true, empty: true, value: null }
+  }
+
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed)) {
+    return { ok: false, error: `${field.label} must be a number.` }
+  }
+
+  return {
+    ok: true,
+    empty: false,
+    value: parsed,
+  }
+}
+
+function parseTextLike(
+  formData: FormData,
+  field: CmsEditableSectionField,
+): ParsedValue {
+  const value = stringField(formData, cmsFieldInputName(field))
+
+  if (!value) {
+    if (field.required) {
+      return { ok: false, error: `${field.label} is required.` }
+    }
+
+    return { ok: true, empty: true, value: null }
+  }
+
+  if ((field.type === "url" || field.type === "image") && !isSafeUrl(value)) {
+    return {
+      ok: false,
+      error: `${field.label} must be an absolute URL or site-root path.`,
+    }
+  }
+
+  if (field.type === "date" && Number.isNaN(Date.parse(value))) {
+    return { ok: false, error: `${field.label} must be a valid date.` }
+  }
+
+  if (field.type === "datetime" && Number.isNaN(Date.parse(value))) {
+    return { ok: false, error: `${field.label} must be a valid date and time.` }
+  }
+
+  if (
+    field.type === "select" &&
+    field.options?.length &&
+    !field.options.some((option) => option.value === value)
+  ) {
+    return { ok: false, error: `${field.label} has an invalid option.` }
+  }
+
+  return {
+    ok: true,
+    empty: false,
+    value,
+  }
+}
+
+function parseFieldValue(
+  formData: FormData,
+  field: CmsEditableSectionField,
+): ParsedValue {
+  if (field.type === "boolean") {
+    return parseBoolean(formData, field)
+  }
+
+  if (field.type === "string-list") {
+    return parseStringList(formData, field)
+  }
+
+  if (field.type === "json") {
+    return parseJson(formData, field)
+  }
+
+  if (field.type === "number") {
+    return parseNumber(formData, field)
+  }
+
+  return parseTextLike(formData, field)
+}
+
+function updatePropsValue(
+  props: CmsJsonObject,
+  field: CmsEditableSectionField,
+  parsed: ParsedValue & { ok: true },
+) {
+  if (parsed.empty) {
+    delete props[field.key]
+    return
+  }
+
+  props[field.key] = parsed.value
+}
+
+export async function updateCmsSectionAction(formData: FormData) {
+  const sectionId = stringField(formData, "section_id")
+
+  if (!sectionId) {
+    redirectWithParams("/ponix/sections", {
+      error: "Missing section id.",
+    })
+  }
+
+  const editPath = `/ponix/sections/${sectionId}/edit`
+  await requireCmsAdmin(editPath)
+
+  const supabase = await createClient()
+  const { data: section, error: loadError } = await supabase
+    .from("sections")
+    .select("*")
+    .eq("id", sectionId)
+    .maybeSingle()
+
+  if (loadError || !section) {
+    redirectWithParams(editPath, {
+      error: "Section not found.",
+    })
+  }
+
+  const schema = getSectionEditorSchema(section.schema_key)
+  if (!schema) {
+    redirectWithParams(editPath, {
+      error: "This section schema is not registered for editing.",
+    })
+  }
+
+  const fields = getEditableSectionFields(section.schema_key)
+  const props = jsonObject(section.props)
+  const update: SectionUpdate = {}
+
+  for (const field of fields) {
+    const parsed = parseFieldValue(formData, field)
+
+    if (!parsed.ok) {
+      redirectWithParams(editPath, {
+        error: parsed.error,
+      })
+    }
+
+    if (field.source === "props") {
+      updatePropsValue(props, field, parsed)
+      continue
+    }
+
+    if (field.key === "published") {
+      update.published = Boolean(parsed.value)
+    }
+
+    if (field.key === "eyebrow") {
+      update.eyebrow = parsed.value === null ? null : String(parsed.value)
+    }
+
+    if (field.key === "title") {
+      update.title = parsed.value === null ? null : String(parsed.value)
+    }
+
+    if (field.key === "subtitle") {
+      update.subtitle = parsed.value === null ? null : String(parsed.value)
+    }
+  }
+
+  update.props = props
+
+  const { error: updateError } = await supabase
+    .from("sections")
+    .update(update)
+    .eq("id", sectionId)
+
+  if (updateError) {
+    redirectWithParams(editPath, {
+      error: "Section save failed.",
+    })
+  }
+
+  revalidatePath("/")
+  revalidatePath("/performances")
+  revalidatePath("/videos")
+  revalidatePath("/photos")
+  revalidatePath("/history")
+  revalidatePath("/ponix")
+  revalidatePath("/ponix/sections")
+  revalidatePath(`/ponix/sections/${sectionId}`)
+  revalidatePath("/ponix/relations")
+
+  redirect(`/ponix/sections/${sectionId}`)
+}

--- a/lib/cms/section-editor.ts
+++ b/lib/cms/section-editor.ts
@@ -1,0 +1,72 @@
+import type {
+  CmsFieldDefinition,
+  CmsSchemaDefinition,
+} from "@/lib/cms/schema-registry"
+import { getCmsSchema } from "@/lib/cms/schema-registry"
+import type { Database, Json } from "@/lib/supabase/types"
+
+type SectionRow = Database["public"]["Tables"]["sections"]["Row"]
+
+const editableSectionColumns = new Set(["eyebrow", "title", "subtitle", "published"])
+
+export type CmsEditableSectionField = CmsFieldDefinition & {
+  source: "column" | "props"
+}
+
+export type CmsJsonObject = Record<string, Json>
+
+export function cmsFieldInputName(field: CmsFieldDefinition) {
+  return `cms:${field.source}:${field.key}`
+}
+
+export function getSectionEditorSchema(
+  schemaKey: string,
+): CmsSchemaDefinition | null {
+  const schema = getCmsSchema(schemaKey)
+
+  if (!schema || schema.kind !== "section" || schema.table !== "sections") {
+    return null
+  }
+
+  return schema
+}
+
+export function getEditableSectionFields(schemaKey: string) {
+  const schema = getSectionEditorSchema(schemaKey)
+
+  if (!schema) {
+    return []
+  }
+
+  return schema.fields.filter((field): field is CmsEditableSectionField => {
+    if (field.readOnly) {
+      return false
+    }
+
+    if (field.source === "props") {
+      return true
+    }
+
+    return field.source === "column" && editableSectionColumns.has(field.key)
+  })
+}
+
+export function jsonObject(value: Json): CmsJsonObject {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {}
+  }
+
+  return { ...(value as CmsJsonObject) }
+}
+
+export function getSectionFieldValue(
+  section: SectionRow,
+  field: CmsEditableSectionField,
+) {
+  if (field.source === "props") {
+    return jsonObject(section.props)[field.key]
+  }
+
+  const row = section as unknown as Record<string, unknown>
+  return row[field.key]
+}


### PR DESCRIPTION
Closes #8

Summary
- Adds `/ponix/sections/[id]/edit` for guarded section copy and props editing.
- Generates editable fields from the CMS schema registry.
- Updates only allowed section columns and registered `sections.props` keys.
- Keeps `key`, `section_type`, `schema_key`, ownership, timestamps, relations, and entities locked.
- Adds visible save errors through redirect query params.

Checks
- git diff --check
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm run build

Supabase impact
- Content rows only when an admin submits the edit form.
- No migration, RLS, storage, or service-role changes.
