### PR TITLE
[Perf] Optimize public content caching and images

### DIFF
--- a/app/auth/actions.ts
+++ b/app/auth/actions.ts
@@ -1,9 +1,10 @@
 "use server"
 
 import { headers } from "next/headers"
-import { revalidatePath } from "next/cache"
+import { revalidatePath, updateTag } from "next/cache"
 import { redirect } from "next/navigation"
 
+import { PUBLIC_CONTENT_CACHE_TAG } from "@/lib/data/public-cache"
 import { createClient } from "@/lib/supabase/server"
 import type { Database } from "@/lib/supabase/types"
 
@@ -213,7 +214,9 @@ export async function updateProfileAction(formData: FormData) {
   }
 
   revalidatePath("/members")
+  revalidatePath("/")
   revalidatePath("/mypage")
+  updateTag(PUBLIC_CONTENT_CACHE_TAG)
   redirectWithParams("/mypage", {
     message: "프로필을 저장했습니다.",
   })

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,7 +4,6 @@ import { Analytics } from '@vercel/analytics/next'
 import { Navigation } from '@/components/navigation'
 import { Footer } from '@/components/footer'
 import { loadSiteChrome } from '@/lib/data/content-graph'
-import { createClient } from '@/lib/supabase/server'
 import './globals.css'
 
 const instrumentSerif = Instrument_Serif({
@@ -34,13 +33,7 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode
 }>) {
-  const supabase = await createClient()
-  const [
-    {
-      data: { user },
-    },
-    siteChrome,
-  ] = await Promise.all([supabase.auth.getUser(), loadSiteChrome()])
+  const siteChrome = await loadSiteChrome()
 
   if (!siteChrome) {
     throw new Error("Missing CMS site chrome configuration")
@@ -53,7 +46,7 @@ export default async function RootLayout({
     >
       <body className="font-sans antialiased">
         <div className="min-h-screen bg-background flex flex-col">
-          <Navigation isSignedIn={Boolean(user)} config={siteChrome.navigation} />
+          <Navigation config={siteChrome.navigation} />
           <main className="pt-20 flex-1">{children}</main>
           <Footer config={siteChrome.footer} />
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,12 @@ import {
   type HomeSectionConfig,
   type HomeStatCard,
 } from "@/components/home-section"
+import { unstable_cache } from "next/cache"
 import { notFound } from "next/navigation"
+import {
+  PUBLIC_CONTENT_CACHE_TAG,
+  PUBLIC_CONTENT_REVALIDATE_SECONDS,
+} from "@/lib/data/public-cache"
 import {
   loadHomeCuration,
   loadPerformancePlaylists,
@@ -14,7 +19,7 @@ import {
   type HomeCurationStatItem,
 } from "@/lib/data/content-graph"
 import { formatViews, type Video } from "@/lib/data/videos"
-import { createClient } from "@/lib/supabase/server"
+import { createPublicClient } from "@/lib/supabase/public"
 
 type HomeVideoSource = Video & {
   caption?: string
@@ -32,7 +37,7 @@ type StatMetricContext = {
   topVideo?: HomeVideoSource
 }
 
-async function loadMemberStats() {
+async function loadMemberStatsUncached() {
   if (
     !process.env.NEXT_PUBLIC_SUPABASE_URL ||
     !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
@@ -41,7 +46,7 @@ async function loadMemberStats() {
   }
 
   try {
-    const supabase = await createClient()
+    const supabase = createPublicClient()
     const { data, error } = await supabase
       .from("members")
       .select("status")
@@ -59,6 +64,15 @@ async function loadMemberStats() {
     return { memberCount: 0, activeMemberCount: 0 }
   }
 }
+
+const loadMemberStats = unstable_cache(
+  loadMemberStatsUncached,
+  ["public-content", "home-member-stats"],
+  {
+    tags: [PUBLIC_CONTENT_CACHE_TAG],
+    revalidate: PUBLIC_CONTENT_REVALIDATE_SECONDS,
+  },
+)
 
 function videoTitle(video: HomeVideoSource) {
   return video.song || video.raw_title

--- a/app/ponix/entities/actions.ts
+++ b/app/ponix/entities/actions.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { revalidatePath } from "next/cache"
+import { revalidatePath, updateTag } from "next/cache"
 import { redirect } from "next/navigation"
 
 import { requireCmsAdmin } from "@/lib/cms/auth"
@@ -12,6 +12,7 @@ import {
   type CmsEditableEntityField,
   type CmsJsonObject,
 } from "@/lib/cms/entity-editor"
+import { PUBLIC_CONTENT_CACHE_TAG } from "@/lib/data/public-cache"
 import { createClient } from "@/lib/supabase/server"
 import type { Database, Json } from "@/lib/supabase/types"
 
@@ -387,6 +388,7 @@ export async function updateCmsEntityAction(formData: FormData) {
   revalidatePath("/videos")
   revalidatePath("/photos")
   revalidatePath("/history")
+  updateTag(PUBLIC_CONTENT_CACHE_TAG)
   revalidatePath("/ponix")
   revalidatePath("/ponix/entities")
   revalidatePath(`/ponix/entities/${entityId}`)

--- a/app/ponix/sections/actions.ts
+++ b/app/ponix/sections/actions.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { revalidatePath } from "next/cache"
+import { revalidatePath, updateTag } from "next/cache"
 import { redirect } from "next/navigation"
 
 import { requireCmsAdmin } from "@/lib/cms/auth"
@@ -12,6 +12,7 @@ import {
   type CmsEditableSectionField,
   type CmsJsonObject,
 } from "@/lib/cms/section-editor"
+import { PUBLIC_CONTENT_CACHE_TAG } from "@/lib/data/public-cache"
 import { createClient } from "@/lib/supabase/server"
 import type { Database, Json } from "@/lib/supabase/types"
 
@@ -292,6 +293,7 @@ export async function updateCmsSectionAction(formData: FormData) {
   revalidatePath("/videos")
   revalidatePath("/photos")
   revalidatePath("/history")
+  updateTag(PUBLIC_CONTENT_CACHE_TAG)
   revalidatePath("/ponix")
   revalidatePath("/ponix/sections")
   revalidatePath(`/ponix/sections/${sectionId}`)

--- a/app/videos/page.tsx
+++ b/app/videos/page.tsx
@@ -8,13 +8,7 @@ export const metadata: Metadata = {
   description: "포스텍 밴드 동아리 브레멘의 공연 영상 아카이브.",
 }
 
-type VideosPageProps = {
-  searchParams?: Promise<Record<string, string | string[] | undefined>>
-}
-
-export default async function VideosPage({ searchParams }: VideosPageProps) {
-  const params = (await searchParams) ?? {}
-  const event = Array.isArray(params.event) ? params.event[0] : params.event
+export default async function VideosPage() {
   const content = await loadVideoPage()
   const sectionKeys = new Set(content?.sections.map((section) => section.key))
   const hasRequiredSections = [
@@ -40,7 +34,6 @@ export default async function VideosPage({ searchParams }: VideosPageProps) {
       videos={content.libraryVideos}
       featuredVideos={content.featuredVideos}
       popularVideos={content.popularVideos}
-      initialEvent={event}
     />
   )
 }

--- a/components/home-section.tsx
+++ b/components/home-section.tsx
@@ -170,7 +170,6 @@ function StatCardView({ card }: { card: HomeStatCard }) {
             src={imageSrc}
             alt={card.label}
             fill
-            unoptimized
             sizes="(max-width: 768px) 50vw, 25vw"
             className="object-cover"
           />
@@ -298,7 +297,6 @@ export function HomeSection({ overview }: { overview: HomeOverview }) {
                 src={homeFeaturedVideo.thumbnailUrl ?? thumbnailUrl(homeFeaturedVideo.id, "max")}
                 alt={homeFeaturedVideo.title}
                 fill
-                unoptimized
                 priority
                 sizes="(max-width: 768px) 100vw, 60vw"
                 className="object-cover transition-transform duration-700 group-hover:scale-[1.03]"
@@ -383,7 +381,6 @@ export function HomeSection({ overview }: { overview: HomeOverview }) {
                     src={v.thumbnailUrl ?? thumbnailUrl(v.id, "max")}
                     alt={`${v.artist ?? "Bremen"} - ${v.song ?? v.title}`}
                     fill
-                    unoptimized
                     sizes="(max-width: 768px) 50vw, 25vw"
                     className="object-cover transition-transform duration-700 group-hover:scale-[1.04]"
                   />

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -1,11 +1,13 @@
 "use client"
 
+import { useEffect, useState } from "react"
 import Image from "next/image"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { UserCircle } from "@phosphor-icons/react"
 
 import { buttonVariants } from "@/components/ui/button"
+import { createClient } from "@/lib/supabase/client"
 import { cn } from "@/lib/utils"
 
 export type NavigationItem = {
@@ -36,11 +38,33 @@ type NavigationProps = {
 
 export function Navigation({ isSignedIn = false, config }: NavigationProps) {
   const pathname = usePathname()
+  const [hasSession, setHasSession] = useState(isSignedIn)
+
+  useEffect(() => {
+    let mounted = true
+    const supabase = createClient()
+
+    supabase.auth.getUser().then(({ data }) => {
+      if (mounted) setHasSession(Boolean(data.user))
+    })
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (mounted) setHasSession(Boolean(session?.user))
+    })
+
+    return () => {
+      mounted = false
+      subscription.unsubscribe()
+    }
+  }, [])
+
   const isAccountActive = accountPaths.some((path) => pathname.startsWith(path))
-  const accountHref = isSignedIn
+  const accountHref = hasSession
     ? config.accountSignedInHref
     : config.accountSignedOutHref
-  const accountLabel = isSignedIn
+  const accountLabel = hasSession
     ? config.accountSignedInLabel
     : config.accountSignedOutLabel
 
@@ -55,7 +79,6 @@ export function Navigation({ isSignedIn = false, config }: NavigationProps) {
               width={36}
               height={36}
               priority
-              unoptimized={config.logoSrc.startsWith("http")}
               className="rounded-sm"
             />
             <span className="hidden sm:flex items-baseline gap-2">

--- a/components/performances-section.tsx
+++ b/components/performances-section.tsx
@@ -83,7 +83,6 @@ function PlaylistCard({
             src={playlist.coverUrl}
             alt={playlist.title}
             fill
-            unoptimized
             sizes="(max-width: 768px) 100vw, 33vw"
             className="object-cover transition-transform duration-700 group-hover:scale-[1.04]"
           />
@@ -301,7 +300,6 @@ export function StageMoments({
                     src={photo.thumbnailUrl}
                     alt={photo.title}
                     fill
-                    unoptimized
                     sizes="(max-width: 768px) 50vw, 16vw"
                     className="object-cover transition-transform duration-700 group-hover:scale-[1.04]"
                   />
@@ -336,7 +334,6 @@ export function PerformanceUpdateCard({
             src={update.thumbnailUrl}
             alt={update.title}
             fill
-            unoptimized
             sizes="(max-width: 640px) 100vw, 160px"
             className="object-cover transition-transform duration-700 group-hover:scale-[1.04]"
           />

--- a/components/photos-section.tsx
+++ b/components/photos-section.tsx
@@ -166,7 +166,6 @@ export function PhotoGallerySurface({
                       src={photo.thumbnailUrl}
                       alt={photo.title}
                       fill
-                      unoptimized
                       sizes="(max-width: 640px) 100vw, (max-width: 1280px) 50vw, 33vw"
                       className="object-cover transition-transform duration-700 group-hover:scale-[1.04]"
                     />
@@ -217,7 +216,6 @@ export function PhotoGallerySurface({
                     src={current.thumbnailUrl}
                     alt={current.title}
                     fill
-                    unoptimized
                     sizes="(max-width: 768px) 100vw, 896px"
                     className="object-cover"
                   />

--- a/components/videos-section.tsx
+++ b/components/videos-section.tsx
@@ -1,8 +1,8 @@
 "use client"
 
 import Image from "next/image"
-import type { CSSProperties } from "react"
-import { useDeferredValue, useState } from "react"
+import { useSearchParams } from "next/navigation"
+import { Suspense, useDeferredValue, useState, type CSSProperties } from "react"
 import {
   ArrowUpRight,
   CaretDown,
@@ -157,7 +157,6 @@ function VideoCard({
             src={videoThumbnailUrl(video, "mq")}
             alt={video.raw_title}
             fill
-            unoptimized
             sizes="(max-width: 768px) 100vw, 33vw"
             className="object-cover transition-transform duration-700 group-hover:scale-[1.04]"
           />
@@ -217,7 +216,6 @@ function FeaturedVideoCard({ video }: { video: Video }) {
             src={videoThumbnailUrl(video, "max")}
             alt={video.raw_title}
             fill
-            unoptimized
             sizes="(max-width: 1024px) 100vw, 60vw"
             className="object-cover transition-transform duration-700 group-hover:scale-[1.04]"
           />
@@ -268,7 +266,6 @@ function PickRow({ video, index }: { video: Video; index: number }) {
             src={videoThumbnailUrl(video, "mq")}
             alt={video.raw_title}
             fill
-            unoptimized
             sizes="128px"
             className="object-cover"
           />
@@ -471,7 +468,6 @@ type VideosSectionProps = {
   videos: Video[]
   featuredVideos: Video[]
   popularVideos: Video[]
-  initialEvent?: string
 }
 
 export function FeaturedVideosSurface({
@@ -684,13 +680,30 @@ export function VideoLibrarySurface({
   )
 }
 
+function VideoLibrarySurfaceWithSearchParams({
+  section,
+  videos,
+}: {
+  section?: ContentSectionConfig
+  videos: Video[]
+}) {
+  const searchParams = useSearchParams()
+
+  return (
+    <VideoLibrarySurface
+      section={section}
+      videos={videos}
+      initialEvent={searchParams.get("event") ?? undefined}
+    />
+  )
+}
+
 export function VideosSection({
   page: pageConfig,
   sections,
   videos,
   featuredVideos,
   popularVideos,
-  initialEvent,
 }: VideosSectionProps) {
   const sourceVideos = videos
   const featuredSection = sections.find((section) => section.key === "videos-featured")
@@ -735,11 +748,12 @@ export function VideosSection({
         picks={picks}
       />
 
-      <VideoLibrarySurface
-        section={librarySection}
-        videos={library}
-        initialEvent={initialEvent}
-      />
+      <Suspense fallback={<VideoLibrarySurface section={librarySection} videos={library} />}>
+        <VideoLibrarySurfaceWithSearchParams
+          section={librarySection}
+          videos={library}
+        />
+      </Suspense>
     </div>
   )
 }

--- a/lib/data/content-graph.ts
+++ b/lib/data/content-graph.ts
@@ -1,5 +1,11 @@
-import { createClient } from "@/lib/supabase/server"
+import { unstable_cache } from "next/cache"
+
+import {
+  PUBLIC_CONTENT_CACHE_TAG,
+  PUBLIC_CONTENT_REVALIDATE_SECONDS,
+} from "@/lib/data/public-cache"
 import type { Database, Json } from "@/lib/supabase/types"
+import { createPublicClient } from "@/lib/supabase/public"
 import {
   eventByKey,
   type EventKey,
@@ -447,11 +453,11 @@ function contentSectionFromGraph(section: GraphSection): ContentSectionConfig {
   }
 }
 
-export async function loadGraphPage(slug: string): Promise<GraphPage | null> {
+async function loadGraphPageUncached(slug: string): Promise<GraphPage | null> {
   if (!hasSupabaseEnv()) return null
 
   try {
-    const supabase = await createClient()
+    const supabase = createPublicClient()
     const { data: page, error: pageError } = await supabase
       .from("pages")
       .select("*")
@@ -538,6 +544,15 @@ export async function loadGraphPage(slug: string): Promise<GraphPage | null> {
   }
 }
 
+export const loadGraphPage = unstable_cache(
+  loadGraphPageUncached,
+  ["public-content", "graph-page"],
+  {
+    tags: [PUBLIC_CONTENT_CACHE_TAG],
+    revalidate: PUBLIC_CONTENT_REVALIDATE_SECONDS,
+  },
+)
+
 function sectionItems(page: GraphPage | null, key: string) {
   return page?.sections.find((section) => section.key === key)?.items ?? []
 }
@@ -588,7 +603,7 @@ function siteSocialFromSectionItem(item: GraphSectionItem): SiteSocialItem | nul
   }
 }
 
-export async function loadSiteChrome(): Promise<SiteChrome | null> {
+async function loadSiteChromeUncached(): Promise<SiteChrome | null> {
   const page = await loadGraphPage("site")
   if (!page) return null
 
@@ -858,7 +873,7 @@ async function loadPerformanceSlugsById() {
   return new Map(entries.map((entity) => [entity.id, entity.slug ?? entity.id]))
 }
 
-export async function loadHomeCuration(): Promise<HomeCuration | null> {
+async function loadHomeCurationUncached(): Promise<HomeCuration | null> {
   const page = await loadGraphPage("home")
   if (!page) return null
 
@@ -916,7 +931,7 @@ async function loadPerformancePlaylistsFromPage(page: GraphPage | null) {
   )
 
   try {
-    const supabase = await createClient()
+    const supabase = createPublicClient()
     const performanceIds = performanceEntities.map((entity) => entity.id)
     const { data: relations, error: relationsError } = await supabase
       .from("entity_relations")
@@ -1001,7 +1016,7 @@ async function loadPerformancePlaylistsFromPage(page: GraphPage | null) {
   }
 }
 
-export async function loadPerformanceArchive() {
+async function loadPerformanceArchiveUncached() {
   const page = await loadGraphPage("performances")
   const archiveItems = sectionItems(page, "performances-archive")
     .map((item) => performanceFromEntity(item.entity))
@@ -1014,12 +1029,12 @@ export async function loadPerformanceArchive() {
   return null
 }
 
-export async function loadPerformancePlaylists() {
+async function loadPerformancePlaylistsUncached() {
   const page = await loadGraphPage("performances")
   return loadPerformancePlaylistsFromPage(page)
 }
 
-export async function loadPerformancePage(): Promise<PerformancePageContent | null> {
+async function loadPerformancePageUncached(): Promise<PerformancePageContent | null> {
   const page = await loadGraphPage("performances")
   if (!page) return null
 
@@ -1032,7 +1047,7 @@ export async function loadPerformancePage(): Promise<PerformancePageContent | nu
   }
 }
 
-export async function loadPerformanceUpdates() {
+async function loadPerformanceUpdatesUncached() {
   const page = await loadGraphPage("performances")
   const updates = sectionItems(page, "performances-updates")
     .map((item) => performanceUpdateFromEntity(item.entity))
@@ -1060,7 +1075,7 @@ function sortVideoArchive(recordings: Video[]) {
   })
 }
 
-export async function loadVideoPage(): Promise<VideoPageContent | null> {
+async function loadVideoPageUncached(): Promise<VideoPageContent | null> {
   const page = await loadGraphPage("videos")
   if (!page) return null
 
@@ -1086,7 +1101,7 @@ export async function loadVideoPage(): Promise<VideoPageContent | null> {
   }
 }
 
-export async function loadVideoArchive() {
+async function loadVideoArchiveUncached() {
   const page = await loadVideoPage()
   const recordings = page?.libraryVideos ?? []
 
@@ -1095,7 +1110,7 @@ export async function loadVideoArchive() {
   return recordings
 }
 
-export async function loadPhotoPage(): Promise<PhotoPageContent | null> {
+async function loadPhotoPageUncached(): Promise<PhotoPageContent | null> {
   const page = await loadGraphPage("photos")
   if (!page) return null
 
@@ -1110,12 +1125,12 @@ export async function loadPhotoPage(): Promise<PhotoPageContent | null> {
   }
 }
 
-export async function loadPhotoArchive() {
+async function loadPhotoArchiveUncached() {
   const page = await loadPhotoPage()
   return page?.photos.length ? page.photos : null
 }
 
-export async function loadHistoryPage(): Promise<HistoryPageContent | null> {
+async function loadHistoryPageUncached(): Promise<HistoryPageContent | null> {
   const page = await loadGraphPage("history")
   if (!page) return null
 
@@ -1130,7 +1145,84 @@ export async function loadHistoryPage(): Promise<HistoryPageContent | null> {
   }
 }
 
-export async function loadHistoryArchive() {
+async function loadHistoryArchiveUncached() {
   const page = await loadHistoryPage()
   return page?.milestones.length ? page.milestones : null
 }
+
+const publicContentCacheOptions = {
+  tags: [PUBLIC_CONTENT_CACHE_TAG],
+  revalidate: PUBLIC_CONTENT_REVALIDATE_SECONDS,
+}
+
+export const loadSiteChrome = unstable_cache(
+  loadSiteChromeUncached,
+  ["public-content", "site-chrome"],
+  publicContentCacheOptions,
+)
+
+export const loadHomeCuration = unstable_cache(
+  loadHomeCurationUncached,
+  ["public-content", "home-curation"],
+  publicContentCacheOptions,
+)
+
+export const loadPerformanceArchive = unstable_cache(
+  loadPerformanceArchiveUncached,
+  ["public-content", "performance-archive"],
+  publicContentCacheOptions,
+)
+
+export const loadPerformancePlaylists = unstable_cache(
+  loadPerformancePlaylistsUncached,
+  ["public-content", "performance-playlists"],
+  publicContentCacheOptions,
+)
+
+export const loadPerformancePage = unstable_cache(
+  loadPerformancePageUncached,
+  ["public-content", "performance-page"],
+  publicContentCacheOptions,
+)
+
+export const loadPerformanceUpdates = unstable_cache(
+  loadPerformanceUpdatesUncached,
+  ["public-content", "performance-updates"],
+  publicContentCacheOptions,
+)
+
+export const loadVideoPage = unstable_cache(
+  loadVideoPageUncached,
+  ["public-content", "video-page"],
+  publicContentCacheOptions,
+)
+
+export const loadVideoArchive = unstable_cache(
+  loadVideoArchiveUncached,
+  ["public-content", "video-archive"],
+  publicContentCacheOptions,
+)
+
+export const loadPhotoPage = unstable_cache(
+  loadPhotoPageUncached,
+  ["public-content", "photo-page"],
+  publicContentCacheOptions,
+)
+
+export const loadPhotoArchive = unstable_cache(
+  loadPhotoArchiveUncached,
+  ["public-content", "photo-archive"],
+  publicContentCacheOptions,
+)
+
+export const loadHistoryPage = unstable_cache(
+  loadHistoryPageUncached,
+  ["public-content", "history-page"],
+  publicContentCacheOptions,
+)
+
+export const loadHistoryArchive = unstable_cache(
+  loadHistoryArchiveUncached,
+  ["public-content", "history-archive"],
+  publicContentCacheOptions,
+)

--- a/lib/data/public-cache.ts
+++ b/lib/data/public-cache.ts
@@ -1,0 +1,2 @@
+export const PUBLIC_CONTENT_CACHE_TAG = "public-content"
+export const PUBLIC_CONTENT_REVALIDATE_SECONDS = 300

--- a/lib/supabase/public.ts
+++ b/lib/supabase/public.ts
@@ -1,0 +1,17 @@
+import { createClient } from "@supabase/supabase-js"
+
+import type { Database } from "./types"
+
+export function createPublicClient() {
+  return createClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      auth: {
+        persistSession: false,
+        autoRefreshToken: false,
+        detectSessionInUrl: false,
+      },
+    },
+  )
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,3 +1,7 @@
+const supabaseStorageHostname = process.env.NEXT_PUBLIC_SUPABASE_URL
+  ? new URL(process.env.NEXT_PUBLIC_SUPABASE_URL).hostname
+  : "tyosnoncxaewrjlbnytg.supabase.co"
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   typescript: {
@@ -9,7 +13,23 @@ const nextConfig = {
     },
   },
   images: {
-    unoptimized: true,
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: supabaseStorageHostname,
+        pathname: "/storage/v1/object/public/**",
+      },
+      {
+        protocol: "https",
+        hostname: supabaseStorageHostname,
+        pathname: "/storage/v1/object/sign/**",
+      },
+      {
+        protocol: "https",
+        hostname: "i.ytimg.com",
+        pathname: "/vi/**",
+      },
+    ],
   },
 }
 


### PR DESCRIPTION
Closes #16

Summary
- Adds a cookie-free public Supabase client for CMS/public data loaders.
- Wraps public content graph loaders and home member stats in a shared 5-minute cache tag.
- Invalidates that tag from CMS entity/section saves and member profile saves.
- Moves navigation auth state to the client so public pages are not forced dynamic by root layout cookies.
- Enables Next image optimization for Supabase Storage public/signed URLs and YouTube thumbnails, then removes public `unoptimized` image usage.
- Keeps `/videos?event=...` deep-link filtering via a client Suspense boundary instead of server `searchParams`.

Build result
- Static with 5m revalidation: `/`, `/performances`, `/videos`, `/photos`, `/history`.
- Still dynamic by design: auth/member/CMS routes and `/performances/updates` query pagination, with the updates loader cached.

Checks
- `git diff --check`
- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `pnpm run build`

Supabase impact
- No schema, RLS, storage policy, auth config, or content-row changes.
- Public reads still use anon-key RLS.
- No service-role usage.