### PR TITLE
[CMS] Add entity creation flow

### DIFF
--- a/app/ponix/_components/cms-entity-create-form.tsx
+++ b/app/ponix/_components/cms-entity-create-form.tsx
@@ -1,0 +1,242 @@
+import Link from "next/link"
+
+import { createCmsEntityAction } from "@/app/ponix/entities/actions"
+import { renderFieldInput } from "@/app/ponix/_components/cms-entity-form"
+import { ProfileImageInput } from "@/components/profile-image-input"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Label } from "@/components/ui/label"
+import type { CmsSchemaDefinition } from "@/lib/cms/schema-registry"
+import {
+  cmsEntityFieldInputName,
+  entityTypeFromSchemaKey,
+  getEditableEntityFields,
+  type CmsEditableEntityField,
+} from "@/lib/cms/entity-editor"
+
+export function CmsEntityCreatePage({
+  schema,
+  error,
+}: {
+  schema: CmsSchemaDefinition
+  error?: string
+}) {
+  const editableFields = getEditableEntityFields(schema.schemaKey)
+  const columnFields = editableFields.filter((field) => field.source === "column")
+  const dataFields = editableFields.filter((field) => field.source === "data")
+  const formId = `cms-entity-create-${schema.schemaKey.replace(/[^a-z0-9]+/gi, "-")}`
+  const entityType = entityTypeFromSchemaKey(schema.schemaKey)
+
+  return (
+    <main className="relative min-h-[calc(100vh-5rem)] overflow-hidden">
+      <div className="pointer-events-none absolute inset-0 -z-10">
+        <div className="absolute right-[-10rem] top-10 h-96 w-96 rounded-full bg-accent/10 blur-3xl" />
+        <div className="absolute left-[-8rem] bottom-0 h-80 w-80 rounded-full bg-muted blur-3xl" />
+      </div>
+
+      <section className="mx-auto max-w-5xl px-6 py-16 md:px-8 md:py-24">
+        <div className="mb-10 flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+          <div>
+            <p className="caps mb-5">PONIX / New entity</p>
+            <h1 className="font-serif text-[clamp(3.25rem,8vw,6.5rem)] italic leading-[0.84] tracking-tight">
+              {schema.label}
+            </h1>
+            <p className="mt-5 max-w-2xl text-sm leading-relaxed text-muted-foreground md:text-base">
+              Create a reusable content record, then place it into sections or
+              link it to related entities.
+            </p>
+            <div className="mt-6 flex flex-wrap items-center gap-2">
+              <Badge variant="outline" className="rounded-full font-mono">
+                {entityType}
+              </Badge>
+              <Badge variant="secondary" className="rounded-full">
+                {schema.schemaKey}
+              </Badge>
+            </div>
+          </div>
+          <Button asChild variant="outline" className="w-fit rounded-full">
+            <Link href="/ponix/entities/new">Change schema</Link>
+          </Button>
+        </div>
+
+        <form id={formId} action={createCmsEntityAction} className="space-y-6">
+          <input type="hidden" name="schema_key" value={schema.schemaKey} />
+
+          {error && (
+            <Alert variant="destructive">
+              <AlertTitle>Create failed</AlertTitle>
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          <Card className="rounded-md bg-card/95 shadow-xl">
+            <CardHeader className="border-b">
+              <CardTitle className="font-serif text-3xl italic">
+                Locked identity
+              </CardTitle>
+              <CardDescription>
+                The schema determines renderer behavior. Relations can be added
+                after the entity exists.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="grid gap-4 px-6 py-6 md:grid-cols-3">
+              <ReadonlyMeta label="Entity type" value={entityType} />
+              <ReadonlyMeta label="Schema" value={schema.schemaKey} />
+              <ReadonlyMeta label="Description" value={schema.description} />
+            </CardContent>
+          </Card>
+
+          <ThumbnailCard />
+
+          <CreateEditorCard
+            title="Entity fields"
+            description="Shared columns used by cards, lists, and detail pages."
+            fields={columnFields}
+          />
+
+          <CreateEditorCard
+            title="Schema data"
+            description="Typed JSON fields registered for this entity schema."
+            fields={dataFields}
+          />
+
+          <div className="flex flex-col gap-3 rounded-md border bg-card/95 p-4 shadow-xl sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-sm text-muted-foreground">
+              Creation inserts one entity row only. Section placement is a
+              separate relation step.
+            </p>
+            <div className="flex gap-2">
+              <Button asChild type="button" variant="outline">
+                <Link href="/ponix/entities">Cancel</Link>
+              </Button>
+              <Button type="submit">Create entity</Button>
+            </div>
+          </div>
+        </form>
+      </section>
+    </main>
+  )
+}
+
+function ThumbnailCard() {
+  return (
+    <Card className="rounded-md bg-card/95 shadow-xl">
+      <CardHeader className="border-b">
+        <CardTitle className="font-serif text-3xl italic">
+          Thumbnail upload
+        </CardTitle>
+        <CardDescription>
+          An uploaded image is stored in Supabase Storage and saved as the
+          entity thumbnail URL.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="px-6 py-6">
+        <div className="max-w-xl space-y-2">
+          <Label htmlFor="thumbnail_file">Upload image</Label>
+          <ProfileImageInput id="thumbnail_file" name="thumbnail_file" />
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            You can also paste a URL in the thumbnail field below.
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function CreateEditorCard({
+  title,
+  description,
+  fields,
+}: {
+  title: string
+  description: string
+  fields: CmsEditableEntityField[]
+}) {
+  return (
+    <Card className="rounded-md bg-card/95 shadow-xl">
+      <CardHeader className="border-b">
+        <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+          <div>
+            <CardTitle className="font-serif text-3xl italic">{title}</CardTitle>
+            <CardDescription>{description}</CardDescription>
+          </div>
+          <p className="caps text-muted-foreground">{fields.length} fields</p>
+        </div>
+      </CardHeader>
+      <CardContent className="grid gap-5 px-6 py-6 md:grid-cols-2">
+        {fields.length > 0 ? (
+          fields.map((field) => (
+            <CreateEditorField key={`${field.source}:${field.key}`} field={field} />
+          ))
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            No editable fields in this group.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function CreateEditorField({ field }: { field: CmsEditableEntityField }) {
+  const id = `new-entity-${field.source}-${field.key}`
+  const name = cmsEntityFieldInputName(field)
+  const wide =
+    field.type === "textarea" ||
+    field.type === "json" ||
+    field.type === "string-list"
+  const value = createDefaultValue(field)
+
+  return (
+    <div className={wide ? "space-y-2 md:col-span-2" : "space-y-2"}>
+      <div className="flex items-center gap-2">
+        <Label htmlFor={id}>{field.label}</Label>
+        {field.required && (
+          <Badge variant="outline" className="rounded-full">
+            Required
+          </Badge>
+        )}
+      </div>
+      {renderFieldInput({ field, id, name, value })}
+      <p className="font-mono text-xs text-muted-foreground">
+        {field.source}.{field.key}
+      </p>
+      {field.description && (
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          {field.description}
+        </p>
+      )}
+    </div>
+  )
+}
+
+function createDefaultValue(field: CmsEditableEntityField) {
+  if (field.source === "column" && field.key === "sort_at") {
+    return new Date().toISOString().slice(0, 16)
+  }
+
+  if (field.type === "boolean") {
+    return false
+  }
+
+  return ""
+}
+
+function ReadonlyMeta({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border bg-background/60 p-4">
+      <p className="caps mb-2 text-muted-foreground">{label}</p>
+      <p className="break-words text-xs leading-relaxed text-muted-foreground">
+        {value}
+      </p>
+    </div>
+  )
+}

--- a/app/ponix/_components/cms-entity-form.tsx
+++ b/app/ponix/_components/cms-entity-form.tsx
@@ -267,7 +267,7 @@ function EditorField({
   )
 }
 
-function renderFieldInput({
+export function renderFieldInput({
   field,
   id,
   name,

--- a/app/ponix/_components/cms-list.tsx
+++ b/app/ponix/_components/cms-list.tsx
@@ -15,11 +15,13 @@ export function CmsListPage({
   eyebrow,
   title,
   description,
+  actions,
   children,
 }: {
   eyebrow: string
   title: string
   description: string
+  actions?: ReactNode
   children: ReactNode
 }) {
   return (
@@ -40,9 +42,12 @@ export function CmsListPage({
               {description}
             </p>
           </div>
-          <Button asChild variant="outline" className="w-fit rounded-full">
-            <Link href="/ponix">PONIX Home</Link>
-          </Button>
+          <div className="flex flex-wrap items-center gap-2">
+            {actions}
+            <Button asChild variant="outline" className="w-fit rounded-full">
+              <Link href="/ponix">PONIX Home</Link>
+            </Button>
+          </div>
         </div>
         {children}
       </section>

--- a/app/ponix/entities/actions.ts
+++ b/app/ponix/entities/actions.ts
@@ -6,7 +6,9 @@ import { redirect } from "next/navigation"
 import { requireCmsAdmin } from "@/lib/cms/auth"
 import {
   cmsEntityFieldInputName,
+  entityTypeFromSchemaKey,
   getEditableEntityFields,
+  getEntityCreationSchema,
   getEntityEditorSchema,
   jsonObject,
   type CmsEditableEntityField,
@@ -17,6 +19,7 @@ import { createClient } from "@/lib/supabase/server"
 import type { Database, Json } from "@/lib/supabase/types"
 
 type EntityUpdate = Database["public"]["Tables"]["entities"]["Update"]
+type EntityInsert = Database["public"]["Tables"]["entities"]["Insert"]
 type EntityRow = Database["public"]["Tables"]["entities"]["Row"]
 
 type ParsedValue =
@@ -30,7 +33,7 @@ type ParsedValue =
       error: string
     }
 
-const maxThumbnailSize = 8 * 1024 * 1024
+const maxThumbnailSize = 5 * 1024 * 1024
 
 function stringField(formData: FormData, key: string) {
   const value = formData.get(key)
@@ -38,8 +41,33 @@ function stringField(formData: FormData, key: string) {
 }
 
 function redirectWithParams(path: string, params: Record<string, string>): never {
-  const search = new URLSearchParams(params)
-  redirect(`${path}?${search.toString()}`)
+  const [pathname, currentSearch = ""] = path.split("?")
+  const search = new URLSearchParams(currentSearch)
+
+  for (const [key, value] of Object.entries(params)) {
+    search.set(key, value)
+  }
+
+  redirect(`${pathname}?${search.toString()}`)
+}
+
+function revalidateEntitySurfaces(entityId?: string) {
+  revalidatePath("/")
+  revalidatePath("/performances")
+  revalidatePath("/performances/updates")
+  revalidatePath("/videos")
+  revalidatePath("/photos")
+  revalidatePath("/history")
+  updateTag(PUBLIC_CONTENT_CACHE_TAG)
+  revalidatePath("/ponix")
+  revalidatePath("/ponix/entities")
+  revalidatePath("/ponix/entities/new")
+  revalidatePath("/ponix/relations")
+
+  if (entityId) {
+    revalidatePath(`/ponix/entities/${entityId}`)
+    revalidatePath(`/ponix/entities/${entityId}/edit`)
+  }
 }
 
 function isSafeUrl(value: string) {
@@ -256,7 +284,7 @@ async function uploadThumbnailIfPresent({
 
   if (file.size > maxThumbnailSize) {
     redirectWithParams(editPath, {
-      error: "Thumbnail image must be 8MB or smaller.",
+      error: "Thumbnail image must be 5MB or smaller.",
     })
   }
 
@@ -277,6 +305,114 @@ async function uploadThumbnailIfPresent({
   }
 
   return supabase.storage.from(bucket).getPublicUrl(path).data.publicUrl
+}
+
+export async function createCmsEntityAction(formData: FormData) {
+  const schemaKey = stringField(formData, "schema_key")
+  const createPath = schemaKey
+    ? `/ponix/entities/new?schema=${encodeURIComponent(schemaKey)}`
+    : "/ponix/entities/new"
+  const admin = await requireCmsAdmin(createPath)
+
+  const schema = getEntityCreationSchema(schemaKey)
+  if (!schema) {
+    redirectWithParams("/ponix/entities/new", {
+      error: "Choose a schema that can be created from CMS.",
+    })
+  }
+
+  const fields = getEditableEntityFields(schema.schemaKey)
+  const data: CmsJsonObject = {}
+  const insert: EntityInsert = {
+    data,
+    entity_type: entityTypeFromSchemaKey(schema.schemaKey),
+    owner_member_id: admin.id,
+    published: false,
+    schema_key: schema.schemaKey,
+    sort_at: new Date().toISOString(),
+    title: "",
+  }
+
+  for (const field of fields) {
+    const parsed = parseFieldValue(formData, field)
+
+    if (!parsed.ok) {
+      redirectWithParams(createPath, {
+        error: parsed.error,
+      })
+    }
+
+    if (field.source === "data") {
+      updateDataValue(data, field, parsed)
+      continue
+    }
+
+    if (field.key === "published") {
+      insert.published = Boolean(parsed.value)
+    }
+
+    if (field.key === "slug") {
+      insert.slug = parsed.value === null ? null : String(parsed.value)
+    }
+
+    if (field.key === "title") {
+      insert.title = String(parsed.value)
+    }
+
+    if (field.key === "subtitle") {
+      insert.subtitle = parsed.value === null ? null : String(parsed.value)
+    }
+
+    if (field.key === "summary") {
+      insert.summary = parsed.value === null ? null : String(parsed.value)
+    }
+
+    if (field.key === "thumbnail_url") {
+      insert.thumbnail_url = parsed.value === null ? null : String(parsed.value)
+    }
+
+    if (field.key === "sort_at") {
+      insert.sort_at = new Date(String(parsed.value)).toISOString()
+    }
+  }
+
+  const supabase = await createClient()
+  const { data: created, error: insertError } = await supabase
+    .from("entities")
+    .insert(insert)
+    .select("*")
+    .single()
+
+  if (insertError || !created) {
+    redirectWithParams(createPath, {
+      error: "Entity creation failed.",
+    })
+  }
+
+  const editPath = `/ponix/entities/${created.id}/edit`
+  const uploadedThumbnailUrl = await uploadThumbnailIfPresent({
+    supabase,
+    entity: created,
+    formData,
+    editPath,
+  })
+
+  if (uploadedThumbnailUrl) {
+    const { error: thumbnailUpdateError } = await supabase
+      .from("entities")
+      .update({ thumbnail_url: uploadedThumbnailUrl })
+      .eq("id", created.id)
+
+    if (thumbnailUpdateError) {
+      redirectWithParams(editPath, {
+        error: "Thumbnail URL save failed.",
+      })
+    }
+  }
+
+  revalidateEntitySurfaces(created.id)
+
+  redirect(`/ponix/entities/${created.id}`)
 }
 
 export async function updateCmsEntityAction(formData: FormData) {
@@ -382,17 +518,7 @@ export async function updateCmsEntityAction(formData: FormData) {
     })
   }
 
-  revalidatePath("/")
-  revalidatePath("/performances")
-  revalidatePath("/performances/updates")
-  revalidatePath("/videos")
-  revalidatePath("/photos")
-  revalidatePath("/history")
-  updateTag(PUBLIC_CONTENT_CACHE_TAG)
-  revalidatePath("/ponix")
-  revalidatePath("/ponix/entities")
-  revalidatePath(`/ponix/entities/${entityId}`)
-  revalidatePath("/ponix/relations")
+  revalidateEntitySurfaces(entityId)
 
   redirect(`/ponix/entities/${entityId}`)
 }

--- a/app/ponix/entities/new/page.tsx
+++ b/app/ponix/entities/new/page.tsx
@@ -1,0 +1,142 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+
+import { CmsEntityCreatePage } from "@/app/ponix/_components/cms-entity-create-form"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { requireCmsAdmin } from "@/lib/cms/auth"
+import {
+  entityTypeFromSchemaKey,
+  getEntityCreationSchema,
+  getEntityCreationSchemas,
+} from "@/lib/cms/entity-editor"
+
+export const metadata: Metadata = {
+  title: "New PONIX Entity | 브레멘 Bremen",
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
+
+type PonixNewEntityPageProps = {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>
+}
+
+function firstParam(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value
+}
+
+export default async function PonixNewEntityPage({
+  searchParams,
+}: PonixNewEntityPageProps) {
+  const query = (await searchParams) ?? {}
+  const schemaKey = firstParam(query.schema)
+  const error = firstParam(query.error)
+
+  await requireCmsAdmin("/ponix/entities/new")
+
+  if (schemaKey) {
+    const schema = getEntityCreationSchema(schemaKey)
+
+    if (schema) {
+      return <CmsEntityCreatePage schema={schema} error={error} />
+    }
+  }
+
+  return (
+    <SchemaPickerPage
+      error={
+        schemaKey
+          ? `Schema ${schemaKey} cannot be created from CMS.`
+          : error
+      }
+    />
+  )
+}
+
+function SchemaPickerPage({ error }: { error?: string }) {
+  const schemas = getEntityCreationSchemas()
+
+  return (
+    <main className="relative min-h-[calc(100vh-5rem)] overflow-hidden">
+      <div className="pointer-events-none absolute inset-0 -z-10">
+        <div className="absolute right-[-10rem] top-10 h-96 w-96 rounded-full bg-accent/10 blur-3xl" />
+        <div className="absolute left-[-8rem] bottom-0 h-80 w-80 rounded-full bg-muted blur-3xl" />
+      </div>
+
+      <section className="mx-auto max-w-6xl px-6 py-16 md:px-8 md:py-24">
+        <div className="mb-10 flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+          <div>
+            <p className="caps mb-5">PONIX / New entity</p>
+            <h1 className="font-serif text-[clamp(3.25rem,8vw,6.5rem)] italic leading-[0.84] tracking-tight">
+              Choose schema
+            </h1>
+            <p className="mt-5 max-w-2xl text-sm leading-relaxed text-muted-foreground md:text-base">
+              Start with a registered entity schema. Imported source-only
+              schemas stay locked until their required source identifiers exist.
+            </p>
+          </div>
+          <Button asChild variant="outline" className="w-fit rounded-full">
+            <Link href="/ponix/entities">All entities</Link>
+          </Button>
+        </div>
+
+        <div className="space-y-6">
+          {error && (
+            <Alert variant="destructive">
+              <AlertTitle>Schema unavailable</AlertTitle>
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {schemas.map((schema) => (
+              <Card
+                key={schema.schemaKey}
+                className="rounded-md bg-card/95 shadow-xl transition-transform hover:-translate-y-1"
+              >
+                <CardHeader className="border-b">
+                  <div className="mb-3 flex flex-wrap items-center gap-2">
+                    <Badge variant="outline" className="rounded-full font-mono">
+                      {entityTypeFromSchemaKey(schema.schemaKey)}
+                    </Badge>
+                    <Badge variant="secondary" className="rounded-full">
+                      {schema.fields.length} fields
+                    </Badge>
+                  </div>
+                  <CardTitle className="font-serif text-3xl italic">
+                    {schema.label}
+                  </CardTitle>
+                  <CardDescription>{schema.description}</CardDescription>
+                </CardHeader>
+                <CardContent className="flex items-center justify-between gap-4 px-6 py-5">
+                  <p className="break-all font-mono text-xs text-muted-foreground">
+                    {schema.schemaKey}
+                  </p>
+                  <Button asChild size="sm" className="shrink-0 rounded-full">
+                    <Link
+                      href={`/ponix/entities/new?schema=${encodeURIComponent(
+                        schema.schemaKey,
+                      )}`}
+                    >
+                      Select
+                    </Link>
+                  </Button>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/app/ponix/entities/page.tsx
+++ b/app/ponix/entities/page.tsx
@@ -8,6 +8,7 @@ import {
   PublishBadge,
   SchemaBadge,
 } from "@/app/ponix/_components/cms-list"
+import { Button } from "@/components/ui/button"
 import {
   Table,
   TableBody,
@@ -38,7 +39,12 @@ export default async function PonixEntitiesPage() {
     <CmsListPage
       eyebrow="PONIX / Entities"
       title="Entities"
-      description="Reusable content records. This read-only list exposes schema registration status before edit forms are added."
+      description="Reusable content records that can be edited, linked, and placed into public sections."
+      actions={
+        <Button asChild className="w-fit rounded-full">
+          <Link href="/ponix/entities/new">New entity</Link>
+        </Button>
+      }
     >
       <CmsTableCard title="Entity records" meta={meta}>
         <Table>

--- a/lib/cms/entity-editor.ts
+++ b/lib/cms/entity-editor.ts
@@ -2,7 +2,7 @@ import type {
   CmsFieldDefinition,
   CmsSchemaDefinition,
 } from "@/lib/cms/schema-registry"
-import { getCmsSchema } from "@/lib/cms/schema-registry"
+import { getCmsSchema, getCmsSchemasByKind } from "@/lib/cms/schema-registry"
 import type { Database, Json } from "@/lib/supabase/types"
 
 type EntityRow = Database["public"]["Tables"]["entities"]["Row"]
@@ -37,6 +37,38 @@ export function getEntityEditorSchema(
   }
 
   return schema
+}
+
+export function entityTypeFromSchemaKey(schemaKey: string) {
+  return schemaKey.split("/")[0] || "entity"
+}
+
+function hasRequiredReadOnlyField(schema: CmsSchemaDefinition) {
+  return schema.fields.some((field) => {
+    if (!field.required || !field.readOnly) {
+      return false
+    }
+
+    return !(field.source === "column" && field.key === "entity_type")
+  })
+}
+
+export function getEntityCreationSchema(
+  schemaKey: string,
+): CmsSchemaDefinition | null {
+  const schema = getEntityEditorSchema(schemaKey)
+
+  if (!schema || hasRequiredReadOnlyField(schema)) {
+    return null
+  }
+
+  return schema
+}
+
+export function getEntityCreationSchemas() {
+  return getCmsSchemasByKind("entity")
+    .filter((schema) => getEntityCreationSchema(schema.schemaKey))
+    .sort((left, right) => left.label.localeCompare(right.label))
 }
 
 export function getEditableEntityFields(schemaKey: string) {


### PR DESCRIPTION
Closes #21

Summary
- Adds `/ponix/entities/new` with a registered schema picker and schema-specific entity creation form.
- Inserts guarded `entities` rows through a CMS server action; no relation rows are created automatically.
- Reuses schema-registered editable fields and blocks schemas with required read-only source identifiers from manual creation.
- Supports optional thumbnail upload during creation, saving the public Supabase Storage URL to `thumbnail_url`.
- Adds a New entity action to the PONIX entities list.
- Lowers thumbnail upload validation to 5MB to stay under the current 6MB Server Action body limit.

Checks
- `git diff --check`
- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `pnpm run build`

Supabase impact
- Content mutation only: inserts into `entities` and optional `thumbnail_url` update after Storage upload.
- Storage upload uses existing `photos`/`posters` buckets and existing policies.
- No migration, RLS policy, auth, bucket, or schema changes.