### PR TITLE
[CMS] Add page composition editor

### DIFF
--- a/app/ponix/_components/cms-relations.tsx
+++ b/app/ponix/_components/cms-relations.tsx
@@ -3,9 +3,12 @@ import type { ReactNode } from "react"
 
 import {
   addEntityRelationAction,
+  addPageSectionRelationAction,
   addSectionEntityRelationAction,
   deleteEntityRelationAction,
+  deletePageSectionRelationAction,
   deleteSectionEntityRelationAction,
+  updatePageSectionRelationAction,
   updateEntityRelationAction,
   updateSectionEntityRelationAction,
 } from "@/app/ponix/relations/actions"
@@ -101,13 +104,26 @@ export function PageSectionRelationsCard({
   description = "Ordered section placement for pages.",
   relationList,
   relations,
+  editable = false,
+  editorOptions,
+  redirectTo = "/ponix/relations",
+  fixedPageId,
+  fixedSectionId,
 }: {
   title?: string
   description?: string
   relationList?: CmsRelationList<CmsPageSectionRelation>
   relations?: CmsPageSectionRelation[]
+  editable?: boolean
+  editorOptions?: CmsRelationEditorOptions
+  redirectTo?: string
+  fixedPageId?: string
+  fixedSectionId?: string
 }) {
   const rows = relationList?.relations ?? relations ?? []
+  const nextSortOrder = fixedPageId
+    ? Math.max(0, ...rows.map((relation) => relation.sortOrder)) + 10
+    : 0
 
   return (
     <RelationCard
@@ -117,7 +133,20 @@ export function PageSectionRelationsCard({
       count={relationList?.count ?? rows.length}
       limit={relationList?.limit}
     >
-      <PageSectionRelationsTable relations={rows} />
+      {editable && editorOptions && (
+        <PageSectionAddForm
+          options={editorOptions}
+          redirectTo={redirectTo}
+          fixedPageId={fixedPageId}
+          fixedSectionId={fixedSectionId}
+          defaultSortOrder={nextSortOrder}
+        />
+      )}
+      <PageSectionRelationsTable
+        relations={rows}
+        editable={editable}
+        redirectTo={redirectTo}
+      />
     </RelationCard>
   )
 }
@@ -217,6 +246,56 @@ export function EntityRelationsCard({
         redirectTo={redirectTo}
       />
     </RelationCard>
+  )
+}
+
+function PageSectionAddForm({
+  options,
+  redirectTo,
+  fixedPageId,
+  fixedSectionId,
+  defaultSortOrder = 0,
+}: {
+  options: CmsRelationEditorOptions
+  redirectTo: string
+  fixedPageId?: string
+  fixedSectionId?: string
+  defaultSortOrder?: number
+}) {
+  return (
+    <form
+      action={addPageSectionRelationAction}
+      className="grid gap-4 border-b bg-muted/20 px-6 py-6 lg:grid-cols-[minmax(12rem,0.9fr)_minmax(14rem,1.2fr)_7rem_auto]"
+    >
+      <input type="hidden" name="redirect_to" value={redirectTo} />
+      {fixedPageId ? (
+        <input type="hidden" name="page_id" value={fixedPageId} />
+      ) : (
+        <FieldGroup label="Page">
+          <PageSelect name="page_id" pages={options.pages} />
+        </FieldGroup>
+      )}
+      {fixedSectionId ? (
+        <input type="hidden" name="section_id" value={fixedSectionId} />
+      ) : (
+        <FieldGroup label="Section">
+          <SectionSelect name="section_id" sections={options.sections} />
+        </FieldGroup>
+      )}
+      <FieldGroup label="Order">
+        <Input
+          name="sort_order"
+          type="number"
+          defaultValue={defaultSortOrder}
+          className="h-10 bg-background/80"
+        />
+      </FieldGroup>
+      <div className="flex items-end">
+        <Button type="submit" className="w-full rounded-full">
+          Add
+        </Button>
+      </div>
+    </form>
   )
 }
 
@@ -375,6 +454,32 @@ function FieldGroup({
   )
 }
 
+function PageSelect({
+  name,
+  pages,
+}: {
+  name: string
+  pages: CmsRelationEditorOptions["pages"]
+}) {
+  return (
+    <select
+      name={name}
+      required
+      className={selectClassName}
+      defaultValue=""
+    >
+      <option value="" disabled>
+        Select page
+      </option>
+      {pages.map((page) => (
+        <option key={page.id} value={page.id}>
+          {page.slug} · {page.title}
+        </option>
+      ))}
+    </select>
+  )
+}
+
 function SectionSelect({
   name,
   sections,
@@ -466,8 +571,12 @@ function RelationCard({
 
 function PageSectionRelationsTable({
   relations,
+  editable = false,
+  redirectTo = "/ponix/relations",
 }: {
   relations: CmsPageSectionRelation[]
+  editable?: boolean
+  redirectTo?: string
 }) {
   if (relations.length === 0) {
     return <EmptyRelationRows message="No page-section relations." />
@@ -483,6 +592,7 @@ function PageSectionRelationsTable({
           <TableHead>Renderer</TableHead>
           <TableHead>Schema</TableHead>
           <TableHead>Status</TableHead>
+          {editable && <TableHead>Manage</TableHead>}
         </TableRow>
       </TableHeader>
       <TableBody>
@@ -516,6 +626,14 @@ function PageSectionRelationsTable({
             <TableCell>
               <PageSectionStatus relation={relation} />
             </TableCell>
+            {editable && (
+              <TableCell>
+                <PageSectionRelationActions
+                  relation={relation}
+                  redirectTo={redirectTo}
+                />
+              </TableCell>
+            )}
           </TableRow>
         ))}
       </TableBody>
@@ -649,6 +767,48 @@ function EntityRelationsTable({
         ))}
       </TableBody>
     </Table>
+  )
+}
+
+function PageSectionRelationActions({
+  relation,
+  redirectTo,
+}: {
+  relation: CmsPageSectionRelation
+  redirectTo: string
+}) {
+  return (
+    <div className="flex min-w-44 flex-col gap-2">
+      <form
+        action={updatePageSectionRelationAction}
+        className="flex items-center gap-2"
+      >
+        <input type="hidden" name="redirect_to" value={redirectTo} />
+        <input type="hidden" name="relation_id" value={relation.id} />
+        <Input
+          aria-label="Sort order"
+          name="sort_order"
+          type="number"
+          defaultValue={relation.sortOrder}
+          className="h-8 w-20 bg-background/80"
+        />
+        <Button type="submit" size="sm" variant="outline">
+          Save
+        </Button>
+      </form>
+      <form action={deletePageSectionRelationAction}>
+        <input type="hidden" name="redirect_to" value={redirectTo} />
+        <input type="hidden" name="relation_id" value={relation.id} />
+        <Button
+          type="submit"
+          size="sm"
+          variant="ghost"
+          className="h-8 px-2 text-destructive hover:text-destructive"
+        >
+          Remove from page
+        </Button>
+      </form>
+    </div>
   )
 }
 

--- a/app/ponix/pages/[id]/page.tsx
+++ b/app/ponix/pages/[id]/page.tsx
@@ -2,9 +2,17 @@ import type { Metadata } from "next"
 import { notFound } from "next/navigation"
 
 import { CmsDetailPage } from "@/app/ponix/_components/cms-detail"
-import { PageSectionRelationsCard } from "@/app/ponix/_components/cms-relations"
+import {
+  PageSectionRelationsCard,
+  RelationMutationNotice,
+  relationMutationState,
+} from "@/app/ponix/_components/cms-relations"
 import { requireCmsAdmin } from "@/lib/cms/auth"
-import { loadCmsPageDetail, loadCmsPageRelations } from "@/lib/cms/content"
+import {
+  loadCmsPageDetail,
+  loadCmsPageRelations,
+  loadCmsRelationEditorOptions,
+} from "@/lib/cms/content"
 
 export const metadata: Metadata = {
   title: "PONIX Page Detail | 브레멘 Bremen",
@@ -16,18 +24,23 @@ export const metadata: Metadata = {
 
 type PonixPageRecordPageProps = {
   params: Promise<{ id: string }>
+  searchParams?: Promise<Record<string, string | string[] | undefined>>
 }
 
 export default async function PonixPageRecordPage({
   params,
+  searchParams,
 }: PonixPageRecordPageProps) {
   const { id } = await params
 
   await requireCmsAdmin(`/ponix/pages/${id}`)
-  const [detail, relations] = await Promise.all([
+  const [detail, relations, options, search] = await Promise.all([
     loadCmsPageDetail(id),
     loadCmsPageRelations(id),
+    loadCmsRelationEditorOptions(),
+    searchParams,
   ])
+  const mutation = relationMutationState(search)
 
   if (!detail) {
     notFound()
@@ -39,10 +52,18 @@ export default async function PonixPageRecordPage({
       backHref="/ponix/pages"
       backLabel="All pages"
     >
+      <RelationMutationNotice
+        message={mutation.message}
+        error={mutation.error}
+      />
       <PageSectionRelationsCard
         title="Page structure"
         description="Sections attached to this page in render order."
         relations={relations.pageSections}
+        editable
+        editorOptions={options}
+        fixedPageId={id}
+        redirectTo={`/ponix/pages/${id}`}
       />
     </CmsDetailPage>
   )

--- a/app/ponix/relations/actions.ts
+++ b/app/ponix/relations/actions.ts
@@ -8,6 +8,10 @@ import { PUBLIC_CONTENT_CACHE_TAG } from "@/lib/data/public-cache"
 import { createClient } from "@/lib/supabase/server"
 import type { Database, Json } from "@/lib/supabase/types"
 
+type PageSectionInsert =
+  Database["public"]["Tables"]["page_sections"]["Insert"]
+type PageSectionUpdate =
+  Database["public"]["Tables"]["page_sections"]["Update"]
 type SectionEntityInsert =
   Database["public"]["Tables"]["section_entities"]["Insert"]
 type SectionEntityUpdate =
@@ -108,11 +112,112 @@ function revalidateRelationSurfaces(paths: string[]) {
     "/history",
     "/ponix",
     "/ponix/relations",
+    "/ponix/pages",
     "/ponix/sections",
     "/ponix/entities",
     ...paths,
   ]) {
     revalidatePath(path)
+  }
+}
+
+export async function addPageSectionRelationAction(formData: FormData) {
+  const redirectTo = safeRedirectPath(formData)
+
+  try {
+    await requireCmsAdmin(redirectTo)
+    const supabase = await createClient()
+    const payload: PageSectionInsert = {
+      page_id: parseUuid(formData, "page_id", "Page"),
+      section_id: parseUuid(formData, "section_id", "Section"),
+      sort_order: parseSortOrder(formData),
+    }
+    const { error } = await supabase
+      .from("page_sections")
+      .upsert(payload, {
+        onConflict: "page_id,section_id",
+      })
+
+    if (error) throw new Error(error.message)
+
+    revalidateRelationSurfaces([
+      `/ponix/pages/${payload.page_id}`,
+      `/ponix/sections/${payload.section_id}`,
+    ])
+    relationSuccess(redirectTo, "Page section saved.")
+  } catch (error) {
+    relationError(redirectTo, error)
+  }
+}
+
+export async function updatePageSectionRelationAction(formData: FormData) {
+  const redirectTo = safeRedirectPath(formData)
+
+  try {
+    await requireCmsAdmin(redirectTo)
+    const supabase = await createClient()
+    const relationId = parseUuid(formData, "relation_id", "Relation")
+    const update: PageSectionUpdate = {
+      sort_order: parseSortOrder(formData),
+    }
+    const { data: relation, error: loadError } = await supabase
+      .from("page_sections")
+      .select("page_id, section_id")
+      .eq("id", relationId)
+      .maybeSingle()
+
+    if (loadError || !relation) {
+      throw new Error(loadError?.message ?? "Relation not found.")
+    }
+
+    const { error } = await supabase
+      .from("page_sections")
+      .update(update)
+      .eq("id", relationId)
+
+    if (error) throw new Error(error.message)
+
+    revalidateRelationSurfaces([
+      `/ponix/pages/${relation.page_id}`,
+      `/ponix/sections/${relation.section_id}`,
+    ])
+    relationSuccess(redirectTo, "Page section order saved.")
+  } catch (error) {
+    relationError(redirectTo, error)
+  }
+}
+
+export async function deletePageSectionRelationAction(formData: FormData) {
+  const redirectTo = safeRedirectPath(formData)
+
+  try {
+    await requireCmsAdmin(redirectTo)
+    const supabase = await createClient()
+    const relationId = parseUuid(formData, "relation_id", "Relation")
+    const { data: relation, error: loadError } = await supabase
+      .from("page_sections")
+      .select("page_id, section_id")
+      .eq("id", relationId)
+      .maybeSingle()
+
+    if (loadError || !relation) {
+      throw new Error(loadError?.message ?? "Relation not found.")
+    }
+
+    const { error } = await supabase
+      .from("page_sections")
+      .delete()
+      .eq("id", relationId)
+
+    if (error) throw new Error(error.message)
+
+    revalidateRelationSurfaces([
+      `/ponix/pages/${relation.page_id}`,
+      `/ponix/sections/${relation.section_id}`,
+    ])
+    relationSuccess(redirectTo, "Page section removed.")
+  } catch (error) {
+    relationError(redirectTo, error)
   }
 }
 

--- a/app/ponix/relations/page.tsx
+++ b/app/ponix/relations/page.tsx
@@ -48,7 +48,12 @@ export default async function PonixRelationsPage({
           message={mutation.message}
           error={mutation.error}
         />
-        <PageSectionRelationsCard relationList={graph.pageSections} />
+        <PageSectionRelationsCard
+          relationList={graph.pageSections}
+          editable
+          editorOptions={options}
+          redirectTo="/ponix/relations"
+        />
         <SectionEntityRelationsCard
           relationList={graph.sectionEntities}
           editable

--- a/lib/cms/content.ts
+++ b/lib/cms/content.ts
@@ -170,6 +170,7 @@ export type CmsRelationGraph = {
 }
 
 export type CmsRelationEditorOptions = {
+  pages: CmsPageSummary[]
   sections: CmsSectionSummary[]
   entities: CmsEntitySummary[]
   entityCount: number | null
@@ -579,7 +580,11 @@ export async function loadCmsEntities(): Promise<CmsEntityList> {
 
 export async function loadCmsRelationEditorOptions(): Promise<CmsRelationEditorOptions> {
   const supabase = await createClient()
-  const [sectionsResult, entitiesResult] = await Promise.all([
+  const [pagesResult, sectionsResult, entitiesResult] = await Promise.all([
+    supabase
+      .from("pages")
+      .select("id, slug, title, subtitle, published, updated_at")
+      .order("slug", { ascending: true }),
     supabase
       .from("sections")
       .select("id, key, section_type, schema_key, title, subtitle, published, updated_at")
@@ -601,6 +606,12 @@ export async function loadCmsRelationEditorOptions(): Promise<CmsRelationEditorO
     )
   }
 
+  if (pagesResult.error) {
+    throw new Error(
+      `Failed to load CMS page options: ${pagesResult.error.message}`,
+    )
+  }
+
   if (entitiesResult.error) {
     throw new Error(
       `Failed to load CMS entity options: ${entitiesResult.error.message}`,
@@ -608,6 +619,15 @@ export async function loadCmsRelationEditorOptions(): Promise<CmsRelationEditorO
   }
 
   return {
+    pages: (pagesResult.data ?? []).map((page) => ({
+      ...schemaSummary("page/default/v1"),
+      id: page.id,
+      slug: page.slug,
+      title: page.title,
+      subtitle: page.subtitle,
+      published: page.published,
+      updatedAt: page.updated_at,
+    })),
     sections: (sectionsResult.data ?? []).map((section) => ({
       ...schemaSummary(section.schema_key),
       id: section.id,


### PR DESCRIPTION
Closes #23

Summary
- Adds guarded server actions for `page_sections` add, sort-order update, and relation removal.
- Enables editable page-section composition from `/ponix/pages/[id]`.
- Enables page-section relation management from `/ponix/relations` with page and section selectors.
- Extends relation editor options with page choices.
- Revalidates public content cache, public pages, and affected PONIX page/section routes after relation mutations.
- Keeps deletes relation-only; no `pages` or `sections` rows are deleted.

Checks
- `git diff --check`
- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `pnpm run build`

Supabase impact
- Content rows only: insert/update/delete on `page_sections`.
- No migration, RLS, auth, storage, or service-role changes.