### PR TITLE
[CMS] Add section creation flow

### DIFF
--- a/app/ponix/_components/cms-section-create-form.tsx
+++ b/app/ponix/_components/cms-section-create-form.tsx
@@ -1,0 +1,219 @@
+import Link from "next/link"
+
+import { renderFieldInput } from "@/app/ponix/_components/cms-section-form"
+import { createCmsSectionAction } from "@/app/ponix/sections/actions"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  cmsFieldInputName,
+  getEditableSectionFields,
+  sectionTypeFromSchemaKey,
+  type CmsEditableSectionField,
+} from "@/lib/cms/section-editor"
+import type { CmsSchemaDefinition } from "@/lib/cms/schema-registry"
+
+export function CmsSectionCreatePage({
+  schema,
+  error,
+}: {
+  schema: CmsSchemaDefinition
+  error?: string
+}) {
+  const editableFields = getEditableSectionFields(schema.schemaKey)
+  const columnFields = editableFields.filter((field) => field.source === "column")
+  const propsFields = editableFields.filter((field) => field.source === "props")
+  const formId = `cms-section-create-${schema.schemaKey.replace(/[^a-z0-9]+/gi, "-")}`
+  const sectionType = sectionTypeFromSchemaKey(schema.schemaKey) ?? "unregistered"
+
+  return (
+    <main className="relative min-h-[calc(100vh-5rem)] overflow-hidden">
+      <div className="pointer-events-none absolute inset-0 -z-10">
+        <div className="absolute right-[-10rem] top-10 h-96 w-96 rounded-full bg-accent/10 blur-3xl" />
+        <div className="absolute left-[-8rem] bottom-0 h-80 w-80 rounded-full bg-muted blur-3xl" />
+      </div>
+
+      <section className="mx-auto max-w-5xl px-6 py-16 md:px-8 md:py-24">
+        <div className="mb-10 flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+          <div>
+            <p className="caps mb-5">PONIX / New section</p>
+            <h1 className="font-serif text-[clamp(3.25rem,8vw,6.5rem)] italic leading-[0.84] tracking-tight">
+              {schema.label}
+            </h1>
+            <p className="mt-5 max-w-2xl text-sm leading-relaxed text-muted-foreground md:text-base">
+              Create a section record first. Page placement and curated entities
+              can be connected after the section exists.
+            </p>
+            <div className="mt-6 flex flex-wrap items-center gap-2">
+              <Badge variant="outline" className="rounded-full font-mono">
+                {sectionType}
+              </Badge>
+              <Badge variant="secondary" className="rounded-full">
+                {schema.schemaKey}
+              </Badge>
+            </div>
+          </div>
+          <Button asChild variant="outline" className="w-fit rounded-full">
+            <Link href="/ponix/sections/new">Change schema</Link>
+          </Button>
+        </div>
+
+        <form id={formId} action={createCmsSectionAction} className="space-y-6">
+          <input type="hidden" name="schema_key" value={schema.schemaKey} />
+
+          {error && (
+            <Alert variant="destructive">
+              <AlertTitle>Create failed</AlertTitle>
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          <Card className="rounded-md bg-card/95 shadow-xl">
+            <CardHeader className="border-b">
+              <CardTitle className="font-serif text-3xl italic">
+                Section identity
+              </CardTitle>
+              <CardDescription>
+                The key is the stable CMS handle. Renderer type is derived from
+                the selected schema.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="grid gap-5 px-6 py-6 md:grid-cols-[minmax(0,1fr)_16rem]">
+              <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <Label htmlFor="section_key">Section key</Label>
+                  <Badge variant="outline" className="rounded-full">
+                    Required
+                  </Badge>
+                </div>
+                <Input
+                  id="section_key"
+                  name="section_key"
+                  pattern="[a-z0-9]+(-[a-z0-9]+)*"
+                  placeholder="performances-featured"
+                  required
+                  className="h-11 bg-background/70 font-mono"
+                />
+                <p className="text-xs leading-relaxed text-muted-foreground">
+                  Use lowercase letters, numbers, and hyphens. This must stay
+                  unique across sections.
+                </p>
+              </div>
+              <ReadonlyMeta label="Renderer" value={sectionType} />
+            </CardContent>
+          </Card>
+
+          <CreateEditorCard
+            title="Section copy"
+            description="Shared columns used by section renderers."
+            fields={columnFields}
+          />
+
+          <CreateEditorCard
+            title="Renderer props"
+            description="Schema-registered JSON props for this renderer."
+            fields={propsFields}
+          />
+
+          <div className="flex flex-col gap-3 rounded-md border bg-card/95 p-4 shadow-xl sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-sm text-muted-foreground">
+              Creation inserts one section row only. Page placement is a
+              separate relation step.
+            </p>
+            <div className="flex gap-2">
+              <Button asChild type="button" variant="outline">
+                <Link href="/ponix/sections">Cancel</Link>
+              </Button>
+              <Button type="submit">Create section</Button>
+            </div>
+          </div>
+        </form>
+      </section>
+    </main>
+  )
+}
+
+function CreateEditorCard({
+  title,
+  description,
+  fields,
+}: {
+  title: string
+  description: string
+  fields: CmsEditableSectionField[]
+}) {
+  return (
+    <Card className="rounded-md bg-card/95 shadow-xl">
+      <CardHeader className="border-b">
+        <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+          <div>
+            <CardTitle className="font-serif text-3xl italic">{title}</CardTitle>
+            <CardDescription>{description}</CardDescription>
+          </div>
+          <p className="caps text-muted-foreground">{fields.length} fields</p>
+        </div>
+      </CardHeader>
+      <CardContent className="grid gap-5 px-6 py-6 md:grid-cols-2">
+        {fields.length > 0 ? (
+          fields.map((field) => (
+            <CreateEditorField key={`${field.source}:${field.key}`} field={field} />
+          ))
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            No editable fields in this group.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function CreateEditorField({ field }: { field: CmsEditableSectionField }) {
+  const id = `new-section-${field.source}-${field.key}`
+  const name = cmsFieldInputName(field)
+  const wide =
+    field.type === "textarea" ||
+    field.type === "json" ||
+    field.type === "string-list"
+  const value = field.type === "boolean" ? false : ""
+
+  return (
+    <div className={wide ? "space-y-2 md:col-span-2" : "space-y-2"}>
+      <div className="flex items-center gap-2">
+        <Label htmlFor={id}>{field.label}</Label>
+        {field.required && (
+          <Badge variant="outline" className="rounded-full">
+            Required
+          </Badge>
+        )}
+      </div>
+      {renderFieldInput({ field, id, name, value })}
+      <p className="font-mono text-xs text-muted-foreground">
+        {field.source}.{field.key}
+      </p>
+      {field.description && (
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          {field.description}
+        </p>
+      )}
+    </div>
+  )
+}
+
+function ReadonlyMeta({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border bg-background/60 p-4">
+      <p className="caps mb-2 text-muted-foreground">{label}</p>
+      <p className="break-all font-mono text-xs">{value}</p>
+    </div>
+  )
+}

--- a/app/ponix/_components/cms-section-form.tsx
+++ b/app/ponix/_components/cms-section-form.tsx
@@ -228,7 +228,7 @@ function EditorField({
   )
 }
 
-function renderFieldInput({
+export function renderFieldInput({
   field,
   id,
   name,

--- a/app/ponix/sections/actions.ts
+++ b/app/ponix/sections/actions.ts
@@ -7,8 +7,10 @@ import { requireCmsAdmin } from "@/lib/cms/auth"
 import {
   cmsFieldInputName,
   getEditableSectionFields,
+  getSectionCreationSchema,
   getSectionEditorSchema,
   jsonObject,
+  sectionTypeFromSchemaKey,
   type CmsEditableSectionField,
   type CmsJsonObject,
 } from "@/lib/cms/section-editor"
@@ -17,6 +19,7 @@ import { createClient } from "@/lib/supabase/server"
 import type { Database, Json } from "@/lib/supabase/types"
 
 type SectionUpdate = Database["public"]["Tables"]["sections"]["Update"]
+type SectionInsert = Database["public"]["Tables"]["sections"]["Insert"]
 
 type ParsedValue =
   | {
@@ -35,8 +38,45 @@ function stringField(formData: FormData, key: string) {
 }
 
 function redirectWithParams(path: string, params: Record<string, string>): never {
-  const search = new URLSearchParams(params)
-  redirect(`${path}?${search.toString()}`)
+  const [pathname, currentSearch = ""] = path.split("?")
+  const search = new URLSearchParams(currentSearch)
+
+  for (const [key, value] of Object.entries(params)) {
+    search.set(key, value)
+  }
+
+  redirect(`${pathname}?${search.toString()}`)
+}
+
+function parseSectionKey(formData: FormData, path: string) {
+  const value = stringField(formData, "section_key")
+
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value)) {
+    redirectWithParams(path, {
+      error: "Section key must use lowercase letters, numbers, and hyphens.",
+    })
+  }
+
+  return value
+}
+
+function revalidateSectionSurfaces(sectionId?: string) {
+  revalidatePath("/")
+  revalidatePath("/performances")
+  revalidatePath("/performances/updates")
+  revalidatePath("/videos")
+  revalidatePath("/photos")
+  revalidatePath("/history")
+  updateTag(PUBLIC_CONTENT_CACHE_TAG)
+  revalidatePath("/ponix")
+  revalidatePath("/ponix/sections")
+  revalidatePath("/ponix/sections/new")
+  revalidatePath("/ponix/relations")
+
+  if (sectionId) {
+    revalidatePath(`/ponix/sections/${sectionId}`)
+    revalidatePath(`/ponix/sections/${sectionId}/edit`)
+  }
 }
 
 function isSafeUrl(value: string) {
@@ -208,6 +248,91 @@ function updatePropsValue(
   props[field.key] = parsed.value
 }
 
+export async function createCmsSectionAction(formData: FormData) {
+  const schemaKey = stringField(formData, "schema_key")
+  const createPath = schemaKey
+    ? `/ponix/sections/new?schema=${encodeURIComponent(schemaKey)}`
+    : "/ponix/sections/new"
+  const admin = await requireCmsAdmin(createPath)
+
+  const schema = getSectionCreationSchema(schemaKey)
+  if (!schema) {
+    redirectWithParams("/ponix/sections/new", {
+      error: "Choose a section schema that can be created from CMS.",
+    })
+  }
+
+  const sectionType = sectionTypeFromSchemaKey(schema.schemaKey)
+  if (!sectionType) {
+    redirectWithParams(createPath, {
+      error: "This section schema has no registered renderer type.",
+    })
+  }
+
+  const fields = getEditableSectionFields(schema.schemaKey)
+  const props: CmsJsonObject = {}
+  const insert: SectionInsert = {
+    key: parseSectionKey(formData, createPath),
+    owner_member_id: admin.id,
+    props,
+    published: false,
+    schema_key: schema.schemaKey,
+    section_type: sectionType,
+  }
+
+  for (const field of fields) {
+    const parsed = parseFieldValue(formData, field)
+
+    if (!parsed.ok) {
+      redirectWithParams(createPath, {
+        error: parsed.error,
+      })
+    }
+
+    if (field.source === "props") {
+      updatePropsValue(props, field, parsed)
+      continue
+    }
+
+    if (field.key === "published") {
+      insert.published = Boolean(parsed.value)
+    }
+
+    if (field.key === "eyebrow") {
+      insert.eyebrow = parsed.value === null ? null : String(parsed.value)
+    }
+
+    if (field.key === "title") {
+      insert.title = parsed.value === null ? null : String(parsed.value)
+    }
+
+    if (field.key === "subtitle") {
+      insert.subtitle = parsed.value === null ? null : String(parsed.value)
+    }
+  }
+
+  const supabase = await createClient()
+  const { data: created, error: insertError } = await supabase
+    .from("sections")
+    .insert(insert)
+    .select("*")
+    .single()
+
+  if (insertError || !created) {
+    const code = (insertError as { code?: string } | null)?.code
+    redirectWithParams(createPath, {
+      error:
+        code === "23505"
+          ? "Section key is already in use."
+          : "Section creation failed.",
+    })
+  }
+
+  revalidateSectionSurfaces(created.id)
+
+  redirect(`/ponix/sections/${created.id}`)
+}
+
 export async function updateCmsSectionAction(formData: FormData) {
   const sectionId = stringField(formData, "section_id")
 
@@ -288,16 +413,7 @@ export async function updateCmsSectionAction(formData: FormData) {
     })
   }
 
-  revalidatePath("/")
-  revalidatePath("/performances")
-  revalidatePath("/videos")
-  revalidatePath("/photos")
-  revalidatePath("/history")
-  updateTag(PUBLIC_CONTENT_CACHE_TAG)
-  revalidatePath("/ponix")
-  revalidatePath("/ponix/sections")
-  revalidatePath(`/ponix/sections/${sectionId}`)
-  revalidatePath("/ponix/relations")
+  revalidateSectionSurfaces(sectionId)
 
   redirect(`/ponix/sections/${sectionId}`)
 }

--- a/app/ponix/sections/new/page.tsx
+++ b/app/ponix/sections/new/page.tsx
@@ -1,0 +1,142 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+
+import { CmsSectionCreatePage } from "@/app/ponix/_components/cms-section-create-form"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { requireCmsAdmin } from "@/lib/cms/auth"
+import {
+  getSectionCreationSchema,
+  getSectionCreationSchemas,
+  sectionTypeFromSchemaKey,
+} from "@/lib/cms/section-editor"
+
+export const metadata: Metadata = {
+  title: "New PONIX Section | 브레멘 Bremen",
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
+
+type PonixNewSectionPageProps = {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>
+}
+
+function firstParam(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value
+}
+
+export default async function PonixNewSectionPage({
+  searchParams,
+}: PonixNewSectionPageProps) {
+  const query = (await searchParams) ?? {}
+  const schemaKey = firstParam(query.schema)
+  const error = firstParam(query.error)
+
+  await requireCmsAdmin("/ponix/sections/new")
+
+  if (schemaKey) {
+    const schema = getSectionCreationSchema(schemaKey)
+
+    if (schema) {
+      return <CmsSectionCreatePage schema={schema} error={error} />
+    }
+  }
+
+  return (
+    <SchemaPickerPage
+      error={
+        schemaKey
+          ? `Schema ${schemaKey} cannot be created from CMS.`
+          : error
+      }
+    />
+  )
+}
+
+function SchemaPickerPage({ error }: { error?: string }) {
+  const schemas = getSectionCreationSchemas()
+
+  return (
+    <main className="relative min-h-[calc(100vh-5rem)] overflow-hidden">
+      <div className="pointer-events-none absolute inset-0 -z-10">
+        <div className="absolute right-[-10rem] top-10 h-96 w-96 rounded-full bg-accent/10 blur-3xl" />
+        <div className="absolute left-[-8rem] bottom-0 h-80 w-80 rounded-full bg-muted blur-3xl" />
+      </div>
+
+      <section className="mx-auto max-w-6xl px-6 py-16 md:px-8 md:py-24">
+        <div className="mb-10 flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+          <div>
+            <p className="caps mb-5">PONIX / New section</p>
+            <h1 className="font-serif text-[clamp(3.25rem,8vw,6.5rem)] italic leading-[0.84] tracking-tight">
+              Choose schema
+            </h1>
+            <p className="mt-5 max-w-2xl text-sm leading-relaxed text-muted-foreground md:text-base">
+              Start with a renderer-backed section schema. After creation, place
+              the section into a page and connect entities as needed.
+            </p>
+          </div>
+          <Button asChild variant="outline" className="w-fit rounded-full">
+            <Link href="/ponix/sections">All sections</Link>
+          </Button>
+        </div>
+
+        <div className="space-y-6">
+          {error && (
+            <Alert variant="destructive">
+              <AlertTitle>Schema unavailable</AlertTitle>
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {schemas.map((schema) => (
+              <Card
+                key={schema.schemaKey}
+                className="rounded-md bg-card/95 shadow-xl transition-transform hover:-translate-y-1"
+              >
+                <CardHeader className="border-b">
+                  <div className="mb-3 flex flex-wrap items-center gap-2">
+                    <Badge variant="outline" className="rounded-full font-mono">
+                      {sectionTypeFromSchemaKey(schema.schemaKey)}
+                    </Badge>
+                    <Badge variant="secondary" className="rounded-full">
+                      {schema.fields.length} fields
+                    </Badge>
+                  </div>
+                  <CardTitle className="font-serif text-3xl italic">
+                    {schema.label}
+                  </CardTitle>
+                  <CardDescription>{schema.description}</CardDescription>
+                </CardHeader>
+                <CardContent className="flex items-center justify-between gap-4 px-6 py-5">
+                  <p className="break-all font-mono text-xs text-muted-foreground">
+                    {schema.schemaKey}
+                  </p>
+                  <Button asChild size="sm" className="shrink-0 rounded-full">
+                    <Link
+                      href={`/ponix/sections/new?schema=${encodeURIComponent(
+                        schema.schemaKey,
+                      )}`}
+                    >
+                      Select
+                    </Link>
+                  </Button>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/app/ponix/sections/page.tsx
+++ b/app/ponix/sections/page.tsx
@@ -8,6 +8,7 @@ import {
   PublishBadge,
   SchemaBadge,
 } from "@/app/ponix/_components/cms-list"
+import { Button } from "@/components/ui/button"
 import {
   Table,
   TableBody,
@@ -35,7 +36,12 @@ export default async function PonixSectionsPage() {
     <CmsListPage
       eyebrow="PONIX / Sections"
       title="Sections"
-      description="Renderer-bound section records. Schema registry mapping is shown before any editable props form is introduced."
+      description="Renderer-bound section records that can be edited, placed into pages, and connected to reusable entities."
+      actions={
+        <Button asChild className="w-fit rounded-full">
+          <Link href="/ponix/sections/new">New section</Link>
+        </Button>
+      }
     >
       <CmsTableCard title="Section records" meta={`${sections.length} records`}>
         <Table>

--- a/lib/cms/section-editor.ts
+++ b/lib/cms/section-editor.ts
@@ -2,7 +2,7 @@ import type {
   CmsFieldDefinition,
   CmsSchemaDefinition,
 } from "@/lib/cms/schema-registry"
-import { getCmsSchema } from "@/lib/cms/schema-registry"
+import { getCmsSchema, getCmsSchemasByKind } from "@/lib/cms/schema-registry"
 import type { Database, Json } from "@/lib/supabase/types"
 
 type SectionRow = Database["public"]["Tables"]["sections"]["Row"]
@@ -29,6 +29,67 @@ export function getSectionEditorSchema(
   }
 
   return schema
+}
+
+const sectionTypeBySchemaKey: Record<string, string> = {
+  "section/history-timeline/v1": "entity_timeline",
+  "section/home-activities/v1": "static_activity_grid",
+  "section/home-hero/v1": "entity_feature",
+  "section/home-join/v1": "static_cta",
+  "section/home-stage-highlights/v1": "entity_video_grid",
+  "section/home-stats/v1": "entity_stat_grid",
+  "section/home-upcoming/v1": "computed_event_list",
+  "section/performance-archive/v1": "entity_carousel",
+  "section/performance-current-season/v1": "entity_feature_grid",
+  "section/performance-season-index/v1": "computed_year_index",
+  "section/performance-stage-moments/v1": "computed_photo_strip",
+  "section/performance-updates/v1": "entity_post_grid",
+  "section/photo-gallery/v1": "entity_masonry",
+  "section/site-footer/v1": "site_footer",
+  "section/site-navigation/v1": "site_navigation",
+  "section/video-event-playlists/v1": "entity_grouped_grid",
+  "section/video-featured/v1": "entity_feature",
+  "section/video-library/v1": "entity_grid",
+  "section/video-popular/v1": "entity_list",
+}
+
+export function sectionTypeFromSchemaKey(schemaKey: string) {
+  return sectionTypeBySchemaKey[schemaKey] ?? null
+}
+
+function hasRequiredReadOnlyField(schema: CmsSchemaDefinition) {
+  return schema.fields.some((field) => {
+    if (!field.required || !field.readOnly) {
+      return false
+    }
+
+    return !(
+      field.source === "column" &&
+      (field.key === "key" || field.key === "section_type")
+    )
+  })
+}
+
+export function getSectionCreationSchema(
+  schemaKey: string,
+): CmsSchemaDefinition | null {
+  const schema = getSectionEditorSchema(schemaKey)
+
+  if (!schema || !sectionTypeFromSchemaKey(schema.schemaKey)) {
+    return null
+  }
+
+  if (hasRequiredReadOnlyField(schema)) {
+    return null
+  }
+
+  return schema
+}
+
+export function getSectionCreationSchemas() {
+  return getCmsSchemasByKind("section")
+    .filter((schema) => getSectionCreationSchema(schema.schemaKey))
+    .sort((left, right) => left.label.localeCompare(right.label))
 }
 
 export function getEditableSectionFields(schemaKey: string) {


### PR DESCRIPTION
Closes #25

Summary
- Adds /ponix/sections/new with a registered section schema picker and schema-specific creation form.
- Derives locked section_type from the selected section schema and validates unique lowercase section keys.
- Adds guarded createCmsSectionAction for inserting draft sections rows.
- Reuses schema-registered section fields for column and props inputs.
- Adds a New section action to the PONIX sections list.
- Revalidates public content cache and affected PONIX section/relation routes after creation.

Checks
- git diff --check
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm run build

Supabase impact
- Content rows only: inserts into sections.
- No migration, RLS, auth, storage, service-role, or relation mutation changes.