### PR TITLE
[CMS] Add guarded entity editor with thumbnail upload

### DIFF
--- a/app/ponix/_components/cms-entity-form.tsx
+++ b/app/ponix/_components/cms-entity-form.tsx
@@ -1,0 +1,358 @@
+import Link from "next/link"
+
+import { updateCmsEntityAction } from "@/app/ponix/entities/actions"
+import { ProfileImageInput } from "@/components/profile-image-input"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import type { CmsContentDetail } from "@/lib/cms/content"
+import {
+  cmsEntityFieldInputName,
+  getEditableEntityFields,
+  getEntityEditorSchema,
+  getEntityFieldValue,
+  type CmsEditableEntityField,
+} from "@/lib/cms/entity-editor"
+
+type CmsEntityDetail = Extract<CmsContentDetail, { kind: "entity" }>
+
+export function CmsEntityEditorPage({
+  detail,
+  error,
+}: {
+  detail: CmsEntityDetail
+  error?: string
+}) {
+  const schema = getEntityEditorSchema(detail.schemaKey)
+  const editableFields = getEditableEntityFields(detail.schemaKey)
+  const columnFields = editableFields.filter((field) => field.source === "column")
+  const dataFields = editableFields.filter((field) => field.source === "data")
+
+  return (
+    <main className="relative min-h-[calc(100vh-5rem)] overflow-hidden">
+      <div className="pointer-events-none absolute inset-0 -z-10">
+        <div className="absolute right-[-10rem] top-10 h-96 w-96 rounded-full bg-accent/10 blur-3xl" />
+        <div className="absolute left-[-8rem] bottom-0 h-80 w-80 rounded-full bg-muted blur-3xl" />
+      </div>
+
+      <section className="mx-auto max-w-6xl px-6 py-16 md:px-8 md:py-24">
+        <div className="mb-10 flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+          <div>
+            <p className="caps mb-5">PONIX / Edit entity</p>
+            <h1 className="font-serif text-[clamp(3.25rem,8vw,6.5rem)] italic leading-[0.84] tracking-tight">
+              {detail.title}
+            </h1>
+            <p className="mt-5 max-w-2xl text-sm leading-relaxed text-muted-foreground md:text-base">
+              Edit reusable content fields and the canonical thumbnail URL.
+            </p>
+            <div className="mt-6 flex flex-wrap items-center gap-2">
+              <Badge variant="outline" className="rounded-full font-mono">
+                {detail.row.entity_type}
+              </Badge>
+              <Badge variant="secondary" className="rounded-full">
+                {schema?.label ?? "Unregistered schema"}
+              </Badge>
+            </div>
+          </div>
+          <Button asChild variant="outline" className="w-fit rounded-full">
+            <Link href={`/ponix/entities/${detail.row.id}`}>Back to entity</Link>
+          </Button>
+        </div>
+
+        {!schema ? (
+          <Alert variant="destructive">
+            <AlertTitle>Schema is not editable</AlertTitle>
+            <AlertDescription>
+              This entity uses <code>{detail.schemaKey}</code>, which is not
+              registered as an entity editor schema.
+            </AlertDescription>
+          </Alert>
+        ) : (
+          <form action={updateCmsEntityAction} className="space-y-6">
+            <input type="hidden" name="entity_id" value={detail.row.id} />
+
+            {error && (
+              <Alert variant="destructive">
+                <AlertTitle>Save failed</AlertTitle>
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+
+            <Card className="rounded-md bg-card/95 shadow-xl">
+              <CardHeader className="border-b">
+                <CardTitle className="font-serif text-3xl italic">
+                  Locked identity
+                </CardTitle>
+                <CardDescription>
+                  These values define entity behavior and are not editable in
+                  this slice.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="grid gap-4 px-6 py-6 md:grid-cols-3">
+                <ReadonlyMeta label="Entity type" value={detail.row.entity_type} />
+                <ReadonlyMeta label="Schema" value={detail.row.schema_key} />
+                <ReadonlyMeta label="ID" value={detail.row.id} />
+              </CardContent>
+            </Card>
+
+            <ThumbnailCard detail={detail} />
+
+            <EditorCard
+              title="Entity fields"
+              description="Shared columns used by cards, lists, and detail views."
+              fields={columnFields}
+              detail={detail}
+            />
+
+            <EditorCard
+              title="Schema data"
+              description="Schema-registered JSON data for this entity type."
+              fields={dataFields}
+              detail={detail}
+            />
+
+            <div className="flex flex-col gap-3 rounded-md border bg-card/95 p-4 shadow-xl sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-sm text-muted-foreground">
+                Saving updates this entity row only. Relations stay untouched.
+              </p>
+              <div className="flex gap-2">
+                <Button asChild type="button" variant="outline">
+                  <Link href={`/ponix/entities/${detail.row.id}`}>Cancel</Link>
+                </Button>
+                <Button type="submit">Save entity</Button>
+              </div>
+            </div>
+          </form>
+        )}
+      </section>
+    </main>
+  )
+}
+
+function ThumbnailCard({ detail }: { detail: CmsEntityDetail }) {
+  return (
+    <Card className="rounded-md bg-card/95 shadow-xl">
+      <CardHeader className="border-b">
+        <CardTitle className="font-serif text-3xl italic">
+          Thumbnail upload
+        </CardTitle>
+        <CardDescription>
+          Uploading a new image stores it in Supabase Storage and replaces
+          <code> thumbnail_url</code>.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="grid gap-5 px-6 py-6 md:grid-cols-[12rem_minmax(0,1fr)]">
+        {detail.row.thumbnail_url ? (
+          <div className="h-32 w-48 max-w-full overflow-hidden rounded-md border bg-muted">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={detail.row.thumbnail_url}
+              alt={`${detail.title} thumbnail`}
+              className="h-full w-full object-cover"
+            />
+          </div>
+        ) : (
+          <div className="grid h-32 w-48 max-w-full place-items-center rounded-md border bg-muted text-sm text-muted-foreground">
+            No thumbnail
+          </div>
+        )}
+        <div className="space-y-2">
+          <Label htmlFor="thumbnail_file">Upload image</Label>
+          <ProfileImageInput id="thumbnail_file" name="thumbnail_file" />
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            Leave empty to keep the current URL. Manual URL edits are available
+            in Entity fields.
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function EditorCard({
+  title,
+  description,
+  fields,
+  detail,
+}: {
+  title: string
+  description: string
+  fields: CmsEditableEntityField[]
+  detail: CmsEntityDetail
+}) {
+  return (
+    <Card className="rounded-md bg-card/95 shadow-xl">
+      <CardHeader className="border-b">
+        <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+          <div>
+            <CardTitle className="font-serif text-3xl italic">{title}</CardTitle>
+            <CardDescription>{description}</CardDescription>
+          </div>
+          <p className="caps text-muted-foreground">{fields.length} fields</p>
+        </div>
+      </CardHeader>
+      <CardContent className="grid gap-5 px-6 py-6 md:grid-cols-2">
+        {fields.length > 0 ? (
+          fields.map((field) => (
+            <EditorField key={`${field.source}:${field.key}`} field={field} detail={detail} />
+          ))
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            No editable fields in this group.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function EditorField({
+  field,
+  detail,
+}: {
+  field: CmsEditableEntityField
+  detail: CmsEntityDetail
+}) {
+  const id = `entity-${field.source}-${field.key}`
+  const name = cmsEntityFieldInputName(field)
+  const value = getEntityFieldValue(detail.row, field)
+  const wide = field.type === "textarea" || field.type === "json" || field.type === "string-list"
+
+  return (
+    <div className={wide ? "space-y-2 md:col-span-2" : "space-y-2"}>
+      <div className="flex items-center gap-2">
+        <Label htmlFor={id}>{field.label}</Label>
+        {field.required && (
+          <Badge variant="outline" className="rounded-full">
+            Required
+          </Badge>
+        )}
+      </div>
+      {renderFieldInput({ field, id, name, value })}
+      <p className="font-mono text-xs text-muted-foreground">
+        {field.source}.{field.key}
+      </p>
+      {field.description && (
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          {field.description}
+        </p>
+      )}
+    </div>
+  )
+}
+
+function renderFieldInput({
+  field,
+  id,
+  name,
+  value,
+}: {
+  field: CmsEditableEntityField
+  id: string
+  name: string
+  value: unknown
+}) {
+  if (field.type === "boolean") {
+    return (
+      <div className="flex h-11 items-center gap-3 rounded-md border bg-background/70 px-3">
+        <input type="hidden" name={name} value="false" />
+        <Checkbox
+          id={id}
+          name={name}
+          value="true"
+          defaultChecked={Boolean(value)}
+        />
+        <Label htmlFor={id} className="text-sm font-normal">
+          Enabled
+        </Label>
+      </div>
+    )
+  }
+
+  if (field.type === "textarea" || field.type === "string-list" || field.type === "json") {
+    return (
+      <Textarea
+        id={id}
+        name={name}
+        defaultValue={fieldDefaultText(field, value)}
+        rows={field.type === "json" ? 10 : 5}
+        className="bg-background/70"
+      />
+    )
+  }
+
+  if (field.type === "select") {
+    return (
+      <select
+        id={id}
+        name={name}
+        defaultValue={fieldDefaultText(field, value)}
+        className="border-input h-11 w-full rounded-md border bg-background/70 px-3 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+      >
+        {!field.required && <option value="">Empty</option>}
+        {(field.options ?? []).map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    )
+  }
+
+  return (
+    <Input
+      id={id}
+      name={name}
+      type={inputType(field)}
+      defaultValue={fieldDefaultText(field, value)}
+      className="h-11 bg-background/70"
+    />
+  )
+}
+
+function inputType(field: CmsEditableEntityField) {
+  if (field.type === "number") return "number"
+  if (field.type === "date") return "date"
+  if (field.type === "datetime") return "datetime-local"
+  return "text"
+}
+
+function fieldDefaultText(field: CmsEditableEntityField, value: unknown) {
+  if (value === null || value === undefined) {
+    return ""
+  }
+
+  if (field.type === "string-list") {
+    return Array.isArray(value) ? value.join("\n") : String(value)
+  }
+
+  if (field.type === "json") {
+    return JSON.stringify(value, null, 2)
+  }
+
+  if (field.type === "datetime" && typeof value === "string") {
+    return value.slice(0, 16)
+  }
+
+  return String(value)
+}
+
+function ReadonlyMeta({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border bg-background/60 p-4">
+      <p className="caps mb-2 text-muted-foreground">{label}</p>
+      <p className="break-all font-mono text-xs">{value}</p>
+    </div>
+  )
+}

--- a/app/ponix/_components/cms-entity-form.tsx
+++ b/app/ponix/_components/cms-entity-form.tsx
@@ -25,6 +25,8 @@ import {
   type CmsEditableEntityField,
 } from "@/lib/cms/entity-editor"
 
+import { CmsEntityLivePreview } from "./cms-live-preview"
+
 type CmsEntityDetail = Extract<CmsContentDetail, { kind: "entity" }>
 
 export function CmsEntityEditorPage({
@@ -38,6 +40,7 @@ export function CmsEntityEditorPage({
   const editableFields = getEditableEntityFields(detail.schemaKey)
   const columnFields = editableFields.filter((field) => field.source === "column")
   const dataFields = editableFields.filter((field) => field.source === "data")
+  const formId = `cms-entity-form-${detail.row.id}`
 
   return (
     <main className="relative min-h-[calc(100vh-5rem)] overflow-hidden">
@@ -79,60 +82,72 @@ export function CmsEntityEditorPage({
             </AlertDescription>
           </Alert>
         ) : (
-          <form action={updateCmsEntityAction} className="space-y-6">
+          <form
+            id={formId}
+            action={updateCmsEntityAction}
+            className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_26rem]"
+          >
             <input type="hidden" name="entity_id" value={detail.row.id} />
 
-            {error && (
-              <Alert variant="destructive">
-                <AlertTitle>Save failed</AlertTitle>
-                <AlertDescription>{error}</AlertDescription>
-              </Alert>
-            )}
+            <div className="space-y-6">
+              {error && (
+                <Alert variant="destructive">
+                  <AlertTitle>Save failed</AlertTitle>
+                  <AlertDescription>{error}</AlertDescription>
+                </Alert>
+              )}
 
-            <Card className="rounded-md bg-card/95 shadow-xl">
-              <CardHeader className="border-b">
-                <CardTitle className="font-serif text-3xl italic">
-                  Locked identity
-                </CardTitle>
-                <CardDescription>
-                  These values define entity behavior and are not editable in
-                  this slice.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="grid gap-4 px-6 py-6 md:grid-cols-3">
-                <ReadonlyMeta label="Entity type" value={detail.row.entity_type} />
-                <ReadonlyMeta label="Schema" value={detail.row.schema_key} />
-                <ReadonlyMeta label="ID" value={detail.row.id} />
-              </CardContent>
-            </Card>
+              <Card className="rounded-md bg-card/95 shadow-xl">
+                <CardHeader className="border-b">
+                  <CardTitle className="font-serif text-3xl italic">
+                    Locked identity
+                  </CardTitle>
+                  <CardDescription>
+                    These values define entity behavior and are not editable in
+                    this slice.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="grid gap-4 px-6 py-6 md:grid-cols-3">
+                  <ReadonlyMeta label="Entity type" value={detail.row.entity_type} />
+                  <ReadonlyMeta label="Schema" value={detail.row.schema_key} />
+                  <ReadonlyMeta label="ID" value={detail.row.id} />
+                </CardContent>
+              </Card>
 
-            <ThumbnailCard detail={detail} />
+              <ThumbnailCard detail={detail} />
 
-            <EditorCard
-              title="Entity fields"
-              description="Shared columns used by cards, lists, and detail views."
-              fields={columnFields}
-              detail={detail}
-            />
+              <EditorCard
+                title="Entity fields"
+                description="Shared columns used by cards, lists, and detail views."
+                fields={columnFields}
+                detail={detail}
+              />
 
-            <EditorCard
-              title="Schema data"
-              description="Schema-registered JSON data for this entity type."
-              fields={dataFields}
-              detail={detail}
-            />
+              <EditorCard
+                title="Schema data"
+                description="Schema-registered JSON data for this entity type."
+                fields={dataFields}
+                detail={detail}
+              />
 
-            <div className="flex flex-col gap-3 rounded-md border bg-card/95 p-4 shadow-xl sm:flex-row sm:items-center sm:justify-between">
-              <p className="text-sm text-muted-foreground">
-                Saving updates this entity row only. Relations stay untouched.
-              </p>
-              <div className="flex gap-2">
-                <Button asChild type="button" variant="outline">
-                  <Link href={`/ponix/entities/${detail.row.id}`}>Cancel</Link>
-                </Button>
-                <Button type="submit">Save entity</Button>
+              <div className="flex flex-col gap-3 rounded-md border bg-card/95 p-4 shadow-xl sm:flex-row sm:items-center sm:justify-between">
+                <p className="text-sm text-muted-foreground">
+                  Saving updates this entity row only. Relations stay untouched.
+                </p>
+                <div className="flex gap-2">
+                  <Button asChild type="button" variant="outline">
+                    <Link href={`/ponix/entities/${detail.row.id}`}>Cancel</Link>
+                  </Button>
+                  <Button type="submit">Save entity</Button>
+                </div>
               </div>
             </div>
+
+            <CmsEntityLivePreview
+              formId={formId}
+              detail={detail}
+              fields={editableFields}
+            />
           </form>
         )}
       </section>

--- a/app/ponix/_components/cms-live-preview.tsx
+++ b/app/ponix/_components/cms-live-preview.tsx
@@ -1,0 +1,662 @@
+"use client"
+
+import {
+  startTransition,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
+import type { ReactNode } from "react"
+
+import { Badge } from "@/components/ui/badge"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import type {
+  CmsContentDetail,
+  CmsSectionEntityRelation,
+} from "@/lib/cms/content"
+import type { CmsFieldDefinition } from "@/lib/cms/schema-registry"
+import type { Json } from "@/lib/supabase/types"
+
+type CmsEntityDetail = Extract<CmsContentDetail, { kind: "entity" }>
+type CmsSectionDetail = Extract<CmsContentDetail, { kind: "section" }>
+
+type PreviewValue = {
+  key: string
+  label: string
+  value: unknown
+  type: CmsFieldDefinition["type"]
+}
+
+type EntityPreviewSnapshot = {
+  title: string
+  subtitle: string
+  summary: string
+  thumbnailUrl: string
+  published: boolean
+  values: PreviewValue[]
+}
+
+type SectionPreviewSnapshot = {
+  eyebrow: string
+  title: string
+  subtitle: string
+  body: string
+  actionLabel: string
+  actionHref: string
+  published: boolean
+  values: PreviewValue[]
+}
+
+const primaryPreviewKeys = new Set([
+  "eyebrow",
+  "title",
+  "subtitle",
+  "summary",
+  "thumbnail_url",
+  "published",
+  "body",
+  "action_label",
+  "href",
+])
+
+export function CmsEntityLivePreview({
+  formId,
+  detail,
+  fields,
+}: {
+  formId: string
+  detail: CmsEntityDetail
+  fields: CmsFieldDefinition[]
+}) {
+  const fileRef = useRef<File | null>(null)
+  const objectUrlRef = useRef<string | null>(null)
+  const initialSnapshot = useMemo(
+    () => entitySnapshotFromDetail(detail, fields),
+    [detail, fields],
+  )
+  const [snapshot, setSnapshot] = useState(initialSnapshot)
+  const deferredSnapshot = useDeferredValue(snapshot)
+
+  useEffect(() => {
+    const form = document.getElementById(formId)
+
+    if (!(form instanceof HTMLFormElement)) {
+      return
+    }
+
+    const update = () => {
+      const nextSnapshot = entitySnapshotFromForm({
+        detail,
+        fields,
+        form,
+        currentObjectUrl: objectUrlRef.current,
+        currentFile: fileRef.current,
+        setObjectUrl: (url) => {
+          objectUrlRef.current = url
+        },
+        setFile: (file) => {
+          fileRef.current = file
+        },
+      })
+
+      startTransition(() => {
+        setSnapshot(nextSnapshot)
+      })
+    }
+
+    update()
+    form.addEventListener("input", update)
+    form.addEventListener("change", update)
+
+    return () => {
+      form.removeEventListener("input", update)
+      form.removeEventListener("change", update)
+
+      if (objectUrlRef.current) {
+        URL.revokeObjectURL(objectUrlRef.current)
+      }
+    }
+  }, [detail, fields, formId])
+
+  return (
+    <PreviewShell eyebrow="Live preview" title="Entity card">
+      <EntityPreviewCard
+        schemaLabel={detail.schemaLabel}
+        entityType={detail.row.entity_type}
+        snapshot={deferredSnapshot}
+      />
+    </PreviewShell>
+  )
+}
+
+export function CmsSectionLivePreview({
+  formId,
+  detail,
+  fields,
+  sectionEntities,
+}: {
+  formId: string
+  detail: CmsSectionDetail
+  fields: CmsFieldDefinition[]
+  sectionEntities: CmsSectionEntityRelation[]
+}) {
+  const initialSnapshot = useMemo(
+    () => sectionSnapshotFromDetail(detail, fields),
+    [detail, fields],
+  )
+  const [snapshot, setSnapshot] = useState(initialSnapshot)
+  const deferredSnapshot = useDeferredValue(snapshot)
+
+  useEffect(() => {
+    const form = document.getElementById(formId)
+
+    if (!(form instanceof HTMLFormElement)) {
+      return
+    }
+
+    const update = () => {
+      const nextSnapshot = sectionSnapshotFromForm(detail, fields, form)
+
+      startTransition(() => {
+        setSnapshot(nextSnapshot)
+      })
+    }
+
+    update()
+    form.addEventListener("input", update)
+    form.addEventListener("change", update)
+
+    return () => {
+      form.removeEventListener("input", update)
+      form.removeEventListener("change", update)
+    }
+  }, [detail, fields, formId])
+
+  return (
+    <PreviewShell eyebrow="Live preview" title="Section surface">
+      <SectionPreviewCard
+        sectionKey={detail.row.key}
+        sectionType={detail.row.section_type}
+        schemaLabel={detail.schemaLabel}
+        snapshot={deferredSnapshot}
+        sectionEntities={sectionEntities}
+      />
+    </PreviewShell>
+  )
+}
+
+function PreviewShell({
+  eyebrow,
+  title,
+  children,
+}: {
+  eyebrow: string
+  title: string
+  children: ReactNode
+}) {
+  return (
+    <div className="xl:sticky xl:top-24">
+      <Card className="overflow-hidden rounded-md bg-card/95 shadow-xl">
+        <CardHeader className="border-b">
+          <p className="caps text-muted-foreground">{eyebrow}</p>
+          <CardTitle className="font-serif text-3xl italic">{title}</CardTitle>
+          <CardDescription>
+            Common CMS preview rendered from the current form state.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="bg-muted/25 p-4">{children}</CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function EntityPreviewCard({
+  entityType,
+  schemaLabel,
+  snapshot,
+}: {
+  entityType: string
+  schemaLabel: string
+  snapshot: EntityPreviewSnapshot
+}) {
+  return (
+    <article className="overflow-hidden rounded-md border bg-background shadow-sm">
+      {snapshot.thumbnailUrl && (
+        <div className="aspect-[16/10] w-full overflow-hidden bg-muted">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={snapshot.thumbnailUrl}
+            alt=""
+            className="h-full w-full object-cover"
+          />
+        </div>
+      )}
+      <div className="space-y-5 p-5">
+        <div className="flex flex-wrap gap-2">
+          <Badge variant={snapshot.published ? "default" : "outline"}>
+            {snapshot.published ? "Published" : "Draft"}
+          </Badge>
+          <Badge variant="secondary">{schemaLabel}</Badge>
+          <Badge variant="outline" className="font-mono">
+            {entityType}
+          </Badge>
+        </div>
+        <div>
+          <h2 className="font-serif text-4xl italic leading-none">
+            {snapshot.title || "Untitled entity"}
+          </h2>
+          {snapshot.subtitle && (
+            <p className="mt-3 text-sm text-muted-foreground">
+              {snapshot.subtitle}
+            </p>
+          )}
+        </div>
+        {snapshot.summary && (
+          <p className="text-sm leading-relaxed text-muted-foreground">
+            {snapshot.summary}
+          </p>
+        )}
+        <PreviewValueList values={snapshot.values} />
+      </div>
+    </article>
+  )
+}
+
+function SectionPreviewCard({
+  sectionKey,
+  sectionType,
+  schemaLabel,
+  snapshot,
+  sectionEntities,
+}: {
+  sectionKey: string
+  sectionType: string
+  schemaLabel: string
+  snapshot: SectionPreviewSnapshot
+  sectionEntities: CmsSectionEntityRelation[]
+}) {
+  return (
+    <section className="space-y-5 rounded-md border bg-background p-5 shadow-sm">
+      <div className="flex flex-wrap gap-2">
+        <Badge variant={snapshot.published ? "default" : "outline"}>
+          {snapshot.published ? "Published" : "Draft"}
+        </Badge>
+        <Badge variant="secondary">{schemaLabel}</Badge>
+        <Badge variant="outline" className="font-mono">
+          {sectionType}
+        </Badge>
+      </div>
+      <div>
+        {snapshot.eyebrow && (
+          <p className="caps mb-4 text-muted-foreground">{snapshot.eyebrow}</p>
+        )}
+        <h2 className="font-serif text-5xl italic leading-none">
+          {snapshot.title || sectionKey}
+        </h2>
+        {snapshot.subtitle && (
+          <p className="mt-3 text-lg text-muted-foreground">
+            {snapshot.subtitle}
+          </p>
+        )}
+      </div>
+      {snapshot.body && (
+        <p className="text-sm leading-relaxed text-muted-foreground">
+          {snapshot.body}
+        </p>
+      )}
+      {snapshot.actionLabel && (
+        <div className="inline-flex rounded-full border px-4 py-2 text-sm">
+          {snapshot.actionLabel}
+          {snapshot.actionHref && (
+            <span className="ml-2 text-muted-foreground">-&gt;</span>
+          )}
+        </div>
+      )}
+      <PreviewValueList values={snapshot.values} />
+      <LinkedEntityPreviewList relations={sectionEntities} />
+    </section>
+  )
+}
+
+function PreviewValueList({ values }: { values: PreviewValue[] }) {
+  const visibleValues = values.filter((item) => hasPreviewValue(item.value))
+
+  if (visibleValues.length === 0) {
+    return null
+  }
+
+  return (
+    <dl className="grid gap-2 border-t pt-4 text-sm">
+      {visibleValues.slice(0, 8).map((item) => (
+        <div
+          key={item.key}
+          className="grid gap-1 rounded-md bg-muted/35 p-3 sm:grid-cols-[7rem_minmax(0,1fr)]"
+        >
+          <dt className="caps text-muted-foreground">{item.label}</dt>
+          <dd className="break-words">{formatPreviewValue(item.value, item.type)}</dd>
+        </div>
+      ))}
+    </dl>
+  )
+}
+
+function LinkedEntityPreviewList({
+  relations,
+}: {
+  relations: CmsSectionEntityRelation[]
+}) {
+  if (relations.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+        No linked entities yet.
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3 border-t pt-4">
+      <div className="flex items-center justify-between gap-4">
+        <p className="caps text-muted-foreground">Linked entities</p>
+        <p className="font-mono text-xs text-muted-foreground">
+          {relations.length}
+        </p>
+      </div>
+      <div className="grid gap-3">
+        {relations.slice(0, 6).map((relation) => (
+          <div
+            key={relation.id}
+            className="grid grid-cols-[4.5rem_minmax(0,1fr)] gap-3 rounded-md border bg-card p-3"
+          >
+            {relation.entity?.thumbnailUrl ? (
+              <div className="h-16 overflow-hidden rounded-sm bg-muted">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={relation.entity.thumbnailUrl}
+                  alt=""
+                  className="h-full w-full object-cover"
+                />
+              </div>
+            ) : (
+              <div className="grid h-16 place-items-center rounded-sm bg-muted text-lg font-serif italic text-muted-foreground">
+                {relation.entity?.title?.slice(0, 1) ?? "E"}
+              </div>
+            )}
+            <div className="min-w-0">
+              <p className="truncate font-medium">
+                {relation.entity?.title ?? relation.entityId}
+              </p>
+              <p className="mt-1 truncate text-xs text-muted-foreground">
+                {relation.entity?.subtitle ?? relation.entity?.schemaLabel ?? relation.slot}
+              </p>
+              <div className="mt-2 flex flex-wrap gap-1">
+                <Badge variant="outline" className="rounded-full text-[0.65rem]">
+                  {relation.slot}
+                </Badge>
+                <Badge variant="secondary" className="rounded-full text-[0.65rem]">
+                  {relation.sortOrder}
+                </Badge>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function entitySnapshotFromDetail(
+  detail: CmsEntityDetail,
+  fields: CmsFieldDefinition[],
+): EntityPreviewSnapshot {
+  return {
+    title: detail.row.title,
+    subtitle: detail.row.subtitle ?? "",
+    summary: detail.row.summary ?? "",
+    thumbnailUrl: detail.row.thumbnail_url ?? "",
+    published: detail.row.published,
+    values: previewValuesFromDetail(fields, detail.row.data, {
+      slug: detail.row.slug,
+      sort_at: detail.row.sort_at,
+    }),
+  }
+}
+
+function entitySnapshotFromForm({
+  detail,
+  fields,
+  form,
+  currentObjectUrl,
+  currentFile,
+  setObjectUrl,
+  setFile,
+}: {
+  detail: CmsEntityDetail
+  fields: CmsFieldDefinition[]
+  form: HTMLFormElement
+  currentObjectUrl: string | null
+  currentFile: File | null
+  setObjectUrl: (url: string | null) => void
+  setFile: (file: File | null) => void
+}): EntityPreviewSnapshot {
+  const formData = new FormData(form)
+  const fileInput = form.elements.namedItem("thumbnail_file")
+  let filePreviewUrl = currentObjectUrl
+
+  if (fileInput instanceof HTMLInputElement) {
+    const nextFile = fileInput.files?.[0] ?? null
+
+    if (nextFile !== currentFile) {
+      if (currentObjectUrl) {
+        URL.revokeObjectURL(currentObjectUrl)
+      }
+
+      filePreviewUrl = nextFile ? URL.createObjectURL(nextFile) : null
+      setObjectUrl(filePreviewUrl)
+      setFile(nextFile)
+    }
+  }
+
+  const base = entitySnapshotFromDetail(detail, fields)
+  const values = previewValuesFromForm(fields, formData)
+
+  return {
+    ...base,
+    title: textFormValue(formData, "cms:column:title", base.title),
+    subtitle: textFormValue(formData, "cms:column:subtitle", base.subtitle),
+    summary: textFormValue(formData, "cms:column:summary", base.summary),
+    thumbnailUrl:
+      filePreviewUrl ??
+      textFormValue(formData, "cms:column:thumbnail_url", base.thumbnailUrl),
+    published: booleanFormValue(formData, "cms:column:published", base.published),
+    values,
+  }
+}
+
+function sectionSnapshotFromDetail(
+  detail: CmsSectionDetail,
+  fields: CmsFieldDefinition[],
+): SectionPreviewSnapshot {
+  const props = jsonObject(detail.row.props)
+
+  return {
+    eyebrow: detail.row.eyebrow ?? "",
+    title: detail.row.title ?? detail.row.key,
+    subtitle: detail.row.subtitle ?? "",
+    body: textValue(props.body),
+    actionLabel: textValue(props.action_label),
+    actionHref: textValue(props.href),
+    published: detail.row.published,
+    values: previewValuesFromDetail(fields, detail.row.props, {}),
+  }
+}
+
+function sectionSnapshotFromForm(
+  detail: CmsSectionDetail,
+  fields: CmsFieldDefinition[],
+  form: HTMLFormElement,
+): SectionPreviewSnapshot {
+  const formData = new FormData(form)
+  const base = sectionSnapshotFromDetail(detail, fields)
+  const values = previewValuesFromForm(fields, formData)
+
+  return {
+    ...base,
+    eyebrow: textFormValue(formData, "cms:column:eyebrow", base.eyebrow),
+    title: textFormValue(formData, "cms:column:title", base.title),
+    subtitle: textFormValue(formData, "cms:column:subtitle", base.subtitle),
+    body: textFormValue(formData, "cms:props:body", base.body),
+    actionLabel: textFormValue(
+      formData,
+      "cms:props:action_label",
+      base.actionLabel,
+    ),
+    actionHref: textFormValue(formData, "cms:props:href", base.actionHref),
+    published: booleanFormValue(formData, "cms:column:published", base.published),
+    values,
+  }
+}
+
+function previewValuesFromDetail(
+  fields: CmsFieldDefinition[],
+  sourceJson: Json,
+  columnValues: Record<string, unknown>,
+): PreviewValue[] {
+  const sourceObject = jsonObject(sourceJson)
+
+  return fields
+    .filter((field) => isSupplementalPreviewField(field))
+    .map((field) => ({
+      key: `${field.source}:${field.key}`,
+      label: field.label,
+      type: field.type,
+      value:
+        field.source === "column" ? columnValues[field.key] : sourceObject[field.key],
+    }))
+}
+
+function previewValuesFromForm(
+  fields: CmsFieldDefinition[],
+  formData: FormData,
+): PreviewValue[] {
+  return fields
+    .filter((field) => isSupplementalPreviewField(field))
+    .map((field) => ({
+      key: `${field.source}:${field.key}`,
+      label: field.label,
+      type: field.type,
+      value: fieldValueFromForm(field, formData),
+    }))
+}
+
+function isSupplementalPreviewField(field: CmsFieldDefinition) {
+  if (field.readOnly) {
+    return false
+  }
+
+  return !primaryPreviewKeys.has(field.key)
+}
+
+function fieldValueFromForm(field: CmsFieldDefinition, formData: FormData) {
+  const value = formData.get(`cms:${field.source}:${field.key}`)
+
+  if (field.type === "boolean") {
+    return formData.getAll(`cms:${field.source}:${field.key}`).includes("true")
+  }
+
+  if (typeof value !== "string") {
+    return ""
+  }
+
+  if (field.type === "number") {
+    return value === "" ? "" : Number(value)
+  }
+
+  if (field.type === "string-list") {
+    return value
+      .split("\n")
+      .map((item) => item.trim())
+      .filter(Boolean)
+  }
+
+  if (field.type === "json") {
+    try {
+      return JSON.parse(value)
+    } catch {
+      return value
+    }
+  }
+
+  return value
+}
+
+function textFormValue(formData: FormData, name: string, fallback: string) {
+  const value = formData.get(name)
+  return typeof value === "string" ? value : fallback
+}
+
+function booleanFormValue(formData: FormData, name: string, fallback: boolean) {
+  if (!formData.has(name)) {
+    return fallback
+  }
+
+  return formData.getAll(name).includes("true")
+}
+
+function jsonObject(value: Json): Record<string, Json> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {}
+  }
+
+  return value as Record<string, Json>
+}
+
+function textValue(value: unknown) {
+  if (value === null || value === undefined) {
+    return ""
+  }
+
+  return String(value)
+}
+
+function hasPreviewValue(value: unknown) {
+  if (value === null || value === undefined || value === "") {
+    return false
+  }
+
+  if (Array.isArray(value)) {
+    return value.length > 0
+  }
+
+  return true
+}
+
+function formatPreviewValue(
+  value: unknown,
+  type: CmsFieldDefinition["type"],
+) {
+  if (Array.isArray(value)) {
+    return value.join(", ")
+  }
+
+  if (typeof value === "boolean") {
+    return value ? "true" : "false"
+  }
+
+  if (typeof value === "object" && value !== null) {
+    return JSON.stringify(value)
+  }
+
+  if ((type === "date" || type === "datetime") && typeof value === "string") {
+    return value.replace("T", " ")
+  }
+
+  return String(value)
+}

--- a/app/ponix/_components/cms-section-form.tsx
+++ b/app/ponix/_components/cms-section-form.tsx
@@ -15,7 +15,7 @@ import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
-import type { CmsContentDetail } from "@/lib/cms/content"
+import type { CmsContentDetail, CmsSectionRelationContext } from "@/lib/cms/content"
 import {
   cmsFieldInputName,
   getEditableSectionFields,
@@ -24,19 +24,24 @@ import {
   type CmsEditableSectionField,
 } from "@/lib/cms/section-editor"
 
+import { CmsSectionLivePreview } from "./cms-live-preview"
+
 type CmsSectionDetail = Extract<CmsContentDetail, { kind: "section" }>
 
 export function CmsSectionEditorPage({
   detail,
+  relations,
   error,
 }: {
   detail: CmsSectionDetail
+  relations: CmsSectionRelationContext
   error?: string
 }) {
   const schema = getSectionEditorSchema(detail.schemaKey)
   const editableFields = getEditableSectionFields(detail.schemaKey)
   const columnFields = editableFields.filter((field) => field.source === "column")
   const propsFields = editableFields.filter((field) => field.source === "props")
+  const formId = `cms-section-form-${detail.row.id}`
 
   return (
     <main className="relative min-h-[calc(100vh-5rem)] overflow-hidden">
@@ -78,58 +83,71 @@ export function CmsSectionEditorPage({
             </AlertDescription>
           </Alert>
         ) : (
-          <form action={updateCmsSectionAction} className="space-y-6">
+          <form
+            id={formId}
+            action={updateCmsSectionAction}
+            className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_28rem]"
+          >
             <input type="hidden" name="section_id" value={detail.row.id} />
 
-            {error && (
-              <Alert variant="destructive">
-                <AlertTitle>Save failed</AlertTitle>
-                <AlertDescription>{error}</AlertDescription>
-              </Alert>
-            )}
+            <div className="space-y-6">
+              {error && (
+                <Alert variant="destructive">
+                  <AlertTitle>Save failed</AlertTitle>
+                  <AlertDescription>{error}</AlertDescription>
+                </Alert>
+              )}
 
-            <Card className="rounded-md bg-card/95 shadow-xl">
-              <CardHeader className="border-b">
-                <CardTitle className="font-serif text-3xl italic">
-                  Locked identity
-                </CardTitle>
-                <CardDescription>
-                  These values define routing and renderer behavior and are not
-                  editable in this slice.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="grid gap-4 px-6 py-6 md:grid-cols-3">
-                <ReadonlyMeta label="Key" value={detail.row.key} />
-                <ReadonlyMeta label="Renderer" value={detail.row.section_type} />
-                <ReadonlyMeta label="Schema" value={detail.row.schema_key} />
-              </CardContent>
-            </Card>
+              <Card className="rounded-md bg-card/95 shadow-xl">
+                <CardHeader className="border-b">
+                  <CardTitle className="font-serif text-3xl italic">
+                    Locked identity
+                  </CardTitle>
+                  <CardDescription>
+                    These values define routing and renderer behavior and are not
+                    editable in this slice.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="grid gap-4 px-6 py-6 md:grid-cols-3">
+                  <ReadonlyMeta label="Key" value={detail.row.key} />
+                  <ReadonlyMeta label="Renderer" value={detail.row.section_type} />
+                  <ReadonlyMeta label="Schema" value={detail.row.schema_key} />
+                </CardContent>
+              </Card>
 
-            <EditorCard
-              title="Section copy"
-              description="Column fields shared by section renderers."
-              fields={columnFields}
-              detail={detail}
-            />
+              <EditorCard
+                title="Section copy"
+                description="Column fields shared by section renderers."
+                fields={columnFields}
+                detail={detail}
+              />
 
-            <EditorCard
-              title="Renderer props"
-              description="Schema-registered JSON props for this section renderer."
-              fields={propsFields}
-              detail={detail}
-            />
+              <EditorCard
+                title="Renderer props"
+                description="Schema-registered JSON props for this section renderer."
+                fields={propsFields}
+                detail={detail}
+              />
 
-            <div className="flex flex-col gap-3 rounded-md border bg-card/95 p-4 shadow-xl sm:flex-row sm:items-center sm:justify-between">
-              <p className="text-sm text-muted-foreground">
-                Saving updates this section row only. Relations and entities stay untouched.
-              </p>
-              <div className="flex gap-2">
-                <Button asChild type="button" variant="outline">
-                  <Link href={`/ponix/sections/${detail.row.id}`}>Cancel</Link>
-                </Button>
-                <Button type="submit">Save section</Button>
+              <div className="flex flex-col gap-3 rounded-md border bg-card/95 p-4 shadow-xl sm:flex-row sm:items-center sm:justify-between">
+                <p className="text-sm text-muted-foreground">
+                  Saving updates this section row only. Relations and entities stay untouched.
+                </p>
+                <div className="flex gap-2">
+                  <Button asChild type="button" variant="outline">
+                    <Link href={`/ponix/sections/${detail.row.id}`}>Cancel</Link>
+                  </Button>
+                  <Button type="submit">Save section</Button>
+                </div>
               </div>
             </div>
+
+            <CmsSectionLivePreview
+              formId={formId}
+              detail={detail}
+              fields={editableFields}
+              sectionEntities={relations.sectionEntities}
+            />
           </form>
         )}
       </section>

--- a/app/ponix/entities/[id]/edit/page.tsx
+++ b/app/ponix/entities/[id]/edit/page.tsx
@@ -1,0 +1,40 @@
+import type { Metadata } from "next"
+import { notFound } from "next/navigation"
+
+import { CmsEntityEditorPage } from "@/app/ponix/_components/cms-entity-form"
+import { requireCmsAdmin } from "@/lib/cms/auth"
+import { loadCmsEntityDetail } from "@/lib/cms/content"
+
+export const metadata: Metadata = {
+  title: "Edit PONIX Entity | 브레멘 Bremen",
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
+
+type PonixEntityEditPageProps = {
+  params: Promise<{ id: string }>
+  searchParams?: Promise<Record<string, string | string[] | undefined>>
+}
+
+function firstParam(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value
+}
+
+export default async function PonixEntityEditPage({
+  params,
+  searchParams,
+}: PonixEntityEditPageProps) {
+  const { id } = await params
+  const query = (await searchParams) ?? {}
+
+  await requireCmsAdmin(`/ponix/entities/${id}/edit`)
+  const detail = await loadCmsEntityDetail(id)
+
+  if (!detail || detail.kind !== "entity") {
+    notFound()
+  }
+
+  return <CmsEntityEditorPage detail={detail} error={firstParam(query.error)} />
+}

--- a/app/ponix/entities/[id]/page.tsx
+++ b/app/ponix/entities/[id]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next"
+import Link from "next/link"
 import { notFound } from "next/navigation"
 
 import { CmsDetailPage } from "@/app/ponix/_components/cms-detail"
@@ -44,6 +45,14 @@ export default async function PonixEntityRecordPage({
       detail={detail}
       backHref="/ponix/entities"
       backLabel="All entities"
+      actions={
+        <Link
+          href={`/ponix/entities/${id}/edit`}
+          className="inline-flex h-9 items-center justify-center rounded-full bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-xs transition-colors hover:bg-primary/90"
+        >
+          Edit entity
+        </Link>
+      }
     >
       <SectionEntityRelationsCard
         title="Section placements"

--- a/app/ponix/entities/actions.ts
+++ b/app/ponix/entities/actions.ts
@@ -1,0 +1,396 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+import { redirect } from "next/navigation"
+
+import { requireCmsAdmin } from "@/lib/cms/auth"
+import {
+  cmsEntityFieldInputName,
+  getEditableEntityFields,
+  getEntityEditorSchema,
+  jsonObject,
+  type CmsEditableEntityField,
+  type CmsJsonObject,
+} from "@/lib/cms/entity-editor"
+import { createClient } from "@/lib/supabase/server"
+import type { Database, Json } from "@/lib/supabase/types"
+
+type EntityUpdate = Database["public"]["Tables"]["entities"]["Update"]
+type EntityRow = Database["public"]["Tables"]["entities"]["Row"]
+
+type ParsedValue =
+  | {
+      ok: true
+      empty: boolean
+      value: Json
+    }
+  | {
+      ok: false
+      error: string
+    }
+
+const maxThumbnailSize = 8 * 1024 * 1024
+
+function stringField(formData: FormData, key: string) {
+  const value = formData.get(key)
+  return typeof value === "string" ? value.trim() : ""
+}
+
+function redirectWithParams(path: string, params: Record<string, string>): never {
+  const search = new URLSearchParams(params)
+  redirect(`${path}?${search.toString()}`)
+}
+
+function isSafeUrl(value: string) {
+  if (value.startsWith("/") && !value.startsWith("//")) {
+    return true
+  }
+
+  try {
+    const url = new URL(value)
+    return url.protocol === "http:" || url.protocol === "https:"
+  } catch {
+    return false
+  }
+}
+
+function parseBoolean(formData: FormData, field: CmsEditableEntityField): ParsedValue {
+  const values = formData.getAll(cmsEntityFieldInputName(field))
+
+  return {
+    ok: true,
+    empty: false,
+    value: values.includes("true"),
+  }
+}
+
+function parseStringList(
+  formData: FormData,
+  field: CmsEditableEntityField,
+): ParsedValue {
+  const value = stringField(formData, cmsEntityFieldInputName(field))
+  const items = value
+    .split("\n")
+    .map((item) => item.trim())
+    .filter(Boolean)
+
+  if (field.required && items.length === 0) {
+    return { ok: false, error: `${field.label} is required.` }
+  }
+
+  return {
+    ok: true,
+    empty: items.length === 0,
+    value: items,
+  }
+}
+
+function parseJson(formData: FormData, field: CmsEditableEntityField): ParsedValue {
+  const value = stringField(formData, cmsEntityFieldInputName(field))
+
+  if (!value) {
+    if (field.required) {
+      return { ok: false, error: `${field.label} is required.` }
+    }
+
+    return { ok: true, empty: true, value: null }
+  }
+
+  try {
+    return {
+      ok: true,
+      empty: false,
+      value: JSON.parse(value) as Json,
+    }
+  } catch {
+    return { ok: false, error: `${field.label} must be valid JSON.` }
+  }
+}
+
+function parseNumber(formData: FormData, field: CmsEditableEntityField): ParsedValue {
+  const value = stringField(formData, cmsEntityFieldInputName(field))
+
+  if (!value) {
+    if (field.required) {
+      return { ok: false, error: `${field.label} is required.` }
+    }
+
+    return { ok: true, empty: true, value: null }
+  }
+
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed)) {
+    return { ok: false, error: `${field.label} must be a number.` }
+  }
+
+  return {
+    ok: true,
+    empty: false,
+    value: parsed,
+  }
+}
+
+function parseTextLike(
+  formData: FormData,
+  field: CmsEditableEntityField,
+): ParsedValue {
+  const value = stringField(formData, cmsEntityFieldInputName(field))
+
+  if (!value) {
+    if (field.required) {
+      return { ok: false, error: `${field.label} is required.` }
+    }
+
+    return { ok: true, empty: true, value: null }
+  }
+
+  if ((field.type === "url" || field.type === "image") && !isSafeUrl(value)) {
+    return {
+      ok: false,
+      error: `${field.label} must be an absolute URL or site-root path.`,
+    }
+  }
+
+  if (field.type === "date" && Number.isNaN(Date.parse(value))) {
+    return { ok: false, error: `${field.label} must be a valid date.` }
+  }
+
+  if (field.type === "datetime" && Number.isNaN(Date.parse(value))) {
+    return { ok: false, error: `${field.label} must be a valid date and time.` }
+  }
+
+  if (
+    field.type === "select" &&
+    field.options?.length &&
+    !field.options.some((option) => option.value === value)
+  ) {
+    return { ok: false, error: `${field.label} has an invalid option.` }
+  }
+
+  return {
+    ok: true,
+    empty: false,
+    value,
+  }
+}
+
+function parseFieldValue(
+  formData: FormData,
+  field: CmsEditableEntityField,
+): ParsedValue {
+  if (field.type === "boolean") {
+    return parseBoolean(formData, field)
+  }
+
+  if (field.type === "string-list") {
+    return parseStringList(formData, field)
+  }
+
+  if (field.type === "json") {
+    return parseJson(formData, field)
+  }
+
+  if (field.type === "number") {
+    return parseNumber(formData, field)
+  }
+
+  return parseTextLike(formData, field)
+}
+
+function updateDataValue(
+  data: CmsJsonObject,
+  field: CmsEditableEntityField,
+  parsed: ParsedValue & { ok: true },
+) {
+  if (parsed.empty) {
+    delete data[field.key]
+    return
+  }
+
+  data[field.key] = parsed.value
+}
+
+function extensionFromImage(file: File) {
+  const extension = file.name.split(".").pop()?.toLowerCase()
+  if (extension && ["jpg", "jpeg", "png", "webp", "gif"].includes(extension)) {
+    return extension === "jpeg" ? "jpg" : extension
+  }
+
+  if (file.type === "image/png") return "png"
+  if (file.type === "image/webp") return "webp"
+  if (file.type === "image/gif") return "gif"
+  return "jpg"
+}
+
+function thumbnailBucket(entity: EntityRow) {
+  if (
+    entity.entity_type === "performance" ||
+    entity.schema_key.startsWith("performance/")
+  ) {
+    return "posters"
+  }
+
+  return "photos"
+}
+
+async function uploadThumbnailIfPresent({
+  supabase,
+  entity,
+  formData,
+  editPath,
+}: {
+  supabase: Awaited<ReturnType<typeof createClient>>
+  entity: EntityRow
+  formData: FormData
+  editPath: string
+}) {
+  const file = formData.get("thumbnail_file")
+  if (!(file instanceof File) || file.size === 0) return null
+
+  if (!file.type.startsWith("image/")) {
+    redirectWithParams(editPath, {
+      error: "Thumbnail upload accepts image files only.",
+    })
+  }
+
+  if (file.size > maxThumbnailSize) {
+    redirectWithParams(editPath, {
+      error: "Thumbnail image must be 8MB or smaller.",
+    })
+  }
+
+  const bucket = thumbnailBucket(entity)
+  const extension = extensionFromImage(file)
+  const safeKey = (entity.slug ?? entity.id).replace(/[^a-zA-Z0-9._-]+/g, "-")
+  const path = `entities/${entity.id}/${safeKey}-thumbnail-${Date.now()}.${extension}`
+  const { error } = await supabase.storage.from(bucket).upload(path, file, {
+    cacheControl: "3600",
+    contentType: file.type || `image/${extension}`,
+    upsert: true,
+  })
+
+  if (error) {
+    redirectWithParams(editPath, {
+      error: "Thumbnail upload failed.",
+    })
+  }
+
+  return supabase.storage.from(bucket).getPublicUrl(path).data.publicUrl
+}
+
+export async function updateCmsEntityAction(formData: FormData) {
+  const entityId = stringField(formData, "entity_id")
+
+  if (!entityId) {
+    redirectWithParams("/ponix/entities", {
+      error: "Missing entity id.",
+    })
+  }
+
+  const editPath = `/ponix/entities/${entityId}/edit`
+  await requireCmsAdmin(editPath)
+
+  const supabase = await createClient()
+  const { data: entity, error: loadError } = await supabase
+    .from("entities")
+    .select("*")
+    .eq("id", entityId)
+    .maybeSingle()
+
+  if (loadError || !entity) {
+    redirectWithParams(editPath, {
+      error: "Entity not found.",
+    })
+  }
+
+  const schema = getEntityEditorSchema(entity.schema_key)
+  if (!schema) {
+    redirectWithParams(editPath, {
+      error: "This entity schema is not registered for editing.",
+    })
+  }
+
+  const fields = getEditableEntityFields(entity.schema_key)
+  const data = jsonObject(entity.data)
+  const update: EntityUpdate = {}
+
+  for (const field of fields) {
+    const parsed = parseFieldValue(formData, field)
+
+    if (!parsed.ok) {
+      redirectWithParams(editPath, {
+        error: parsed.error,
+      })
+    }
+
+    if (field.source === "data") {
+      updateDataValue(data, field, parsed)
+      continue
+    }
+
+    if (field.key === "published") {
+      update.published = Boolean(parsed.value)
+    }
+
+    if (field.key === "slug") {
+      update.slug = parsed.value === null ? null : String(parsed.value)
+    }
+
+    if (field.key === "title") {
+      update.title = String(parsed.value)
+    }
+
+    if (field.key === "subtitle") {
+      update.subtitle = parsed.value === null ? null : String(parsed.value)
+    }
+
+    if (field.key === "summary") {
+      update.summary = parsed.value === null ? null : String(parsed.value)
+    }
+
+    if (field.key === "thumbnail_url") {
+      update.thumbnail_url = parsed.value === null ? null : String(parsed.value)
+    }
+
+    if (field.key === "sort_at") {
+      update.sort_at = new Date(String(parsed.value)).toISOString()
+    }
+  }
+
+  const uploadedThumbnailUrl = await uploadThumbnailIfPresent({
+    supabase,
+    entity,
+    formData,
+    editPath,
+  })
+
+  if (uploadedThumbnailUrl) {
+    update.thumbnail_url = uploadedThumbnailUrl
+  }
+
+  update.data = data
+
+  const { error: updateError } = await supabase
+    .from("entities")
+    .update(update)
+    .eq("id", entityId)
+
+  if (updateError) {
+    redirectWithParams(editPath, {
+      error: "Entity save failed.",
+    })
+  }
+
+  revalidatePath("/")
+  revalidatePath("/performances")
+  revalidatePath("/performances/updates")
+  revalidatePath("/videos")
+  revalidatePath("/photos")
+  revalidatePath("/history")
+  revalidatePath("/ponix")
+  revalidatePath("/ponix/entities")
+  revalidatePath(`/ponix/entities/${entityId}`)
+  revalidatePath("/ponix/relations")
+
+  redirect(`/ponix/entities/${entityId}`)
+}

--- a/app/ponix/sections/[id]/edit/page.tsx
+++ b/app/ponix/sections/[id]/edit/page.tsx
@@ -3,7 +3,10 @@ import { notFound } from "next/navigation"
 
 import { CmsSectionEditorPage } from "@/app/ponix/_components/cms-section-form"
 import { requireCmsAdmin } from "@/lib/cms/auth"
-import { loadCmsSectionDetail } from "@/lib/cms/content"
+import {
+  loadCmsSectionDetail,
+  loadCmsSectionRelations,
+} from "@/lib/cms/content"
 
 export const metadata: Metadata = {
   title: "Edit PONIX Section | 브레멘 Bremen",
@@ -30,13 +33,20 @@ export default async function PonixSectionEditPage({
   const query = (await searchParams) ?? {}
 
   await requireCmsAdmin(`/ponix/sections/${id}/edit`)
-  const detail = await loadCmsSectionDetail(id)
+  const [detail, relations] = await Promise.all([
+    loadCmsSectionDetail(id),
+    loadCmsSectionRelations(id),
+  ])
 
   if (!detail || detail.kind !== "section") {
     notFound()
   }
 
   return (
-    <CmsSectionEditorPage detail={detail} error={firstParam(query.error)} />
+    <CmsSectionEditorPage
+      detail={detail}
+      relations={relations}
+      error={firstParam(query.error)}
+    />
   )
 }

--- a/components/profile-image-input.tsx
+++ b/components/profile-image-input.tsx
@@ -27,7 +27,10 @@ export function ProfileImageInput({
   }
 
   function clearFile() {
-    if (inputRef.current) inputRef.current.value = ""
+    if (inputRef.current) {
+      inputRef.current.value = ""
+      inputRef.current.dispatchEvent(new Event("change", { bubbles: true }))
+    }
     setFileName("")
   }
 

--- a/lib/cms/content.ts
+++ b/lib/cms/content.ts
@@ -32,7 +32,7 @@ const SECTION_ENTITY_RELATION_SELECT = `
   props,
   updated_at,
   section:sections!section_entities_section_id_fkey(id, key, title, section_type, schema_key, published),
-  entity:entities!section_entities_entity_id_fkey(id, entity_type, slug, title, schema_key, published, sort_at)
+  entity:entities!section_entities_entity_id_fkey(id, entity_type, slug, title, subtitle, thumbnail_url, schema_key, published, sort_at)
 `
 
 const ENTITY_RELATION_SELECT = `
@@ -44,8 +44,8 @@ const ENTITY_RELATION_SELECT = `
   sort_order,
   props,
   updated_at,
-  fromEntity:entities!entity_relations_from_entity_id_fkey(id, entity_type, slug, title, schema_key, published, sort_at),
-  toEntity:entities!entity_relations_to_entity_id_fkey(id, entity_type, slug, title, schema_key, published, sort_at)
+  fromEntity:entities!entity_relations_from_entity_id_fkey(id, entity_type, slug, title, subtitle, thumbnail_url, schema_key, published, sort_at),
+  toEntity:entities!entity_relations_to_entity_id_fkey(id, entity_type, slug, title, subtitle, thumbnail_url, schema_key, published, sort_at)
 `
 
 type SchemaSummary = {
@@ -117,6 +117,8 @@ export type CmsLinkedEntity = SchemaSummary & {
   entityType: string
   slug: string | null
   title: string
+  subtitle: string | null
+  thumbnailUrl: string | null
   published: boolean
   sortAt: string
 }
@@ -271,6 +273,8 @@ function linkedEntity(entity: RawEntityLink | null): CmsLinkedEntity | null {
     entityType: entity.entity_type,
     slug: entity.slug,
     title: entity.title,
+    subtitle: entity.subtitle,
+    thumbnailUrl: entity.thumbnail_url,
     published: entity.published,
     sortAt: entity.sort_at,
   }
@@ -287,6 +291,8 @@ type RawEntityLink = Pick<
   | "entity_type"
   | "slug"
   | "title"
+  | "subtitle"
+  | "thumbnail_url"
   | "schema_key"
   | "published"
   | "sort_at"

--- a/lib/cms/entity-editor.ts
+++ b/lib/cms/entity-editor.ts
@@ -1,0 +1,80 @@
+import type {
+  CmsFieldDefinition,
+  CmsSchemaDefinition,
+} from "@/lib/cms/schema-registry"
+import { getCmsSchema } from "@/lib/cms/schema-registry"
+import type { Database, Json } from "@/lib/supabase/types"
+
+type EntityRow = Database["public"]["Tables"]["entities"]["Row"]
+
+const editableEntityColumns = new Set([
+  "slug",
+  "title",
+  "subtitle",
+  "summary",
+  "thumbnail_url",
+  "sort_at",
+  "published",
+])
+
+export type CmsEditableEntityField = CmsFieldDefinition & {
+  source: "column" | "data"
+}
+
+export type CmsJsonObject = Record<string, Json>
+
+export function cmsEntityFieldInputName(field: CmsFieldDefinition) {
+  return `cms:${field.source}:${field.key}`
+}
+
+export function getEntityEditorSchema(
+  schemaKey: string,
+): CmsSchemaDefinition | null {
+  const schema = getCmsSchema(schemaKey)
+
+  if (!schema || schema.kind !== "entity" || schema.table !== "entities") {
+    return null
+  }
+
+  return schema
+}
+
+export function getEditableEntityFields(schemaKey: string) {
+  const schema = getEntityEditorSchema(schemaKey)
+
+  if (!schema) {
+    return []
+  }
+
+  return schema.fields.filter((field): field is CmsEditableEntityField => {
+    if (field.readOnly) {
+      return false
+    }
+
+    if (field.source === "data") {
+      return true
+    }
+
+    return field.source === "column" && editableEntityColumns.has(field.key)
+  })
+}
+
+export function jsonObject(value: Json): CmsJsonObject {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {}
+  }
+
+  return { ...(value as CmsJsonObject) }
+}
+
+export function getEntityFieldValue(
+  entity: EntityRow,
+  field: CmsEditableEntityField,
+) {
+  if (field.source === "data") {
+    return jsonObject(entity.data)[field.key]
+  }
+
+  const row = entity as unknown as Record<string, unknown>
+  return row[field.key]
+}


### PR DESCRIPTION
Closes #10

Summary
- Adds `/ponix/entities/[id]/edit` for guarded entity editing.
- Generates editable fields from the CMS schema registry.
- Updates only allowed entity columns and registered `entities.data` keys.
- Adds thumbnail upload through existing Supabase Storage buckets, writing the resulting public URL to `thumbnail_url`.
- Keeps `entity_type`, `schema_key`, ownership, timestamps, and relations locked.

Checks
- git diff --check
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm run build

Supabase impact
- Content rows only when an admin submits the edit form.
- Storage objects only when an admin uploads a thumbnail.
- No migration, RLS, storage policy, or service-role changes.
