### PR TITLE
[CMS] Add guarded relation editor

### DIFF
--- a/app/ponix/_components/cms-relations.tsx
+++ b/app/ponix/_components/cms-relations.tsx
@@ -1,7 +1,17 @@
 import Link from "next/link"
 import type { ReactNode } from "react"
 
+import {
+  addEntityRelationAction,
+  addSectionEntityRelationAction,
+  deleteEntityRelationAction,
+  deleteSectionEntityRelationAction,
+  updateEntityRelationAction,
+  updateSectionEntityRelationAction,
+} from "@/app/ponix/relations/actions"
+import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import {
   Card,
   CardContent,
@@ -17,6 +27,8 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
 import type {
   CmsEntityRelation,
   CmsLinkedEntity,
@@ -24,6 +36,7 @@ import type {
   CmsLinkedSection,
   CmsPageSectionRelation,
   CmsRelationList,
+  CmsRelationEditorOptions,
   CmsSectionEntityRelation,
 } from "@/lib/cms/content"
 
@@ -45,6 +58,42 @@ export function RelationCount({
       {limit && total > limit ? `${visible} of ${total}` : `${visible}`} records
     </p>
   )
+}
+
+export function RelationMutationNotice({
+  message,
+  error,
+}: {
+  message?: string
+  error?: string
+}) {
+  if (!message && !error) return null
+
+  return (
+    <Alert
+      variant={error ? "destructive" : "default"}
+      className="rounded-md bg-card/95 shadow-xl"
+    >
+      <AlertDescription>{error ?? message}</AlertDescription>
+    </Alert>
+  )
+}
+
+export function relationMutationState(
+  searchParams?: Record<string, string | string[] | undefined>,
+) {
+  const message = searchValue(searchParams?.relation_message)
+  const error = searchValue(searchParams?.relation_error)
+
+  return {
+    message,
+    error,
+  }
+}
+
+function searchValue(value: string | string[] | undefined) {
+  if (Array.isArray(value)) return value[0]
+  return value
 }
 
 export function PageSectionRelationsCard({
@@ -78,11 +127,21 @@ export function SectionEntityRelationsCard({
   description = "Ordered entity curation inside sections.",
   relationList,
   relations,
+  editable = false,
+  editorOptions,
+  redirectTo = "/ponix/relations",
+  fixedSectionId,
+  fixedEntityId,
 }: {
   title?: string
   description?: string
   relationList?: CmsRelationList<CmsSectionEntityRelation>
   relations?: CmsSectionEntityRelation[]
+  editable?: boolean
+  editorOptions?: CmsRelationEditorOptions
+  redirectTo?: string
+  fixedSectionId?: string
+  fixedEntityId?: string
 }) {
   const rows = relationList?.relations ?? relations ?? []
 
@@ -94,7 +153,19 @@ export function SectionEntityRelationsCard({
       count={relationList?.count ?? rows.length}
       limit={relationList?.limit}
     >
-      <SectionEntityRelationsTable relations={rows} />
+      {editable && editorOptions && (
+        <SectionEntityAddForm
+          options={editorOptions}
+          redirectTo={redirectTo}
+          fixedSectionId={fixedSectionId}
+          fixedEntityId={fixedEntityId}
+        />
+      )}
+      <SectionEntityRelationsTable
+        relations={rows}
+        editable={editable}
+        redirectTo={redirectTo}
+      />
     </RelationCard>
   )
 }
@@ -104,11 +175,23 @@ export function EntityRelationsCard({
   description = "Domain links between reusable entities.",
   relationList,
   relations,
+  editable = false,
+  allowAdd = true,
+  editorOptions,
+  redirectTo = "/ponix/relations",
+  fixedFromEntityId,
+  fixedToEntityId,
 }: {
   title?: string
   description?: string
   relationList?: CmsRelationList<CmsEntityRelation>
   relations?: CmsEntityRelation[]
+  editable?: boolean
+  allowAdd?: boolean
+  editorOptions?: CmsRelationEditorOptions
+  redirectTo?: string
+  fixedFromEntityId?: string
+  fixedToEntityId?: string
 }) {
   const rows = relationList?.relations ?? relations ?? []
 
@@ -120,10 +203,233 @@ export function EntityRelationsCard({
       count={relationList?.count ?? rows.length}
       limit={relationList?.limit}
     >
-      <EntityRelationsTable relations={rows} />
+      {editable && allowAdd && editorOptions && (
+        <EntityRelationAddForm
+          options={editorOptions}
+          redirectTo={redirectTo}
+          fixedFromEntityId={fixedFromEntityId}
+          fixedToEntityId={fixedToEntityId}
+        />
+      )}
+      <EntityRelationsTable
+        relations={rows}
+        editable={editable}
+        redirectTo={redirectTo}
+      />
     </RelationCard>
   )
 }
+
+function SectionEntityAddForm({
+  options,
+  redirectTo,
+  fixedSectionId,
+  fixedEntityId,
+}: {
+  options: CmsRelationEditorOptions
+  redirectTo: string
+  fixedSectionId?: string
+  fixedEntityId?: string
+}) {
+  return (
+    <form
+      action={addSectionEntityRelationAction}
+      className="grid gap-4 border-b bg-muted/20 px-6 py-6 lg:grid-cols-[minmax(12rem,0.9fr)_minmax(14rem,1.2fr)_9rem_9rem_7rem_auto]"
+    >
+      <input type="hidden" name="redirect_to" value={redirectTo} />
+      {fixedSectionId ? (
+        <input type="hidden" name="section_id" value={fixedSectionId} />
+      ) : (
+        <FieldGroup label="Section">
+          <SectionSelect name="section_id" sections={options.sections} />
+        </FieldGroup>
+      )}
+      {fixedEntityId ? (
+        <input type="hidden" name="entity_id" value={fixedEntityId} />
+      ) : (
+        <FieldGroup label="Entity">
+          <EntitySelect name="entity_id" entities={options.entities} />
+        </FieldGroup>
+      )}
+      <FieldGroup label="Type">
+        <Input
+          name="relation_type"
+          defaultValue="item"
+          list="section-relation-types"
+          required
+          className="h-10 bg-background/80"
+        />
+      </FieldGroup>
+      <FieldGroup label="Slot">
+        <Input
+          name="slot"
+          defaultValue="default"
+          className="h-10 bg-background/80"
+        />
+      </FieldGroup>
+      <FieldGroup label="Order">
+        <Input
+          name="sort_order"
+          type="number"
+          defaultValue="0"
+          className="h-10 bg-background/80"
+        />
+      </FieldGroup>
+      <div className="flex items-end">
+        <Button type="submit" className="w-full rounded-full">
+          Add
+        </Button>
+      </div>
+      <datalist id="section-relation-types">
+        <option value="item" />
+        <option value="features_photo" />
+        <option value="features_post" />
+        <option value="contains_video" />
+      </datalist>
+    </form>
+  )
+}
+
+function EntityRelationAddForm({
+  options,
+  redirectTo,
+  fixedFromEntityId,
+  fixedToEntityId,
+}: {
+  options: CmsRelationEditorOptions
+  redirectTo: string
+  fixedFromEntityId?: string
+  fixedToEntityId?: string
+}) {
+  return (
+    <form
+      action={addEntityRelationAction}
+      className="grid gap-4 border-b bg-muted/20 px-6 py-6 lg:grid-cols-[minmax(14rem,1.2fr)_minmax(14rem,1.2fr)_9rem_9rem_7rem_auto]"
+    >
+      <input type="hidden" name="redirect_to" value={redirectTo} />
+      {fixedFromEntityId ? (
+        <input type="hidden" name="from_entity_id" value={fixedFromEntityId} />
+      ) : (
+        <FieldGroup label="From">
+          <EntitySelect name="from_entity_id" entities={options.entities} />
+        </FieldGroup>
+      )}
+      {fixedToEntityId ? (
+        <input type="hidden" name="to_entity_id" value={fixedToEntityId} />
+      ) : (
+        <FieldGroup label="To">
+          <EntitySelect name="to_entity_id" entities={options.entities} />
+        </FieldGroup>
+      )}
+      <FieldGroup label="Type">
+        <Input
+          name="relation_type"
+          defaultValue="has_recording"
+          list="entity-relation-types"
+          required
+          className="h-10 bg-background/80"
+        />
+      </FieldGroup>
+      <FieldGroup label="Slot">
+        <Input
+          name="slot"
+          defaultValue="default"
+          className="h-10 bg-background/80"
+        />
+      </FieldGroup>
+      <FieldGroup label="Order">
+        <Input
+          name="sort_order"
+          type="number"
+          defaultValue="0"
+          className="h-10 bg-background/80"
+        />
+      </FieldGroup>
+      <div className="flex items-end">
+        <Button type="submit" className="w-full rounded-full">
+          Add
+        </Button>
+      </div>
+      <datalist id="entity-relation-types">
+        <option value="has_recording" />
+        <option value="has_photo" />
+        <option value="has_post" />
+        <option value="related" />
+      </datalist>
+    </form>
+  )
+}
+
+function FieldGroup({
+  label,
+  children,
+}: {
+  label: string
+  children: ReactNode
+}) {
+  return (
+    <div className="space-y-2">
+      <Label className="caps text-muted-foreground">{label}</Label>
+      {children}
+    </div>
+  )
+}
+
+function SectionSelect({
+  name,
+  sections,
+}: {
+  name: string
+  sections: CmsRelationEditorOptions["sections"]
+}) {
+  return (
+    <select
+      name={name}
+      required
+      className={selectClassName}
+      defaultValue=""
+    >
+      <option value="" disabled>
+        Select section
+      </option>
+      {sections.map((section) => (
+        <option key={section.id} value={section.id}>
+          {section.key} · {section.title ?? "Untitled"}
+        </option>
+      ))}
+    </select>
+  )
+}
+
+function EntitySelect({
+  name,
+  entities,
+}: {
+  name: string
+  entities: CmsRelationEditorOptions["entities"]
+}) {
+  return (
+    <select
+      name={name}
+      required
+      className={selectClassName}
+      defaultValue=""
+    >
+      <option value="" disabled>
+        Select entity
+      </option>
+      {entities.map((entity) => (
+        <option key={entity.id} value={entity.id}>
+          {entity.entityType} · {entity.title}
+          {entity.slug ? ` · ${entity.slug}` : ""}
+        </option>
+      ))}
+    </select>
+  )
+}
+
+const selectClassName =
+  "flex h-10 w-full rounded-md border border-input bg-background/80 px-3 py-2 text-sm shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50"
 
 function RelationCard({
   title,
@@ -219,8 +525,12 @@ function PageSectionRelationsTable({
 
 function SectionEntityRelationsTable({
   relations,
+  editable = false,
+  redirectTo = "/ponix/relations",
 }: {
   relations: CmsSectionEntityRelation[]
+  editable?: boolean
+  redirectTo?: string
 }) {
   if (relations.length === 0) {
     return <EmptyRelationRows message="No section-entity relations." />
@@ -236,6 +546,7 @@ function SectionEntityRelationsTable({
           <TableHead>Entity</TableHead>
           <TableHead>Type</TableHead>
           <TableHead>Status</TableHead>
+          {editable && <TableHead>Manage</TableHead>}
         </TableRow>
       </TableHeader>
       <TableBody>
@@ -260,6 +571,14 @@ function SectionEntityRelationsTable({
             <TableCell>
               <SectionEntityStatus relation={relation} />
             </TableCell>
+            {editable && (
+              <TableCell>
+                <SectionEntityRelationActions
+                  relation={relation}
+                  redirectTo={redirectTo}
+                />
+              </TableCell>
+            )}
           </TableRow>
         ))}
       </TableBody>
@@ -269,8 +588,12 @@ function SectionEntityRelationsTable({
 
 function EntityRelationsTable({
   relations,
+  editable = false,
+  redirectTo = "/ponix/relations",
 }: {
   relations: CmsEntityRelation[]
+  editable?: boolean
+  redirectTo?: string
 }) {
   if (relations.length === 0) {
     return <EmptyRelationRows message="No entity relations." />
@@ -286,6 +609,7 @@ function EntityRelationsTable({
           <TableHead>Order</TableHead>
           <TableHead>To</TableHead>
           <TableHead>Status</TableHead>
+          {editable && <TableHead>Manage</TableHead>}
         </TableRow>
       </TableHeader>
       <TableBody>
@@ -313,10 +637,99 @@ function EntityRelationsTable({
             <TableCell>
               <EntityRelationStatus relation={relation} />
             </TableCell>
+            {editable && (
+              <TableCell>
+                <EntityRelationActions
+                  relation={relation}
+                  redirectTo={redirectTo}
+                />
+              </TableCell>
+            )}
           </TableRow>
         ))}
       </TableBody>
     </Table>
+  )
+}
+
+function SectionEntityRelationActions({
+  relation,
+  redirectTo,
+}: {
+  relation: CmsSectionEntityRelation
+  redirectTo: string
+}) {
+  return (
+    <div className="flex min-w-44 flex-col gap-2">
+      <form
+        action={updateSectionEntityRelationAction}
+        className="flex items-center gap-2"
+      >
+        <input type="hidden" name="redirect_to" value={redirectTo} />
+        <input type="hidden" name="relation_id" value={relation.id} />
+        <Input
+          aria-label="Sort order"
+          name="sort_order"
+          type="number"
+          defaultValue={relation.sortOrder}
+          className="h-8 w-20 bg-background/80"
+        />
+        <Button type="submit" size="sm" variant="outline">
+          Save
+        </Button>
+      </form>
+      <form action={deleteSectionEntityRelationAction}>
+        <input type="hidden" name="redirect_to" value={redirectTo} />
+        <input type="hidden" name="relation_id" value={relation.id} />
+        <Button
+          type="submit"
+          size="sm"
+          variant="ghost"
+          className="h-8 px-2 text-destructive hover:text-destructive"
+        >
+          Remove relation
+        </Button>
+      </form>
+    </div>
+  )
+}
+
+function EntityRelationActions({
+  relation,
+  redirectTo,
+}: {
+  relation: CmsEntityRelation
+  redirectTo: string
+}) {
+  return (
+    <div className="flex min-w-44 flex-col gap-2">
+      <form action={updateEntityRelationAction} className="flex items-center gap-2">
+        <input type="hidden" name="redirect_to" value={redirectTo} />
+        <input type="hidden" name="relation_id" value={relation.id} />
+        <Input
+          aria-label="Sort order"
+          name="sort_order"
+          type="number"
+          defaultValue={relation.sortOrder}
+          className="h-8 w-20 bg-background/80"
+        />
+        <Button type="submit" size="sm" variant="outline">
+          Save
+        </Button>
+      </form>
+      <form action={deleteEntityRelationAction}>
+        <input type="hidden" name="redirect_to" value={redirectTo} />
+        <input type="hidden" name="relation_id" value={relation.id} />
+        <Button
+          type="submit"
+          size="sm"
+          variant="ghost"
+          className="h-8 px-2 text-destructive hover:text-destructive"
+        >
+          Remove relation
+        </Button>
+      </form>
+    </div>
   )
 }
 

--- a/app/ponix/entities/[id]/page.tsx
+++ b/app/ponix/entities/[id]/page.tsx
@@ -5,12 +5,15 @@ import { notFound } from "next/navigation"
 import { CmsDetailPage } from "@/app/ponix/_components/cms-detail"
 import {
   EntityRelationsCard,
+  RelationMutationNotice,
+  relationMutationState,
   SectionEntityRelationsCard,
 } from "@/app/ponix/_components/cms-relations"
 import { requireCmsAdmin } from "@/lib/cms/auth"
 import {
   loadCmsEntityDetail,
   loadCmsEntityRelations,
+  loadCmsRelationEditorOptions,
 } from "@/lib/cms/content"
 
 export const metadata: Metadata = {
@@ -23,18 +26,23 @@ export const metadata: Metadata = {
 
 type PonixEntityRecordPageProps = {
   params: Promise<{ id: string }>
+  searchParams?: Promise<Record<string, string | string[] | undefined>>
 }
 
 export default async function PonixEntityRecordPage({
   params,
+  searchParams,
 }: PonixEntityRecordPageProps) {
   const { id } = await params
 
   await requireCmsAdmin(`/ponix/entities/${id}`)
-  const [detail, relations] = await Promise.all([
+  const [detail, relations, options, search] = await Promise.all([
     loadCmsEntityDetail(id),
     loadCmsEntityRelations(id),
+    loadCmsRelationEditorOptions(),
+    searchParams,
   ])
+  const mutation = relationMutationState(search)
 
   if (!detail) {
     notFound()
@@ -54,20 +62,35 @@ export default async function PonixEntityRecordPage({
         </Link>
       }
     >
+      <RelationMutationNotice
+        message={mutation.message}
+        error={mutation.error}
+      />
       <SectionEntityRelationsCard
         title="Section placements"
         description="Sections that curate this entity."
         relations={relations.sectionEntities}
+        editable
+        editorOptions={options}
+        fixedEntityId={id}
+        redirectTo={`/ponix/entities/${id}`}
       />
       <EntityRelationsCard
         title="Outgoing relations"
         description="Entities linked from this record."
         relations={relations.outgoingEntityRelations}
+        editable
+        editorOptions={options}
+        fixedFromEntityId={id}
+        redirectTo={`/ponix/entities/${id}`}
       />
       <EntityRelationsCard
         title="Incoming relations"
         description="Entities that link to this record."
         relations={relations.incomingEntityRelations}
+        editable
+        allowAdd={false}
+        redirectTo={`/ponix/entities/${id}`}
       />
     </CmsDetailPage>
   )

--- a/app/ponix/relations/actions.ts
+++ b/app/ponix/relations/actions.ts
@@ -1,0 +1,331 @@
+"use server"
+
+import { revalidatePath, updateTag } from "next/cache"
+import { redirect } from "next/navigation"
+
+import { requireCmsAdmin } from "@/lib/cms/auth"
+import { PUBLIC_CONTENT_CACHE_TAG } from "@/lib/data/public-cache"
+import { createClient } from "@/lib/supabase/server"
+import type { Database, Json } from "@/lib/supabase/types"
+
+type SectionEntityInsert =
+  Database["public"]["Tables"]["section_entities"]["Insert"]
+type SectionEntityUpdate =
+  Database["public"]["Tables"]["section_entities"]["Update"]
+type EntityRelationInsert =
+  Database["public"]["Tables"]["entity_relations"]["Insert"]
+type EntityRelationUpdate =
+  Database["public"]["Tables"]["entity_relations"]["Update"]
+
+const uuidPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+function stringField(formData: FormData, key: string) {
+  const value = formData.get(key)
+  return typeof value === "string" ? value.trim() : ""
+}
+
+function safeRedirectPath(formData: FormData) {
+  const value = stringField(formData, "redirect_to")
+  return value.startsWith("/ponix") && !value.startsWith("//")
+    ? value
+    : "/ponix/relations"
+}
+
+function redirectWithParams(path: string, params: Record<string, string>): never {
+  const search = new URLSearchParams(params)
+  redirect(`${path}?${search.toString()}`)
+}
+
+function parseUuid(formData: FormData, key: string, label: string) {
+  const value = stringField(formData, key)
+  if (!uuidPattern.test(value)) {
+    throw new Error(`${label} is required.`)
+  }
+
+  return value
+}
+
+function parseText(formData: FormData, key: string, label: string) {
+  const value = stringField(formData, key)
+  if (!value) {
+    throw new Error(`${label} is required.`)
+  }
+
+  return value
+}
+
+function parseSortOrder(formData: FormData) {
+  const raw = stringField(formData, "sort_order")
+  if (!raw) return 0
+
+  const value = Number(raw)
+  if (!Number.isInteger(value)) {
+    throw new Error("Sort order must be an integer.")
+  }
+
+  return value
+}
+
+function parseProps(formData: FormData): Json {
+  const raw = stringField(formData, "props")
+  if (!raw) return {}
+
+  try {
+    const parsed = JSON.parse(raw) as Json
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("Relation props must be a JSON object.")
+    }
+
+    return parsed
+  } catch {
+    throw new Error("Relation props must be valid JSON object syntax.")
+  }
+}
+
+function relationError(path: string, error: unknown): never {
+  redirectWithParams(path, {
+    relation_error:
+      error instanceof Error ? error.message : "Relation mutation failed.",
+  })
+}
+
+function relationSuccess(path: string, message: string): never {
+  redirectWithParams(path, {
+    relation_message: message,
+  })
+}
+
+function revalidateRelationSurfaces(paths: string[]) {
+  updateTag(PUBLIC_CONTENT_CACHE_TAG)
+
+  for (const path of [
+    "/",
+    "/performances",
+    "/performances/updates",
+    "/videos",
+    "/photos",
+    "/history",
+    "/ponix",
+    "/ponix/relations",
+    "/ponix/sections",
+    "/ponix/entities",
+    ...paths,
+  ]) {
+    revalidatePath(path)
+  }
+}
+
+export async function addSectionEntityRelationAction(formData: FormData) {
+  const redirectTo = safeRedirectPath(formData)
+
+  try {
+    await requireCmsAdmin(redirectTo)
+    const supabase = await createClient()
+    const payload: SectionEntityInsert = {
+      section_id: parseUuid(formData, "section_id", "Section"),
+      entity_id: parseUuid(formData, "entity_id", "Entity"),
+      relation_type: parseText(formData, "relation_type", "Relation type"),
+      slot: stringField(formData, "slot") || "default",
+      sort_order: parseSortOrder(formData),
+      props: parseProps(formData),
+    }
+    const { error } = await supabase
+      .from("section_entities")
+      .upsert(payload, {
+        onConflict: "section_id,entity_id,relation_type,slot",
+      })
+
+    if (error) throw new Error(error.message)
+
+    revalidateRelationSurfaces([
+      `/ponix/sections/${payload.section_id}`,
+      `/ponix/entities/${payload.entity_id}`,
+    ])
+    relationSuccess(redirectTo, "Section relation saved.")
+  } catch (error) {
+    relationError(redirectTo, error)
+  }
+}
+
+export async function updateSectionEntityRelationAction(formData: FormData) {
+  const redirectTo = safeRedirectPath(formData)
+
+  try {
+    await requireCmsAdmin(redirectTo)
+    const supabase = await createClient()
+    const relationId = parseUuid(formData, "relation_id", "Relation")
+    const update: SectionEntityUpdate = {
+      sort_order: parseSortOrder(formData),
+    }
+    const { data: relation, error: loadError } = await supabase
+      .from("section_entities")
+      .select("section_id, entity_id")
+      .eq("id", relationId)
+      .maybeSingle()
+
+    if (loadError || !relation) {
+      throw new Error(loadError?.message ?? "Relation not found.")
+    }
+
+    const { error } = await supabase
+      .from("section_entities")
+      .update(update)
+      .eq("id", relationId)
+
+    if (error) throw new Error(error.message)
+
+    revalidateRelationSurfaces([
+      `/ponix/sections/${relation.section_id}`,
+      `/ponix/entities/${relation.entity_id}`,
+    ])
+    relationSuccess(redirectTo, "Section relation order saved.")
+  } catch (error) {
+    relationError(redirectTo, error)
+  }
+}
+
+export async function deleteSectionEntityRelationAction(formData: FormData) {
+  const redirectTo = safeRedirectPath(formData)
+
+  try {
+    await requireCmsAdmin(redirectTo)
+    const supabase = await createClient()
+    const relationId = parseUuid(formData, "relation_id", "Relation")
+    const { data: relation, error: loadError } = await supabase
+      .from("section_entities")
+      .select("section_id, entity_id")
+      .eq("id", relationId)
+      .maybeSingle()
+
+    if (loadError || !relation) {
+      throw new Error(loadError?.message ?? "Relation not found.")
+    }
+
+    const { error } = await supabase
+      .from("section_entities")
+      .delete()
+      .eq("id", relationId)
+
+    if (error) throw new Error(error.message)
+
+    revalidateRelationSurfaces([
+      `/ponix/sections/${relation.section_id}`,
+      `/ponix/entities/${relation.entity_id}`,
+    ])
+    relationSuccess(redirectTo, "Section relation removed.")
+  } catch (error) {
+    relationError(redirectTo, error)
+  }
+}
+
+export async function addEntityRelationAction(formData: FormData) {
+  const redirectTo = safeRedirectPath(formData)
+
+  try {
+    const admin = await requireCmsAdmin(redirectTo)
+    const supabase = await createClient()
+    const fromEntityId = parseUuid(formData, "from_entity_id", "From entity")
+    const toEntityId = parseUuid(formData, "to_entity_id", "To entity")
+
+    if (fromEntityId === toEntityId) {
+      throw new Error("Entity relations cannot point to the same entity.")
+    }
+
+    const payload: EntityRelationInsert = {
+      from_entity_id: fromEntityId,
+      to_entity_id: toEntityId,
+      relation_type: parseText(formData, "relation_type", "Relation type"),
+      slot: stringField(formData, "slot") || "default",
+      sort_order: parseSortOrder(formData),
+      props: parseProps(formData),
+      created_by_member_id: admin.id,
+    }
+    const { error } = await supabase
+      .from("entity_relations")
+      .upsert(payload, {
+        onConflict: "from_entity_id,to_entity_id,relation_type,slot",
+      })
+
+    if (error) throw new Error(error.message)
+
+    revalidateRelationSurfaces([
+      `/ponix/entities/${fromEntityId}`,
+      `/ponix/entities/${toEntityId}`,
+    ])
+    relationSuccess(redirectTo, "Entity relation saved.")
+  } catch (error) {
+    relationError(redirectTo, error)
+  }
+}
+
+export async function updateEntityRelationAction(formData: FormData) {
+  const redirectTo = safeRedirectPath(formData)
+
+  try {
+    await requireCmsAdmin(redirectTo)
+    const supabase = await createClient()
+    const relationId = parseUuid(formData, "relation_id", "Relation")
+    const update: EntityRelationUpdate = {
+      sort_order: parseSortOrder(formData),
+    }
+    const { data: relation, error: loadError } = await supabase
+      .from("entity_relations")
+      .select("from_entity_id, to_entity_id")
+      .eq("id", relationId)
+      .maybeSingle()
+
+    if (loadError || !relation) {
+      throw new Error(loadError?.message ?? "Relation not found.")
+    }
+
+    const { error } = await supabase
+      .from("entity_relations")
+      .update(update)
+      .eq("id", relationId)
+
+    if (error) throw new Error(error.message)
+
+    revalidateRelationSurfaces([
+      `/ponix/entities/${relation.from_entity_id}`,
+      `/ponix/entities/${relation.to_entity_id}`,
+    ])
+    relationSuccess(redirectTo, "Entity relation order saved.")
+  } catch (error) {
+    relationError(redirectTo, error)
+  }
+}
+
+export async function deleteEntityRelationAction(formData: FormData) {
+  const redirectTo = safeRedirectPath(formData)
+
+  try {
+    await requireCmsAdmin(redirectTo)
+    const supabase = await createClient()
+    const relationId = parseUuid(formData, "relation_id", "Relation")
+    const { data: relation, error: loadError } = await supabase
+      .from("entity_relations")
+      .select("from_entity_id, to_entity_id")
+      .eq("id", relationId)
+      .maybeSingle()
+
+    if (loadError || !relation) {
+      throw new Error(loadError?.message ?? "Relation not found.")
+    }
+
+    const { error } = await supabase
+      .from("entity_relations")
+      .delete()
+      .eq("id", relationId)
+
+    if (error) throw new Error(error.message)
+
+    revalidateRelationSurfaces([
+      `/ponix/entities/${relation.from_entity_id}`,
+      `/ponix/entities/${relation.to_entity_id}`,
+    ])
+    relationSuccess(redirectTo, "Entity relation removed.")
+  } catch (error) {
+    relationError(redirectTo, error)
+  }
+}

--- a/app/ponix/relations/page.tsx
+++ b/app/ponix/relations/page.tsx
@@ -3,11 +3,16 @@ import type { Metadata } from "next"
 import {
   EntityRelationsCard,
   PageSectionRelationsCard,
+  RelationMutationNotice,
+  relationMutationState,
   SectionEntityRelationsCard,
 } from "@/app/ponix/_components/cms-relations"
 import { CmsListPage } from "@/app/ponix/_components/cms-list"
 import { requireCmsAdmin } from "@/lib/cms/auth"
-import { loadCmsRelationGraph } from "@/lib/cms/content"
+import {
+  loadCmsRelationEditorOptions,
+  loadCmsRelationGraph,
+} from "@/lib/cms/content"
 
 export const metadata: Metadata = {
   title: "PONIX Relations | 브레멘 Bremen",
@@ -17,9 +22,20 @@ export const metadata: Metadata = {
   },
 }
 
-export default async function PonixRelationsPage() {
+type PonixRelationsPageProps = {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>
+}
+
+export default async function PonixRelationsPage({
+  searchParams,
+}: PonixRelationsPageProps) {
   await requireCmsAdmin("/ponix/relations")
-  const graph = await loadCmsRelationGraph()
+  const [graph, options, params] = await Promise.all([
+    loadCmsRelationGraph(),
+    loadCmsRelationEditorOptions(),
+    searchParams,
+  ])
+  const mutation = relationMutationState(params)
 
   return (
     <CmsListPage
@@ -28,9 +44,23 @@ export default async function PonixRelationsPage() {
       description="The content graph that connects pages, sections, and reusable entities."
     >
       <div className="space-y-6">
+        <RelationMutationNotice
+          message={mutation.message}
+          error={mutation.error}
+        />
         <PageSectionRelationsCard relationList={graph.pageSections} />
-        <SectionEntityRelationsCard relationList={graph.sectionEntities} />
-        <EntityRelationsCard relationList={graph.entityRelations} />
+        <SectionEntityRelationsCard
+          relationList={graph.sectionEntities}
+          editable
+          editorOptions={options}
+          redirectTo="/ponix/relations"
+        />
+        <EntityRelationsCard
+          relationList={graph.entityRelations}
+          editable
+          editorOptions={options}
+          redirectTo="/ponix/relations"
+        />
       </div>
     </CmsListPage>
   )

--- a/app/ponix/sections/[id]/page.tsx
+++ b/app/ponix/sections/[id]/page.tsx
@@ -5,10 +5,13 @@ import { notFound } from "next/navigation"
 import { CmsDetailPage } from "@/app/ponix/_components/cms-detail"
 import {
   PageSectionRelationsCard,
+  RelationMutationNotice,
+  relationMutationState,
   SectionEntityRelationsCard,
 } from "@/app/ponix/_components/cms-relations"
 import { requireCmsAdmin } from "@/lib/cms/auth"
 import {
+  loadCmsRelationEditorOptions,
   loadCmsSectionDetail,
   loadCmsSectionRelations,
 } from "@/lib/cms/content"
@@ -23,18 +26,23 @@ export const metadata: Metadata = {
 
 type PonixSectionRecordPageProps = {
   params: Promise<{ id: string }>
+  searchParams?: Promise<Record<string, string | string[] | undefined>>
 }
 
 export default async function PonixSectionRecordPage({
   params,
+  searchParams,
 }: PonixSectionRecordPageProps) {
   const { id } = await params
 
   await requireCmsAdmin(`/ponix/sections/${id}`)
-  const [detail, relations] = await Promise.all([
+  const [detail, relations, options, search] = await Promise.all([
     loadCmsSectionDetail(id),
     loadCmsSectionRelations(id),
+    loadCmsRelationEditorOptions(),
+    searchParams,
   ])
+  const mutation = relationMutationState(search)
 
   if (!detail) {
     notFound()
@@ -54,6 +62,10 @@ export default async function PonixSectionRecordPage({
         </Link>
       }
     >
+      <RelationMutationNotice
+        message={mutation.message}
+        error={mutation.error}
+      />
       <PageSectionRelationsCard
         title="Page placements"
         description="Pages that include this section."
@@ -63,6 +75,10 @@ export default async function PonixSectionRecordPage({
         title="Curated entities"
         description="Entities attached to this section by slot and order."
         relations={relations.sectionEntities}
+        editable
+        editorOptions={options}
+        fixedSectionId={id}
+        redirectTo={`/ponix/sections/${id}`}
       />
     </CmsDetailPage>
   )

--- a/lib/cms/content.ts
+++ b/lib/cms/content.ts
@@ -4,6 +4,7 @@ import type { Database, Json } from "@/lib/supabase/types"
 import { getCmsSchema } from "./schema-registry"
 
 const ENTITY_LIST_LIMIT = 200
+const RELATION_ENTITY_OPTION_LIMIT = 1000
 const RELATION_LIST_LIMIT = 300
 
 type PageRow = Database["public"]["Tables"]["pages"]["Row"]
@@ -166,6 +167,13 @@ export type CmsRelationGraph = {
   pageSections: CmsRelationList<CmsPageSectionRelation>
   sectionEntities: CmsRelationList<CmsSectionEntityRelation>
   entityRelations: CmsRelationList<CmsEntityRelation>
+}
+
+export type CmsRelationEditorOptions = {
+  sections: CmsSectionSummary[]
+  entities: CmsEntitySummary[]
+  entityCount: number | null
+  entityLimit: number
 }
 
 export type CmsPageRelationContext = {
@@ -566,6 +574,64 @@ export async function loadCmsEntities(): Promise<CmsEntityList> {
       sortAt: entity.sort_at,
       updatedAt: entity.updated_at,
     })),
+  }
+}
+
+export async function loadCmsRelationEditorOptions(): Promise<CmsRelationEditorOptions> {
+  const supabase = await createClient()
+  const [sectionsResult, entitiesResult] = await Promise.all([
+    supabase
+      .from("sections")
+      .select("id, key, section_type, schema_key, title, subtitle, published, updated_at")
+      .order("key", { ascending: true }),
+    supabase
+      .from("entities")
+      .select(
+        "id, entity_type, schema_key, slug, title, subtitle, thumbnail_url, published, sort_at, updated_at",
+        { count: "exact" },
+      )
+      .order("entity_type", { ascending: true })
+      .order("sort_at", { ascending: false })
+      .range(0, RELATION_ENTITY_OPTION_LIMIT - 1),
+  ])
+
+  if (sectionsResult.error) {
+    throw new Error(
+      `Failed to load CMS section options: ${sectionsResult.error.message}`,
+    )
+  }
+
+  if (entitiesResult.error) {
+    throw new Error(
+      `Failed to load CMS entity options: ${entitiesResult.error.message}`,
+    )
+  }
+
+  return {
+    sections: (sectionsResult.data ?? []).map((section) => ({
+      ...schemaSummary(section.schema_key),
+      id: section.id,
+      key: section.key,
+      sectionType: section.section_type,
+      title: section.title,
+      subtitle: section.subtitle,
+      published: section.published,
+      updatedAt: section.updated_at,
+    })),
+    entities: (entitiesResult.data ?? []).map((entity) => ({
+      ...schemaSummary(entity.schema_key),
+      id: entity.id,
+      entityType: entity.entity_type,
+      slug: entity.slug,
+      title: entity.title,
+      subtitle: entity.subtitle,
+      thumbnailUrl: entity.thumbnail_url,
+      published: entity.published,
+      sortAt: entity.sort_at,
+      updatedAt: entity.updated_at,
+    })),
+    entityCount: entitiesResult.count,
+    entityLimit: RELATION_ENTITY_OPTION_LIMIT,
   }
 }
 


### PR DESCRIPTION
Closes #19

Summary
- Adds guarded server actions for `section_entities` and `entity_relations` mutations.
- Adds CMS forms to create section-entity and entity-entity relation rows from `/ponix/relations`.
- Enables context-aware relation editing from section and entity detail pages.
- Supports relation removal and sort-order edits without deleting linked entities or sections.
- Revalidates public content cache and affected CMS detail/list routes after relation mutations.
- Loads relation editor options from existing section/entity rows; no schema changes.

Checks
- `git diff --check`
- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `pnpm run build`

Supabase impact
- Content-row mutations only: `section_entities`, `entity_relations`.
- No migration, RLS, storage policy, auth config, or service-role usage.
- Deletes target relation rows by id only; linked entities/sections are never deleted.

Vercel impact
- Added branch-scoped Preview env for `cms/19-relation-editor`: `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`.