### PR TITLE
[CMS] Reuse public renderers in section previews

### DIFF
--- a/app/ponix/_components/cms-live-preview.tsx
+++ b/app/ponix/_components/cms-live-preview.tsx
@@ -53,6 +53,7 @@ import type {
 import { type EventKey, type Video } from "@/lib/data/videos"
 import type {
   CmsContentDetail,
+  CmsEntityRelation,
   CmsSectionEntityRelation,
 } from "@/lib/cms/content"
 import type { CmsFieldDefinition } from "@/lib/cms/schema-registry"
@@ -60,6 +61,7 @@ import type { Json } from "@/lib/supabase/types"
 
 type CmsEntityDetail = Extract<CmsContentDetail, { kind: "entity" }>
 type CmsSectionDetail = Extract<CmsContentDetail, { kind: "section" }>
+type PreviewLinkedEntity = NonNullable<CmsSectionEntityRelation["entity"]>
 
 type PreviewValue = {
   key: string
@@ -175,11 +177,13 @@ export function CmsSectionLivePreview({
   detail,
   fields,
   sectionEntities,
+  entityRelations,
 }: {
   formId: string
   detail: CmsSectionDetail
   fields: CmsFieldDefinition[]
   sectionEntities: CmsSectionEntityRelation[]
+  entityRelations: CmsEntityRelation[]
 }) {
   const initialSnapshot = useMemo(
     () => sectionSnapshotFromDetail(detail, fields),
@@ -219,6 +223,7 @@ export function CmsSectionLivePreview({
         detail={detail}
         snapshot={deferredSnapshot}
         sectionEntities={sectionEntities}
+        entityRelations={entityRelations}
         fallback={
           <SectionPreviewCard
             sectionKey={detail.row.key}
@@ -262,11 +267,13 @@ function PublicSectionPreview({
   detail,
   snapshot,
   sectionEntities,
+  entityRelations,
   fallback,
 }: {
   detail: CmsSectionDetail
   snapshot: SectionPreviewSnapshot
   sectionEntities: CmsSectionEntityRelation[]
+  entityRelations: CmsEntityRelation[]
   fallback: ReactNode
 }) {
   const section = contentSectionFromPreview(detail, snapshot)
@@ -274,25 +281,33 @@ function PublicSectionPreview({
     .map((relation) => videoFromRelation(relation))
     .filter((item): item is Video => Boolean(item))
   const playlists = sectionEntities
-    .map((relation) => performancePlaylistFromRelation(relation))
+    .map((relation) => performancePlaylistFromRelation(relation, entityRelations))
     .filter((item): item is PerformancePlaylistItem => Boolean(item))
-  const photos = sectionEntities
+  const directPhotos = sectionEntities
     .map((relation) => photoFromRelation(relation))
     .filter((item): item is PhotoArchiveItem => Boolean(item))
+  const photos = uniqueById([
+    ...directPhotos,
+    ...playlists.flatMap((playlist) => playlist.photos),
+  ])
   const milestones = sectionEntities
     .map((relation) => historyMilestoneFromRelation(relation))
     .filter((item): item is HistoryMilestoneItem => Boolean(item))
     .sort((left, right) => left.order - right.order)
-  const updates = sectionEntities
+  const directUpdates = sectionEntities
     .map((relation) => performanceUpdateFromRelation(relation))
     .filter((item): item is PerformanceUpdateItem => Boolean(item))
+  const updates = uniqueById([
+    ...directUpdates,
+    ...playlists.flatMap((playlist) => playlist.updates),
+  ])
     .sort((left, right) => right.isoDate.localeCompare(left.isoDate))
 
   if (detail.row.key.startsWith("home-")) {
     return (
       <PublicPreviewCanvas>
         <HomeSection
-          overview={homeOverviewFromRelations(section, sectionEntities)}
+          overview={homeOverviewFromRelations(section, sectionEntities, entityRelations)}
         />
       </PublicPreviewCanvas>
     )
@@ -898,6 +913,7 @@ function contentSectionFromPreview(
 function homeOverviewFromRelations(
   section: ContentSectionConfig,
   relations: CmsSectionEntityRelation[],
+  entityRelations: CmsEntityRelation[],
 ): HomeOverview {
   const videos = relations
     .map((relation) => homeVideoFromRelation(relation))
@@ -909,7 +925,7 @@ function homeOverviewFromRelations(
     .map((relation) => homeActivityFromRelation(relation))
     .filter((item): item is HomeOverview["activities"][number] => Boolean(item))
   const upcomingEvents = relations
-    .map((relation) => performancePlaylistFromRelation(relation))
+    .map((relation) => performancePlaylistFromRelation(relation, entityRelations))
     .filter((item): item is PerformancePlaylistItem => Boolean(item))
     .slice(0, 2)
     .map((performance) => ({
@@ -970,7 +986,12 @@ function linkedEntity(relation: CmsSectionEntityRelation) {
 }
 
 function relationData(relation: CmsSectionEntityRelation) {
-  return jsonObject(relation.entity?.data ?? null)
+  const entity = linkedEntity(relation)
+  return entity ? entityData(entity) : {}
+}
+
+function entityData(entity: PreviewLinkedEntity) {
+  return jsonObject(entity.data)
 }
 
 function relationProps(relation: CmsSectionEntityRelation) {
@@ -1055,9 +1076,13 @@ function homeActivityFromRelation(
 
 function videoFromRelation(relation: CmsSectionEntityRelation): Video | null {
   const entity = linkedEntity(relation)
-  if (!entity || entity.entityType !== "video") return null
+  return entity ? videoFromEntity(entity) : null
+}
 
-  const data = relationData(relation)
+function videoFromEntity(entity: PreviewLinkedEntity): Video | null {
+  if (entity.entityType !== "video") return null
+
+  const data = entityData(entity)
   const youtubeId = stringOrNull(data.youtube_id)
   if (!youtubeId) return null
 
@@ -1082,18 +1107,35 @@ function videoFromRelation(relation: CmsSectionEntityRelation): Video | null {
 
 function performancePlaylistFromRelation(
   relation: CmsSectionEntityRelation,
+  entityRelations: CmsEntityRelation[],
 ): PerformancePlaylistItem | null {
   const entity = linkedEntity(relation)
   if (!entity || entity.entityType !== "performance") return null
 
-  const data = relationData(relation)
+  const data = entityData(entity)
   const isoDate = stringOrNull(data.event_date) ?? entity.sortAt.slice(0, 10)
   const year = isoDate.slice(0, 4)
   if (!year) return null
 
-  const recordingCount = numberOrNull(data.recording_count) ?? 1
-  const photoCount = numberOrNull(data.photo_count) ?? 0
-  const postCount = numberOrNull(data.post_count) ?? 0
+  const related = entityRelations.filter((item) => item.fromEntityId === entity.id)
+  const videos = related
+    .map((item) => item.toEntity)
+    .filter((item): item is PreviewLinkedEntity => Boolean(item))
+    .map((item) => videoFromEntity(item))
+    .filter((item): item is Video => Boolean(item))
+  const photos = related
+    .map((item) => item.toEntity)
+    .filter((item): item is PreviewLinkedEntity => Boolean(item))
+    .map((item) => photoFromEntity(item))
+    .filter((item): item is PhotoArchiveItem => Boolean(item))
+  const updates = related
+    .map((item) => item.toEntity)
+    .filter((item): item is PreviewLinkedEntity => Boolean(item))
+    .map((item) => performanceUpdateFromEntity(item))
+    .filter((item): item is PerformanceUpdateItem => Boolean(item))
+  const recordingCount = videos.length || numberOrNull(data.recording_count) || 0
+  const photoCount = photos.length || numberOrNull(data.photo_count) || 0
+  const postCount = updates.length || numberOrNull(data.post_count) || 0
 
   return {
     id: entity.id,
@@ -1109,10 +1151,15 @@ function performancePlaylistFromRelation(
     recordingCount,
     photoCount,
     postCount,
-    coverUrl: entity.thumbnailUrl,
-    videos: [],
-    photos: [],
-    updates: [],
+    coverUrl:
+      entity.thumbnailUrl ??
+      videos[0]?.thumbnailUrl ??
+      photos[0]?.thumbnailUrl ??
+      updates[0]?.thumbnailUrl ??
+      null,
+    videos,
+    photos,
+    updates,
   }
 }
 
@@ -1120,9 +1167,15 @@ function performanceUpdateFromRelation(
   relation: CmsSectionEntityRelation,
 ): PerformanceUpdateItem | null {
   const entity = linkedEntity(relation)
-  if (!entity || entity.entityType !== "post") return null
+  return entity ? performanceUpdateFromEntity(entity) : null
+}
 
-  const data = relationData(relation)
+function performanceUpdateFromEntity(
+  entity: PreviewLinkedEntity,
+): PerformanceUpdateItem | null {
+  if (entity.entityType !== "post") return null
+
+  const data = entityData(entity)
   const isoDate = stringOrNull(data.taken_at) ?? entity.sortAt.slice(0, 10)
 
   return {
@@ -1140,9 +1193,13 @@ function performanceUpdateFromRelation(
 
 function photoFromRelation(relation: CmsSectionEntityRelation): PhotoArchiveItem | null {
   const entity = linkedEntity(relation)
-  if (!entity || entity.entityType !== "photo") return null
+  return entity ? photoFromEntity(entity) : null
+}
 
-  const data = relationData(relation)
+function photoFromEntity(entity: PreviewLinkedEntity): PhotoArchiveItem | null {
+  if (entity.entityType !== "photo") return null
+
+  const data = entityData(entity)
   if (booleanOrNull(data.gallery_include) === false) return null
 
   return {
@@ -1259,6 +1316,10 @@ function photoCategoryLabel(category: string | null): "공연" | "일상" {
     category === "performance"
     ? "공연"
     : "일상"
+}
+
+function uniqueById<T extends { id: string }>(items: T[]) {
+  return [...new Map(items.map((item) => [item.id, item])).values()]
 }
 
 function stringArray(value: unknown) {

--- a/app/ponix/_components/cms-live-preview.tsx
+++ b/app/ponix/_components/cms-live-preview.tsx
@@ -10,6 +10,25 @@ import {
 } from "react"
 import type { ReactNode } from "react"
 
+import { HistoryTimelineSurface } from "@/components/history-section"
+import { HomeSection } from "@/components/home-section"
+import type {
+  HomeOverview,
+  HomeSectionConfig,
+  HomeStatCard,
+  HomeVideo,
+} from "@/components/home-section"
+import {
+  EditorialSectionHead,
+  PageSection,
+} from "@/components/editorial"
+import {
+  PlaylistCarousel,
+  SeasonIndex,
+  StageMoments,
+  PerformanceUpdateCard,
+} from "@/components/performances-section"
+import { PhotoGallerySurface } from "@/components/photos-section"
 import { Badge } from "@/components/ui/badge"
 import {
   Card,
@@ -18,6 +37,20 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
+import {
+  FeaturedVideosSurface,
+  VideoLibrarySurface,
+} from "@/components/videos-section"
+import type {
+  ContentSectionConfig,
+  HistoryMilestoneItem,
+  PerformancePlaylistItem,
+  PerformanceTypeLabel,
+  PerformanceUpdateItem,
+  PerformanceUpdateKind,
+  PhotoArchiveItem,
+} from "@/lib/data/content-graph"
+import { type EventKey, type Video } from "@/lib/data/videos"
 import type {
   CmsContentDetail,
   CmsSectionEntityRelation,
@@ -182,12 +215,19 @@ export function CmsSectionLivePreview({
 
   return (
     <PreviewShell eyebrow="Live preview" title="Section surface">
-      <SectionPreviewCard
-        sectionKey={detail.row.key}
-        sectionType={detail.row.section_type}
-        schemaLabel={detail.schemaLabel}
+      <PublicSectionPreview
+        detail={detail}
         snapshot={deferredSnapshot}
         sectionEntities={sectionEntities}
+        fallback={
+          <SectionPreviewCard
+            sectionKey={detail.row.key}
+            sectionType={detail.row.section_type}
+            schemaLabel={detail.schemaLabel}
+            snapshot={deferredSnapshot}
+            sectionEntities={sectionEntities}
+          />
+        }
       />
     </PreviewShell>
   )
@@ -215,6 +255,164 @@ function PreviewShell({
         <CardContent className="bg-muted/25 p-4">{children}</CardContent>
       </Card>
     </div>
+  )
+}
+
+function PublicSectionPreview({
+  detail,
+  snapshot,
+  sectionEntities,
+  fallback,
+}: {
+  detail: CmsSectionDetail
+  snapshot: SectionPreviewSnapshot
+  sectionEntities: CmsSectionEntityRelation[]
+  fallback: ReactNode
+}) {
+  const section = contentSectionFromPreview(detail, snapshot)
+  const videos = sectionEntities
+    .map((relation) => videoFromRelation(relation))
+    .filter((item): item is Video => Boolean(item))
+  const playlists = sectionEntities
+    .map((relation) => performancePlaylistFromRelation(relation))
+    .filter((item): item is PerformancePlaylistItem => Boolean(item))
+  const photos = sectionEntities
+    .map((relation) => photoFromRelation(relation))
+    .filter((item): item is PhotoArchiveItem => Boolean(item))
+  const milestones = sectionEntities
+    .map((relation) => historyMilestoneFromRelation(relation))
+    .filter((item): item is HistoryMilestoneItem => Boolean(item))
+    .sort((left, right) => left.order - right.order)
+  const updates = sectionEntities
+    .map((relation) => performanceUpdateFromRelation(relation))
+    .filter((item): item is PerformanceUpdateItem => Boolean(item))
+    .sort((left, right) => right.isoDate.localeCompare(left.isoDate))
+
+  if (detail.row.key.startsWith("home-")) {
+    return (
+      <PublicPreviewCanvas>
+        <HomeSection
+          overview={homeOverviewFromRelations(section, sectionEntities)}
+        />
+      </PublicPreviewCanvas>
+    )
+  }
+
+  if (detail.row.key === "performances-archive" && playlists.length) {
+    return (
+      <PublicPreviewCanvas>
+        <PlaylistCarousel
+          playlists={playlists.filter((playlist) => playlist.recordingCount > 0)}
+          section={section}
+        />
+      </PublicPreviewCanvas>
+    )
+  }
+
+  if (detail.row.key === "performances-season-index" && playlists.length) {
+    return (
+      <PublicPreviewCanvas>
+        <SeasonIndex playlists={playlists} section={section} />
+      </PublicPreviewCanvas>
+    )
+  }
+
+  if (detail.row.key === "performances-stage-moments" && photos.length) {
+    return (
+      <PublicPreviewCanvas>
+        <StageMoments photos={photos} section={section} />
+      </PublicPreviewCanvas>
+    )
+  }
+
+  if (detail.row.key === "performances-updates" && updates.length) {
+    return (
+      <PublicPreviewCanvas>
+        <PerformanceUpdatesSurface section={section} updates={updates} />
+      </PublicPreviewCanvas>
+    )
+  }
+
+  if (
+    (detail.row.key === "videos-featured" || detail.row.key === "videos-popular") &&
+    videos.length
+  ) {
+    const featured = videos.find((video) => video.highlight) ?? videos[0]
+
+    return (
+      <PublicPreviewCanvas>
+        <FeaturedVideosSurface
+          featuredSection={section}
+          popularSection={section}
+          featured={featured}
+          picks={videos.filter((video) => video.id !== featured.id).slice(0, 3)}
+        />
+      </PublicPreviewCanvas>
+    )
+  }
+
+  if (detail.row.key === "videos-library" && videos.length) {
+    return (
+      <PublicPreviewCanvas>
+        <VideoLibrarySurface section={section} videos={videos} />
+      </PublicPreviewCanvas>
+    )
+  }
+
+  if (detail.row.key === "photos-gallery" && photos.length) {
+    return (
+      <PublicPreviewCanvas>
+        <PhotoGallerySurface gallerySection={section} photos={photos} />
+      </PublicPreviewCanvas>
+    )
+  }
+
+  if (detail.row.key === "history-timeline" && milestones.length) {
+    return (
+      <PublicPreviewCanvas>
+        <HistoryTimelineSurface
+          timelineSection={section}
+          milestones={milestones}
+        />
+      </PublicPreviewCanvas>
+    )
+  }
+
+  return fallback
+}
+
+function PublicPreviewCanvas({ children }: { children: ReactNode }) {
+  return (
+    <div className="overflow-hidden rounded-md border bg-background">
+      {children}
+    </div>
+  )
+}
+
+function PerformanceUpdatesSurface({
+  section,
+  updates,
+}: {
+  section: ContentSectionConfig
+  updates: PerformanceUpdateItem[]
+}) {
+  return (
+    <PageSection className="p-6 md:p-8">
+      <EditorialSectionHead
+        eyebrow={section.eyebrow ?? ""}
+        en={section.title ?? ""}
+        kr={section.subtitle ?? ""}
+      />
+      <ul className="grid gap-5 md:grid-cols-2">
+        {updates.slice(0, 4).map((update, index) => (
+          <PerformanceUpdateCard
+            key={update.id}
+            update={update}
+            index={index}
+          />
+        ))}
+      </ul>
+    </PageSection>
   )
 }
 
@@ -659,4 +857,450 @@ function formatPreviewValue(
   }
 
   return String(value)
+}
+
+function contentSectionFromPreview(
+  detail: CmsSectionDetail,
+  snapshot: SectionPreviewSnapshot,
+): ContentSectionConfig {
+  const props = jsonObject(detail.row.props)
+  const values = new Map(snapshot.values.map((item) => [item.key, item.value]))
+
+  return {
+    key: detail.row.key,
+    sectionType: detail.row.section_type,
+    eyebrow: snapshot.eyebrow || null,
+    title: snapshot.title || null,
+    subtitle: snapshot.subtitle || null,
+    body: snapshot.body || null,
+    href: snapshot.actionHref || null,
+    actionLabel: snapshot.actionLabel || null,
+    filters:
+      stringArray(values.get("props:filters")) ||
+      stringArray(props.filters) ||
+      [],
+    accentEyebrow:
+      stringOrNull(values.get("props:eyebrow_accent")) ??
+      stringOrNull(props.eyebrow_accent),
+    accentTitle:
+      stringOrNull(values.get("props:title_accent")) ??
+      stringOrNull(props.title_accent),
+    accentBody:
+      stringOrNull(values.get("props:body_accent")) ??
+      stringOrNull(props.body_accent),
+    accentCaption:
+      booleanOrNull(values.get("props:feature_caption_accent")) ??
+      booleanOrNull(props.feature_caption_accent) ??
+      false,
+  }
+}
+
+function homeOverviewFromRelations(
+  section: ContentSectionConfig,
+  relations: CmsSectionEntityRelation[],
+): HomeOverview {
+  const videos = relations
+    .map((relation) => homeVideoFromRelation(relation))
+    .filter((item): item is HomeVideo => Boolean(item))
+  const statCards = relations
+    .map((relation) => homeStatCardFromRelation(relation))
+    .filter((item): item is HomeStatCard => Boolean(item))
+  const activities = relations
+    .map((relation) => homeActivityFromRelation(relation))
+    .filter((item): item is HomeOverview["activities"][number] => Boolean(item))
+  const upcomingEvents = relations
+    .map((relation) => performancePlaylistFromRelation(relation))
+    .filter((item): item is PerformancePlaylistItem => Boolean(item))
+    .slice(0, 2)
+    .map((performance) => ({
+      date: performance.date,
+      year: performance.year,
+      title: performance.title,
+      location: performance.venue,
+      time: "TBA",
+    }))
+  const featuredVideo = videos[0] ?? placeholderHomeVideo(section)
+
+  return {
+    sections: [homeSectionConfig(section)],
+    activeYears: 0,
+    performanceCount: upcomingEvents.length,
+    videoCount: videos.length,
+    photoCount: 0,
+    memberCount: 0,
+    activeMemberCount: 0,
+    totalViews: videos.reduce((sum, video) => sum + video.views, 0),
+    statCards,
+    featuredVideo,
+    stageHighlights: videos,
+    upcomingEvents,
+    activities,
+  }
+}
+
+function homeSectionConfig(section: ContentSectionConfig): HomeSectionConfig {
+  return {
+    key: section.key,
+    sectionType: section.sectionType,
+    eyebrow: section.eyebrow ?? undefined,
+    title: section.title ?? undefined,
+    subtitle: section.subtitle ?? undefined,
+    body: section.body ?? undefined,
+    href: section.href ?? undefined,
+    actionLabel: section.actionLabel ?? undefined,
+    accentEyebrow: section.accentEyebrow ?? undefined,
+    accentTitle: section.accentTitle ?? undefined,
+    accentBody: section.accentBody ?? undefined,
+    accentCaption: section.accentCaption,
+  }
+}
+
+function placeholderHomeVideo(section: ContentSectionConfig): HomeVideo {
+  return {
+    id: "preview",
+    title: section.title ?? "Preview video",
+    duration: "",
+    views: 0,
+    caption: section.eyebrow ?? undefined,
+  }
+}
+
+function linkedEntity(relation: CmsSectionEntityRelation) {
+  return relation.entity
+}
+
+function relationData(relation: CmsSectionEntityRelation) {
+  return jsonObject(relation.entity?.data ?? null)
+}
+
+function relationProps(relation: CmsSectionEntityRelation) {
+  return jsonObject(relation.props)
+}
+
+function homeVideoFromRelation(relation: CmsSectionEntityRelation): HomeVideo | null {
+  const video = videoFromRelation(relation)
+  if (!video) return null
+
+  const props = relationProps(relation)
+
+  return {
+    id: video.id,
+    title: video.song || video.raw_title,
+    thumbnailUrl: video.thumbnailUrl,
+    watchUrl: video.watchUrl,
+    artist: video.artist,
+    song: video.song,
+    team: video.team,
+    duration: video.duration,
+    views: video.views,
+    caption: stringOrUndefined(props.caption),
+  }
+}
+
+function homeStatCardFromRelation(
+  relation: CmsSectionEntityRelation,
+): HomeStatCard | null {
+  const entity = linkedEntity(relation)
+  if (!entity || entity.entityType !== "stat") return null
+
+  const data = relationData(relation)
+  const base = {
+    label: entity.title,
+    value: displayString(data.value) ?? "0",
+    unit: stringOrNull(data.unit) ?? "",
+    detail: entity.summary ?? stringOrNull(data.detail) ?? "",
+    tilt: stringOrNull(data.tilt) ?? "0deg",
+  }
+  const type = stringOrNull(data.card_type)
+
+  if (type === "image") {
+    return {
+      ...base,
+      type: "image",
+      thumbnailUrl: entity.thumbnailUrl ?? undefined,
+    }
+  }
+
+  if (type === "color") {
+    return {
+      ...base,
+      type: "color",
+    }
+  }
+
+  return {
+    ...base,
+    type: "text",
+  }
+}
+
+function homeActivityFromRelation(
+  relation: CmsSectionEntityRelation,
+): HomeOverview["activities"][number] | null {
+  const entity = linkedEntity(relation)
+  if (!entity || entity.entityType !== "activity") return null
+
+  const data = relationData(relation)
+
+  return {
+    id: entity.id,
+    title: entity.title,
+    kr: entity.subtitle ?? stringOrNull(data.kr) ?? "",
+    description: entity.summary ?? stringOrNull(data.description) ?? "",
+    schedule: stringOrNull(data.schedule) ?? "",
+    variant: stringOrNull(data.variant) === "color" ? "color" : "text",
+    tilt: stringOrNull(data.tilt) ?? "0deg",
+  }
+}
+
+function videoFromRelation(relation: CmsSectionEntityRelation): Video | null {
+  const entity = linkedEntity(relation)
+  if (!entity || entity.entityType !== "video") return null
+
+  const data = relationData(relation)
+  const youtubeId = stringOrNull(data.youtube_id)
+  if (!youtubeId) return null
+
+  const parsed = parseVideoTitle(entity.title)
+
+  return {
+    id: youtubeId,
+    thumbnailUrl: entity.thumbnailUrl ?? undefined,
+    watchUrl: stringOrUndefined(data.youtube_url),
+    artist: stringOrUndefined(data.artist) ?? parsed.artist,
+    song: stringOrUndefined(data.song) ?? parsed.song,
+    raw_title: entity.title,
+    team: stringOrUndefined(data.team) ?? parsed.team,
+    event: (stringOrNull(data.event_slug) ?? "recording") as EventKey,
+    eventLabel: stringOrUndefined(data.event_title),
+    eventOrder: numberOrUndefined(data.source_index),
+    duration: stringOrNull(data.duration) ?? "",
+    views: numberOrNull(data.views) ?? 0,
+    highlight: booleanOrNull(data.is_highlight) ?? false,
+  }
+}
+
+function performancePlaylistFromRelation(
+  relation: CmsSectionEntityRelation,
+): PerformancePlaylistItem | null {
+  const entity = linkedEntity(relation)
+  if (!entity || entity.entityType !== "performance") return null
+
+  const data = relationData(relation)
+  const isoDate = stringOrNull(data.event_date) ?? entity.sortAt.slice(0, 10)
+  const year = isoDate.slice(0, 4)
+  if (!year) return null
+
+  const recordingCount = numberOrNull(data.recording_count) ?? 1
+  const photoCount = numberOrNull(data.photo_count) ?? 0
+  const postCount = numberOrNull(data.post_count) ?? 0
+
+  return {
+    id: entity.id,
+    slug: entity.slug ?? entity.id,
+    title: entity.title,
+    subtitle: entity.subtitle,
+    date: stringOrNull(data.display_date) ?? formatMonthDay(isoDate),
+    year,
+    isoDate,
+    venue: stringOrNull(data.venue) ?? "",
+    type: performanceTypeLabel(stringOrNull(data.type)),
+    thumbnailUrl: entity.thumbnailUrl,
+    recordingCount,
+    photoCount,
+    postCount,
+    coverUrl: entity.thumbnailUrl,
+    videos: [],
+    photos: [],
+    updates: [],
+  }
+}
+
+function performanceUpdateFromRelation(
+  relation: CmsSectionEntityRelation,
+): PerformanceUpdateItem | null {
+  const entity = linkedEntity(relation)
+  if (!entity || entity.entityType !== "post") return null
+
+  const data = relationData(relation)
+  const isoDate = stringOrNull(data.taken_at) ?? entity.sortAt.slice(0, 10)
+
+  return {
+    id: entity.id,
+    title: entity.title,
+    summary: entity.summary,
+    date: stringOrNull(data.display_date) ?? formatMonthDay(isoDate),
+    isoDate,
+    kind: performanceUpdateKind(stringOrNull(data.content_kind)),
+    eventTitle: stringOrNull(data.event_title),
+    sourceUrl: stringOrNull(data.source_url),
+    thumbnailUrl: entity.thumbnailUrl,
+  }
+}
+
+function photoFromRelation(relation: CmsSectionEntityRelation): PhotoArchiveItem | null {
+  const entity = linkedEntity(relation)
+  if (!entity || entity.entityType !== "photo") return null
+
+  const data = relationData(relation)
+  if (booleanOrNull(data.gallery_include) === false) return null
+
+  return {
+    id: entity.id,
+    title: entity.title,
+    caption: entity.summary,
+    category: photoCategoryLabel(stringOrNull(data.category)),
+    aspect: stringOrNull(data.aspect) === "portrait" ? "portrait" : "landscape",
+    thumbnailUrl: entity.thumbnailUrl,
+  }
+}
+
+function historyMilestoneFromRelation(
+  relation: CmsSectionEntityRelation,
+): HistoryMilestoneItem | null {
+  const entity = linkedEntity(relation)
+  if (!entity || entity.entityType !== "history_milestone") return null
+
+  const data = relationData(relation)
+  const year = stringOrNull(data.year) ?? entity.title.match(/\d{4}/)?.[0]
+  if (!year) return null
+
+  return {
+    id: entity.id,
+    title: entity.title,
+    summary: entity.summary,
+    year,
+    order: numberOrNull(data.display_order) ?? 0,
+  }
+}
+
+function parseVideoTitle(title: string) {
+  const segments = title.split("|").map((segment) => segment.trim()).filter(Boolean)
+  const head = segments[0] ?? title.trim()
+  const second = segments[1]
+
+  function isContextSegment(segment: string | undefined) {
+    if (!segment) return true
+    const normalized = segment.toLowerCase()
+    return (
+      normalized.includes("bremen cover") ||
+      segment.includes("브레멘 커버") ||
+      segment.includes("포스텍") ||
+      segment.includes("정기공연") ||
+      segment.includes("정기 공연") ||
+      segment.includes("신환공") ||
+      segment.includes("새터") ||
+      segment.includes("해맞이") ||
+      segment.includes("STadium")
+    )
+  }
+
+  function cleanTeam(segment: string) {
+    return segment.replace(/\s*팀$/, "").trim()
+  }
+
+  function cleanSong(segment: string) {
+    return segment.replace(/\s*\(20\d{2}.*\)$/, "").trim()
+  }
+
+  const secondSong = second ? cleanSong(second) : undefined
+
+  if (secondSong && !isContextSegment(secondSong) && head.includes("팀")) {
+    return {
+      artist: undefined,
+      song: secondSong,
+      team: cleanTeam(head),
+    }
+  }
+
+  if (second && !isContextSegment(second) && !head.includes("-")) {
+    return {
+      artist: undefined,
+      song: head,
+      team: cleanTeam(second),
+    }
+  }
+
+  const match = head.match(/^\d{4}\b/)
+    ? null
+    : head.match(/^(.+?)\s*-\s*(.+)$/)
+  const teamSegment = segments.slice(1).find((segment) => !isContextSegment(segment))
+
+  return {
+    artist: match?.[1]?.trim(),
+    song: match?.[2]?.trim(),
+    team: teamSegment ? cleanTeam(teamSegment) : undefined,
+  }
+}
+
+function formatMonthDay(isoDate: string) {
+  const [, month, day] = isoDate.split("-")
+  return month && day ? `${month}/${day}` : isoDate
+}
+
+function performanceTypeLabel(type: string | null): PerformanceTypeLabel {
+  if (type === "regular") return "정기공연"
+  if (type === "festival") return "축제"
+  if (type === "stadium") return "STadium"
+  return "특별"
+}
+
+function performanceUpdateKind(kind: string | null): PerformanceUpdateKind {
+  if (kind === "recruiting") return "recruiting"
+  if (kind === "event") return "event"
+  if (kind === "setlist") return "setlist"
+  if (kind === "promo") return "promo"
+  return "notice"
+}
+
+function photoCategoryLabel(category: string | null): "공연" | "일상" {
+  return category === "live" ||
+    category === "events" ||
+    category === "performance"
+    ? "공연"
+    : "일상"
+}
+
+function stringArray(value: unknown) {
+  if (!Array.isArray(value)) return null
+
+  return value.filter((item): item is string =>
+    typeof item === "string" && item.trim().length > 0,
+  )
+}
+
+function stringOrNull(value: unknown) {
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : null
+}
+
+function stringOrUndefined(value: unknown) {
+  return stringOrNull(value) ?? undefined
+}
+
+function displayString(value: unknown) {
+  if (typeof value === "string" && value.trim().length > 0) return value
+  if (typeof value === "number" || typeof value === "boolean") return String(value)
+  return null
+}
+
+function numberOrNull(value: unknown) {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null
+  if (typeof value === "string") {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+
+  return null
+}
+
+function numberOrUndefined(value: unknown) {
+  return numberOrNull(value) ?? undefined
+}
+
+function booleanOrNull(value: unknown) {
+  if (typeof value === "boolean") return value
+  if (typeof value === "string") return value === "true"
+  return null
 }

--- a/app/ponix/_components/cms-section-form.tsx
+++ b/app/ponix/_components/cms-section-form.tsx
@@ -50,7 +50,7 @@ export function CmsSectionEditorPage({
         <div className="absolute left-[-8rem] bottom-0 h-80 w-80 rounded-full bg-muted blur-3xl" />
       </div>
 
-      <section className="mx-auto max-w-6xl px-6 py-16 md:px-8 md:py-24">
+      <section className="mx-auto max-w-[96rem] px-6 py-16 md:px-8 md:py-24">
         <div className="mb-10 flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
           <div>
             <p className="caps mb-5">PONIX / Edit section</p>
@@ -86,7 +86,7 @@ export function CmsSectionEditorPage({
           <form
             id={formId}
             action={updateCmsSectionAction}
-            className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_28rem]"
+            className="grid gap-6 xl:grid-cols-[minmax(26rem,0.8fr)_minmax(42rem,1.2fr)]"
           >
             <input type="hidden" name="section_id" value={detail.row.id} />
 

--- a/app/ponix/_components/cms-section-form.tsx
+++ b/app/ponix/_components/cms-section-form.tsx
@@ -147,6 +147,7 @@ export function CmsSectionEditorPage({
               detail={detail}
               fields={editableFields}
               sectionEntities={relations.sectionEntities}
+              entityRelations={relations.entityRelations}
             />
           </form>
         )}

--- a/components/history-section.tsx
+++ b/components/history-section.tsx
@@ -13,6 +13,54 @@ type HistorySectionProps = {
   milestones: HistoryMilestoneItem[]
 }
 
+export function HistoryTimelineSurface({
+  timelineSection,
+  milestones,
+}: {
+  timelineSection?: ContentSectionConfig
+  milestones: HistoryMilestoneItem[]
+}) {
+  return (
+    <PageSection>
+      <Reveal offset={24} blur={10}>
+        <EditorialSectionHead
+          eyebrow={timelineSection?.eyebrow ?? ""}
+          en={timelineSection?.title ?? ""}
+          kr={timelineSection?.subtitle ?? ""}
+        />
+      </Reveal>
+
+      <ol className="border-t">
+        {milestones.map((item, index) => (
+          <Reveal
+            key={item.id}
+            as="li"
+            delay={index * 55}
+            className="grid grid-cols-12 gap-6 border-b py-8 md:gap-10 md:py-10"
+          >
+            <div className="col-span-12 md:col-span-3">
+              <p className="caps">Year</p>
+              <p className="mt-2 font-serif italic text-5xl leading-none tracking-tight tabular-nums md:text-6xl">
+                {item.year}
+              </p>
+            </div>
+            <div className="col-span-12 md:col-span-8">
+              <h3 className="font-serif-kr text-2xl leading-tight md:text-3xl">
+                {item.title}
+              </h3>
+              {item.summary && (
+                <p className="mt-4 max-w-3xl text-sm leading-relaxed text-muted-foreground md:text-base">
+                  {item.summary}
+                </p>
+              )}
+            </div>
+          </Reveal>
+        ))}
+      </ol>
+    </PageSection>
+  )
+}
+
 export function HistorySection({
   page,
   sections,
@@ -43,43 +91,10 @@ export function HistorySection({
         }
       />
 
-      <PageSection>
-        <Reveal offset={24} blur={10}>
-          <EditorialSectionHead
-            eyebrow={timelineSection?.eyebrow ?? ""}
-            en={timelineSection?.title ?? ""}
-            kr={timelineSection?.subtitle ?? ""}
-          />
-        </Reveal>
-
-        <ol className="border-t">
-          {items.map((item, index) => (
-            <Reveal
-              key={item.id}
-              as="li"
-              delay={index * 55}
-              className="grid grid-cols-12 gap-6 border-b py-8 md:gap-10 md:py-10"
-            >
-              <div className="col-span-12 md:col-span-3">
-                <p className="caps">Year</p>
-                <p className="mt-2 font-serif italic text-5xl leading-none tracking-tight tabular-nums md:text-6xl">
-                  {item.year}
-                </p>
-              </div>
-              <div className="col-span-12 md:col-span-8">
-                <h3 className="font-serif-kr text-2xl leading-tight md:text-3xl">
-                  {item.title}
-                </h3>
-                {item.summary && (
-                  <p className="mt-4 max-w-3xl text-sm leading-relaxed text-muted-foreground md:text-base">
-                    {item.summary}
-                  </p>
-                )}
-              </div>
-            </Reveal>
-          ))}
-        </ol>
-      </PageSection>
+      <HistoryTimelineSurface
+        timelineSection={timelineSection}
+        milestones={items}
+      />
     </div>
   )
 }

--- a/components/performances-section.tsx
+++ b/components/performances-section.tsx
@@ -135,7 +135,7 @@ function PlaylistCard({
   )
 }
 
-function PlaylistCarousel({
+export function PlaylistCarousel({
   playlists,
   section,
 }: {
@@ -180,7 +180,7 @@ function PlaylistCarousel({
   )
 }
 
-function SeasonIndex({
+export function SeasonIndex({
   playlists,
   section,
 }: {
@@ -259,7 +259,7 @@ function SeasonIndex({
   )
 }
 
-function StageMoments({
+export function StageMoments({
   photos,
   section,
 }: {

--- a/components/photos-section.tsx
+++ b/components/photos-section.tsx
@@ -50,15 +50,16 @@ function pinHeight(photo: Photo, index: number) {
   return "min-h-[16rem] md:min-h-[18rem]"
 }
 
-export function PhotosSection({
-  page,
-  sections,
+export function PhotoGallerySurface({
+  gallerySection,
   photos,
-}: PhotosSectionProps) {
+}: {
+  gallerySection?: ContentSectionConfig
+  photos: Photo[]
+}) {
   const [selectedCategory, setSelectedCategory] = useState("전체")
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null)
   const sourcePhotos = photos
-  const gallerySection = sections.find((section) => section.key === "photos-gallery")
   const derivedCategories = Array.from(
     new Set(sourcePhotos.map((photo) => photo.category)),
   )
@@ -124,14 +125,7 @@ export function PhotosSection({
   )
 
   return (
-    <div className="mx-auto max-w-6xl px-6 py-16 md:px-8 md:py-24">
-      <PageHero
-        eyebrow={gallerySection?.eyebrow ?? ""}
-        titleEn={page.subtitle ?? ""}
-        titleKr={page.title}
-        description={page.description}
-      />
-
+    <>
       <PageSection className="mb-0">
         <Reveal offset={24} blur={10}>
           <EditorialSectionHead
@@ -267,6 +261,27 @@ export function PhotosSection({
           )}
         </DialogContent>
       </Dialog>
+    </>
+  )
+}
+
+export function PhotosSection({
+  page,
+  sections,
+  photos,
+}: PhotosSectionProps) {
+  const gallerySection = sections.find((section) => section.key === "photos-gallery")
+
+  return (
+    <div className="mx-auto max-w-6xl px-6 py-16 md:px-8 md:py-24">
+      <PageHero
+        eyebrow={gallerySection?.eyebrow ?? ""}
+        titleEn={page.subtitle ?? ""}
+        titleKr={page.title}
+        description={page.description}
+      />
+
+      <PhotoGallerySurface gallerySection={gallerySection} photos={photos} />
     </div>
   )
 }

--- a/components/videos-section.tsx
+++ b/components/videos-section.tsx
@@ -474,18 +474,60 @@ type VideosSectionProps = {
   initialEvent?: string
 }
 
-export function VideosSection({
-  page: pageConfig,
-  sections,
+export function FeaturedVideosSurface({
+  featuredSection,
+  popularSection,
+  featured,
+  picks,
+}: {
+  featuredSection?: ContentSectionConfig
+  popularSection?: ContentSectionConfig
+  featured: Video
+  picks: Video[]
+}) {
+  return (
+    <PageSection>
+      <Reveal offset={24} blur={10}>
+        <EditorialSectionHead
+          eyebrow={featuredSection?.eyebrow ?? ""}
+          en={featuredSection?.title ?? ""}
+          kr={featuredSection?.subtitle ?? ""}
+        />
+      </Reveal>
+
+      <div className="grid grid-cols-12 gap-5">
+        <div className="col-span-12 lg:col-span-7">
+          <FeaturedVideoCard video={featured} />
+        </div>
+        <div className="col-span-12 lg:col-span-5">
+          <Reveal offset={18} blur={8}>
+            <div className="mb-4 flex items-center justify-between">
+              <p className="caps">
+                {popularSection?.title}
+              </p>
+            </div>
+          </Reveal>
+          <div className="border-t">
+            {picks.map((video, index) => (
+              <PickRow key={`${video.id}-${index}`} video={video} index={index} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </PageSection>
+  )
+}
+
+export function VideoLibrarySurface({
+  section,
   videos,
-  featuredVideos,
-  popularVideos,
   initialEvent,
-}: VideosSectionProps) {
+}: {
+  section?: ContentSectionConfig
+  videos: Video[]
+  initialEvent?: string
+}) {
   const sourceVideos = videos
-  const featuredSection = sections.find((section) => section.key === "videos-featured")
-  const popularSection = sections.find((section) => section.key === "videos-popular")
-  const librarySection = sections.find((section) => section.key === "videos-library")
   const initialEventFilter =
     initialEvent && sourceVideos.some((video) => video.event === initialEvent)
       ? initialEvent
@@ -495,20 +537,9 @@ export function VideosSection({
   const [sortBy, setSortBy] = useState<SortOption>("recent")
   const [page, setPage] = useState(1)
   const deferredQuery = useDeferredValue(query)
-  const featured =
-    featuredVideos.find((video) => video.highlight) ??
-    featuredVideos[0]
-  if (!featured) return null
-
-  const library = featured
-    ? [...sourceVideos].filter((video) => video.id !== featured.id)
-    : [...sourceVideos]
-  const picks = popularVideos
-    .filter((video) => video.id !== featured.id)
-    .slice(0, 3)
 
   const eventOptions = Array.from(
-    library
+    sourceVideos
       .reduce((events, video) => {
         const existing = events.get(video.event)
 
@@ -525,7 +556,7 @@ export function VideosSection({
   ).sort((left, right) => left.order - right.order)
 
   const searchText = normalizeSearch(deferredQuery)
-  const filteredLibrary = library.filter((video) => {
+  const filteredLibrary = sourceVideos.filter((video) => {
     const matchesEvent =
       eventFilter === ALL_EVENTS || video.event === eventFilter
     const matchesSearch =
@@ -548,6 +579,136 @@ export function VideosSection({
   }
 
   return (
+    <PageSection className="mb-0" id="recordings-library">
+      <Reveal offset={24} blur={10}>
+        <EditorialSectionHead
+          eyebrow={section?.eyebrow ?? ""}
+          en={section?.title ?? ""}
+          kr={section?.subtitle ?? ""}
+          action={
+            <p className="caps text-right tabular-nums">
+              {orderedLibrary.length} / {sourceVideos.length}
+            </p>
+          }
+        />
+      </Reveal>
+
+      <Reveal offset={18} blur={8}>
+        <div className="mb-8 rounded-md border bg-card/80 p-4 shadow-sm md:p-5">
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-[1fr_16rem_12rem]">
+            <label className="relative">
+              <span className="sr-only">영상 검색</span>
+              <MagnifyingGlass
+                weight="light"
+                className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+              />
+              <Input
+                value={query}
+                onChange={(event) => {
+                  setQuery(event.target.value)
+                  setPage(1)
+                }}
+                placeholder="곡, 가수, 팀 검색"
+                className="h-11 bg-background/70 pl-9"
+              />
+            </label>
+
+            <EventCombobox
+              value={eventFilter}
+              options={eventOptions}
+              onChange={(nextEvent) => {
+                setEventFilter(nextEvent)
+                setPage(1)
+              }}
+            />
+
+            <Select
+              value={sortBy}
+              onValueChange={(value) => {
+                setSortBy(value as SortOption)
+                setPage(1)
+              }}
+            >
+              <SelectTrigger className="h-11 w-full bg-background/70">
+                <SelectValue placeholder="정렬" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="recent">최신 공연순</SelectItem>
+                <SelectItem value="popular">조회수순</SelectItem>
+                <SelectItem value="title">곡명순</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+            <p className="caps tabular-nums text-muted-foreground">
+              Page {currentPage} / {pageCount}
+            </p>
+            {hasActiveFilter && (
+              <Button variant="ghost" size="sm" onClick={resetFilters}>
+                Clear filters
+              </Button>
+            )}
+          </div>
+        </div>
+      </Reveal>
+
+      {pageItems.length > 0 ? (
+        <>
+          <ul className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+            {pageItems.map((video, index) => (
+              <VideoCard
+                key={`${video.id}-${currentPage}-${index}`}
+                video={video}
+                index={index}
+              />
+            ))}
+          </ul>
+          <LibraryPagination
+            currentPage={currentPage}
+            pageCount={pageCount}
+            onPageChange={setPage}
+          />
+        </>
+      ) : (
+        <Reveal>
+          <div className="rounded-md border bg-muted/30 px-6 py-12 text-center">
+            <p className="font-serif-kr text-2xl">조건에 맞는 영상이 없습니다.</p>
+            <Button variant="outline" className="mt-5" onClick={resetFilters}>
+              Clear filters
+            </Button>
+          </div>
+        </Reveal>
+      )}
+    </PageSection>
+  )
+}
+
+export function VideosSection({
+  page: pageConfig,
+  sections,
+  videos,
+  featuredVideos,
+  popularVideos,
+  initialEvent,
+}: VideosSectionProps) {
+  const sourceVideos = videos
+  const featuredSection = sections.find((section) => section.key === "videos-featured")
+  const popularSection = sections.find((section) => section.key === "videos-popular")
+  const librarySection = sections.find((section) => section.key === "videos-library")
+  const featured =
+    featuredVideos.find((video) => video.highlight) ??
+    featuredVideos[0]
+  if (!featured) return null
+
+  const library = featured
+    ? [...sourceVideos].filter((video) => video.id !== featured.id)
+    : [...sourceVideos]
+  const picks = popularVideos
+    .filter((video) => video.id !== featured.id)
+    .slice(0, 3)
+
+  return (
     <div className="mx-auto max-w-6xl px-6 py-16 md:px-8 md:py-24">
       <PageHero
         eyebrow="Recorded live"
@@ -567,138 +728,18 @@ export function VideosSection({
         }
       />
 
-      <PageSection>
-        <Reveal offset={24} blur={10}>
-          <EditorialSectionHead
-            eyebrow={featuredSection?.eyebrow ?? ""}
-            en={featuredSection?.title ?? ""}
-            kr={featuredSection?.subtitle ?? ""}
-          />
-        </Reveal>
+      <FeaturedVideosSurface
+        featuredSection={featuredSection}
+        popularSection={popularSection}
+        featured={featured}
+        picks={picks}
+      />
 
-        <div className="grid grid-cols-12 gap-5">
-          <div className="col-span-12 lg:col-span-7">
-            <FeaturedVideoCard video={featured} />
-          </div>
-          <div className="col-span-12 lg:col-span-5">
-            <Reveal offset={18} blur={8}>
-              <div className="mb-4 flex items-center justify-between">
-                <p className="caps">
-                  {popularSection?.title}
-                </p>
-              </div>
-            </Reveal>
-            <div className="border-t">
-              {picks.map((video, index) => (
-                <PickRow key={`${video.id}-${index}`} video={video} index={index} />
-              ))}
-            </div>
-          </div>
-        </div>
-      </PageSection>
-
-      <PageSection className="mb-0" id="recordings-library">
-        <Reveal offset={24} blur={10}>
-          <EditorialSectionHead
-            eyebrow={librarySection?.eyebrow ?? ""}
-            en={librarySection?.title ?? ""}
-            kr={librarySection?.subtitle ?? ""}
-            action={
-              <p className="caps text-right tabular-nums">
-                {orderedLibrary.length} / {library.length}
-              </p>
-            }
-          />
-        </Reveal>
-
-        <Reveal offset={18} blur={8}>
-          <div className="mb-8 rounded-md border bg-card/80 p-4 shadow-sm md:p-5">
-            <div className="grid grid-cols-1 gap-3 md:grid-cols-[1fr_16rem_12rem]">
-              <label className="relative">
-                <span className="sr-only">영상 검색</span>
-                <MagnifyingGlass
-                  weight="light"
-                  className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
-                />
-                <Input
-                  value={query}
-                  onChange={(event) => {
-                    setQuery(event.target.value)
-                    setPage(1)
-                  }}
-                  placeholder="곡, 가수, 팀 검색"
-                  className="h-11 bg-background/70 pl-9"
-                />
-              </label>
-
-              <EventCombobox
-                value={eventFilter}
-                options={eventOptions}
-                onChange={(nextEvent) => {
-                  setEventFilter(nextEvent)
-                  setPage(1)
-                }}
-              />
-
-              <Select
-                value={sortBy}
-                onValueChange={(value) => {
-                  setSortBy(value as SortOption)
-                  setPage(1)
-                }}
-              >
-                <SelectTrigger className="h-11 w-full bg-background/70">
-                  <SelectValue placeholder="정렬" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="recent">최신 공연순</SelectItem>
-                  <SelectItem value="popular">조회수순</SelectItem>
-                  <SelectItem value="title">곡명순</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
-              <p className="caps tabular-nums text-muted-foreground">
-                Page {currentPage} / {pageCount}
-              </p>
-              {hasActiveFilter && (
-                <Button variant="ghost" size="sm" onClick={resetFilters}>
-                  Clear filters
-                </Button>
-              )}
-            </div>
-          </div>
-        </Reveal>
-
-        {pageItems.length > 0 ? (
-          <>
-            <ul className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
-              {pageItems.map((video, index) => (
-                <VideoCard
-                  key={`${video.id}-${currentPage}-${index}`}
-                  video={video}
-                  index={index}
-                />
-              ))}
-            </ul>
-            <LibraryPagination
-              currentPage={currentPage}
-              pageCount={pageCount}
-              onPageChange={setPage}
-            />
-          </>
-        ) : (
-          <Reveal>
-            <div className="rounded-md border bg-muted/30 px-6 py-12 text-center">
-              <p className="font-serif-kr text-2xl">조건에 맞는 영상이 없습니다.</p>
-              <Button variant="outline" className="mt-5" onClick={resetFilters}>
-                Clear filters
-              </Button>
-            </div>
-          </Reveal>
-        )}
-      </PageSection>
+      <VideoLibrarySurface
+        section={librarySection}
+        videos={library}
+        initialEvent={initialEvent}
+      />
     </div>
   )
 }

--- a/lib/cms/content.ts
+++ b/lib/cms/content.ts
@@ -175,6 +175,7 @@ export type CmsPageRelationContext = {
 export type CmsSectionRelationContext = {
   pageSections: CmsPageSectionRelation[]
   sectionEntities: CmsSectionEntityRelation[]
+  entityRelations: CmsEntityRelation[]
 }
 
 export type CmsEntityRelationContext = {
@@ -717,6 +718,39 @@ async function loadEntityRelations({
   return relationList(relations, count, limit)
 }
 
+async function loadEntityRelationsForFromEntities({
+  supabase,
+  fromEntityIds,
+  limit = RELATION_LIST_LIMIT,
+}: {
+  supabase: SupabaseClient
+  fromEntityIds: string[]
+  limit?: number
+}): Promise<CmsRelationList<CmsEntityRelation>> {
+  if (!fromEntityIds.length) {
+    return relationList([], 0, limit)
+  }
+
+  const { data, error, count } = await supabase
+    .from("entity_relations")
+    .select(ENTITY_RELATION_SELECT, { count: "exact" })
+    .in("from_entity_id", fromEntityIds)
+    .order("from_entity_id", { ascending: true })
+    .order("slot", { ascending: true })
+    .order("sort_order", { ascending: true })
+    .range(0, limit - 1)
+
+  if (error) {
+    throw new Error(`Failed to load entity relations: ${error.message}`)
+  }
+
+  const relations = ((data ?? []) as unknown as RawEntityRelation[])
+    .map(mapEntityRelation)
+    .sort(byEntityRelationOrder)
+
+  return relationList(relations, count, limit)
+}
+
 export async function loadCmsRelationGraph(): Promise<CmsRelationGraph> {
   const supabase = await createClient()
   const [pageSections, sectionEntities, entityRelations] = await Promise.all([
@@ -751,10 +785,15 @@ export async function loadCmsSectionRelations(
     loadPageSectionRelations({ supabase, sectionId }),
     loadSectionEntityRelations({ supabase, sectionId }),
   ])
+  const entityRelations = await loadEntityRelationsForFromEntities({
+    supabase,
+    fromEntityIds: sectionEntities.relations.map((relation) => relation.entityId),
+  })
 
   return {
     pageSections: pageSections.relations,
     sectionEntities: sectionEntities.relations,
+    entityRelations: entityRelations.relations,
   }
 }
 

--- a/lib/cms/content.ts
+++ b/lib/cms/content.ts
@@ -32,7 +32,7 @@ const SECTION_ENTITY_RELATION_SELECT = `
   props,
   updated_at,
   section:sections!section_entities_section_id_fkey(id, key, title, section_type, schema_key, published),
-  entity:entities!section_entities_entity_id_fkey(id, entity_type, slug, title, subtitle, thumbnail_url, schema_key, published, sort_at)
+  entity:entities!section_entities_entity_id_fkey(id, entity_type, slug, title, subtitle, summary, thumbnail_url, schema_key, data, published, sort_at)
 `
 
 const ENTITY_RELATION_SELECT = `
@@ -44,8 +44,8 @@ const ENTITY_RELATION_SELECT = `
   sort_order,
   props,
   updated_at,
-  fromEntity:entities!entity_relations_from_entity_id_fkey(id, entity_type, slug, title, subtitle, thumbnail_url, schema_key, published, sort_at),
-  toEntity:entities!entity_relations_to_entity_id_fkey(id, entity_type, slug, title, subtitle, thumbnail_url, schema_key, published, sort_at)
+  fromEntity:entities!entity_relations_from_entity_id_fkey(id, entity_type, slug, title, subtitle, summary, thumbnail_url, schema_key, data, published, sort_at),
+  toEntity:entities!entity_relations_to_entity_id_fkey(id, entity_type, slug, title, subtitle, summary, thumbnail_url, schema_key, data, published, sort_at)
 `
 
 type SchemaSummary = {
@@ -118,7 +118,9 @@ export type CmsLinkedEntity = SchemaSummary & {
   slug: string | null
   title: string
   subtitle: string | null
+  summary: string | null
   thumbnailUrl: string | null
+  data: Json
   published: boolean
   sortAt: string
 }
@@ -274,7 +276,9 @@ function linkedEntity(entity: RawEntityLink | null): CmsLinkedEntity | null {
     slug: entity.slug,
     title: entity.title,
     subtitle: entity.subtitle,
+    summary: entity.summary,
     thumbnailUrl: entity.thumbnail_url,
+    data: entity.data,
     published: entity.published,
     sortAt: entity.sort_at,
   }
@@ -292,8 +296,10 @@ type RawEntityLink = Pick<
   | "slug"
   | "title"
   | "subtitle"
+  | "summary"
   | "thumbnail_url"
   | "schema_key"
+  | "data"
   | "published"
   | "sort_at"
 >


### PR DESCRIPTION
Closes #14

Summary
- Reuses exported public section renderer surfaces in `/ponix/sections/[id]/edit` previews for supported sections.
- Keeps the generic CMS preview as a fallback for unsupported or empty sections.
- Extends CMS relation projections with linked entity `summary` and `data` so previews can build the same public view models.
- Widens the section editor preview column so public layouts render closer to site breakpoints.

Supported preview surfaces
- Home sections through `HomeSection` with a single-section overview.
- Performance archive, season index, stage moments, and updates.
- Video featured/popular and video library surfaces.
- Photo gallery and history timeline surfaces.

Checks
- git diff --check
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm run build

Supabase impact
- Read projection only: linked `entities` include `summary` and `data` in CMS relation queries.
- No migration, RLS, storage policy, or data mutation.