### PR TITLE
[CMS] Add section contents editor

### DIFF
--- a/app/ponix/_components/cms-entity-picker.tsx
+++ b/app/ponix/_components/cms-entity-picker.tsx
@@ -1,0 +1,120 @@
+"use client"
+
+import { Check, ChevronsUpDown } from "lucide-react"
+import { useState } from "react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import type { CmsRelationEditorOptions } from "@/lib/cms/content"
+import { cn } from "@/lib/utils"
+
+type EntityOption = CmsRelationEditorOptions["entities"][number]
+
+export function CmsEntityPicker({
+  name,
+  entities,
+}: {
+  name: string
+  entities: EntityOption[]
+}) {
+  const [open, setOpen] = useState(false)
+  const [selectedId, setSelectedId] = useState("")
+  const selected = entities.find((entity) => entity.id === selectedId)
+
+  function entitySearchValue(entity: EntityOption) {
+    return [
+      entity.title,
+      entity.subtitle,
+      entity.slug,
+      entity.entityType,
+      entity.schemaKey,
+      entity.schemaLabel,
+    ]
+      .filter(Boolean)
+      .join(" ")
+  }
+
+  return (
+    <div className="space-y-2">
+      <input type="hidden" name={name} value={selectedId} />
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            className="h-10 w-full justify-between bg-background/80 px-3 font-normal"
+          >
+            <span className="min-w-0 truncate text-left">
+              {selected ? selected.title : "Search entity"}
+            </span>
+            <ChevronsUpDown className="size-4 shrink-0 text-muted-foreground" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="start"
+          className="w-[min(42rem,calc(100vw-3rem))] p-0"
+        >
+          <Command>
+            <CommandInput placeholder="Search by title, slug, type, schema" />
+            <CommandList className="max-h-96">
+              <CommandEmpty>No matching entity.</CommandEmpty>
+              <CommandGroup>
+                {entities.map((entity) => (
+                  <CommandItem
+                    key={entity.id}
+                    value={entitySearchValue(entity)}
+                    onSelect={() => {
+                      setSelectedId(entity.id)
+                      setOpen(false)
+                    }}
+                    className="items-start gap-3 py-3"
+                  >
+                    <Check
+                      className={cn(
+                        "mt-1 size-4 shrink-0",
+                        selectedId === entity.id ? "opacity-100" : "opacity-0",
+                      )}
+                    />
+                    <div className="min-w-0 flex-1 space-y-1">
+                      <div className="flex min-w-0 flex-wrap items-center gap-2">
+                        <span className="min-w-0 truncate font-medium">
+                          {entity.title}
+                        </span>
+                        <Badge variant="outline" className="rounded-full">
+                          {entity.entityType}
+                        </Badge>
+                        {!entity.published && (
+                          <Badge variant="secondary" className="rounded-full">
+                            Draft
+                          </Badge>
+                        )}
+                      </div>
+                      <p className="line-clamp-1 text-xs text-muted-foreground">
+                        {entity.slug || entity.subtitle || entity.schemaLabel}
+                      </p>
+                    </div>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+    </div>
+  )
+}

--- a/app/ponix/_components/cms-live-preview.tsx
+++ b/app/ponix/_components/cms-live-preview.tsx
@@ -179,7 +179,7 @@ export function CmsSectionLivePreview({
   sectionEntities,
   entityRelations,
 }: {
-  formId: string
+  formId?: string
   detail: CmsSectionDetail
   fields: CmsFieldDefinition[]
   sectionEntities: CmsSectionEntityRelation[]
@@ -193,6 +193,10 @@ export function CmsSectionLivePreview({
   const deferredSnapshot = useDeferredValue(snapshot)
 
   useEffect(() => {
+    if (!formId) {
+      return
+    }
+
     const form = document.getElementById(formId)
 
     if (!(form instanceof HTMLFormElement)) {

--- a/app/ponix/_components/cms-relations.tsx
+++ b/app/ponix/_components/cms-relations.tsx
@@ -44,6 +44,7 @@ import type {
 } from "@/lib/cms/content"
 
 import { SchemaBadge } from "./cms-list"
+import { CmsEntityPicker } from "./cms-entity-picker"
 
 export function RelationCount({
   visible,
@@ -173,6 +174,10 @@ export function SectionEntityRelationsCard({
   fixedEntityId?: string
 }) {
   const rows = relationList?.relations ?? relations ?? []
+  const isSectionLocal = Boolean(fixedSectionId)
+  const nextSortOrder = fixedSectionId
+    ? Math.max(0, ...rows.map((relation) => relation.sortOrder)) + 10
+    : 0
 
   return (
     <RelationCard
@@ -188,12 +193,14 @@ export function SectionEntityRelationsCard({
           redirectTo={redirectTo}
           fixedSectionId={fixedSectionId}
           fixedEntityId={fixedEntityId}
+          defaultSortOrder={nextSortOrder}
         />
       )}
       <SectionEntityRelationsTable
         relations={rows}
         editable={editable}
         redirectTo={redirectTo}
+        hideSection={isSectionLocal}
       />
     </RelationCard>
   )
@@ -292,7 +299,7 @@ function PageSectionAddForm({
       </FieldGroup>
       <div className="flex items-end">
         <Button type="submit" className="w-full rounded-full">
-          Add
+          {fixedSectionId ? "Add to section" : "Add"}
         </Button>
       </div>
     </form>
@@ -304,16 +311,18 @@ function SectionEntityAddForm({
   redirectTo,
   fixedSectionId,
   fixedEntityId,
+  defaultSortOrder = 0,
 }: {
   options: CmsRelationEditorOptions
   redirectTo: string
   fixedSectionId?: string
   fixedEntityId?: string
+  defaultSortOrder?: number
 }) {
   return (
     <form
       action={addSectionEntityRelationAction}
-      className="grid gap-4 border-b bg-muted/20 px-6 py-6 lg:grid-cols-[minmax(12rem,0.9fr)_minmax(14rem,1.2fr)_9rem_9rem_7rem_auto]"
+      className="grid gap-4 border-b bg-muted/20 px-6 py-6 lg:grid-cols-[minmax(12rem,0.8fr)_minmax(22rem,1.5fr)_9rem_9rem_7rem_auto]"
     >
       <input type="hidden" name="redirect_to" value={redirectTo} />
       {fixedSectionId ? (
@@ -327,7 +336,12 @@ function SectionEntityAddForm({
         <input type="hidden" name="entity_id" value={fixedEntityId} />
       ) : (
         <FieldGroup label="Entity">
-          <EntitySelect name="entity_id" entities={options.entities} />
+          <CmsEntityPicker name="entity_id" entities={options.entities} />
+          {options.entityCount && options.entityCount > options.entityLimit ? (
+            <p className="text-xs text-muted-foreground">
+              Search covers the latest {options.entityLimit} entities.
+            </p>
+          ) : null}
         </FieldGroup>
       )}
       <FieldGroup label="Type">
@@ -350,7 +364,7 @@ function SectionEntityAddForm({
         <Input
           name="sort_order"
           type="number"
-          defaultValue="0"
+          defaultValue={defaultSortOrder}
           className="h-10 bg-background/80"
         />
       </FieldGroup>
@@ -645,20 +659,22 @@ function SectionEntityRelationsTable({
   relations,
   editable = false,
   redirectTo = "/ponix/relations",
+  hideSection = false,
 }: {
   relations: CmsSectionEntityRelation[]
   editable?: boolean
   redirectTo?: string
+  hideSection?: boolean
 }) {
   if (relations.length === 0) {
-    return <EmptyRelationRows message="No section-entity relations." />
+    return <EmptyRelationRows message="No entities in this section." />
   }
 
   return (
     <Table>
       <TableHeader>
         <TableRow>
-          <TableHead>Section</TableHead>
+          {!hideSection && <TableHead>Section</TableHead>}
           <TableHead>Slot</TableHead>
           <TableHead>Order</TableHead>
           <TableHead>Entity</TableHead>
@@ -670,12 +686,14 @@ function SectionEntityRelationsTable({
       <TableBody>
         {relations.map((relation) => (
           <TableRow key={relation.id}>
-            <TableCell>
-              <SectionLink
-                section={relation.section}
-                fallbackId={relation.sectionId}
-              />
-            </TableCell>
+            {!hideSection && (
+              <TableCell>
+                <SectionLink
+                  section={relation.section}
+                  fallbackId={relation.sectionId}
+                />
+              </TableCell>
+            )}
             <TableCell className="font-mono text-xs">{relation.slot}</TableCell>
             <TableCell className="font-mono text-xs">
               {relation.sortOrder}
@@ -847,7 +865,7 @@ function SectionEntityRelationActions({
           variant="ghost"
           className="h-8 px-2 text-destructive hover:text-destructive"
         >
-          Remove relation
+          Remove from section
         </Button>
       </form>
     </div>

--- a/app/ponix/relations/actions.ts
+++ b/app/ponix/relations/actions.ts
@@ -235,11 +235,28 @@ export async function addSectionEntityRelationAction(formData: FormData) {
       sort_order: parseSortOrder(formData),
       props: parseProps(formData),
     }
-    const { error } = await supabase
+    const { data: existing, error: existingError } = await supabase
       .from("section_entities")
-      .upsert(payload, {
-        onConflict: "section_id,entity_id,relation_type,slot",
-      })
+      .select("id")
+      .eq("section_id", payload.section_id)
+      .eq("entity_id", payload.entity_id)
+      .order("sort_order", { ascending: true })
+      .limit(1)
+      .maybeSingle()
+
+    if (existingError) throw new Error(existingError.message)
+
+    const { error } = existing
+      ? await supabase
+          .from("section_entities")
+          .update({
+            relation_type: payload.relation_type,
+            slot: payload.slot,
+            sort_order: payload.sort_order,
+            props: payload.props,
+          } satisfies SectionEntityUpdate)
+          .eq("id", existing.id)
+      : await supabase.from("section_entities").insert(payload)
 
     if (error) throw new Error(error.message)
 

--- a/app/ponix/sections/[id]/page.tsx
+++ b/app/ponix/sections/[id]/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link"
 import { notFound } from "next/navigation"
 
 import { CmsDetailPage } from "@/app/ponix/_components/cms-detail"
+import { CmsSectionLivePreview } from "@/app/ponix/_components/cms-live-preview"
 import {
   PageSectionRelationsCard,
   RelationMutationNotice,
@@ -15,6 +16,7 @@ import {
   loadCmsSectionDetail,
   loadCmsSectionRelations,
 } from "@/lib/cms/content"
+import { getEditableSectionFields } from "@/lib/cms/section-editor"
 
 export const metadata: Metadata = {
   title: "PONIX Section Detail | 브레멘 Bremen",
@@ -44,9 +46,11 @@ export default async function PonixSectionRecordPage({
   ])
   const mutation = relationMutationState(search)
 
-  if (!detail) {
+  if (!detail || detail.kind !== "section") {
     notFound()
   }
+
+  const editableFields = getEditableSectionFields(detail.schemaKey)
 
   return (
     <CmsDetailPage
@@ -73,12 +77,18 @@ export default async function PonixSectionRecordPage({
       />
       <SectionEntityRelationsCard
         title="Curated entities"
-        description="Entities attached to this section by slot and order."
+        description="Search existing entities, attach them here, and tune their order."
         relations={relations.sectionEntities}
         editable
         editorOptions={options}
         fixedSectionId={id}
         redirectTo={`/ponix/sections/${id}`}
+      />
+      <CmsSectionLivePreview
+        detail={detail}
+        fields={editableFields}
+        sectionEntities={relations.sectionEntities}
+        entityRelations={relations.entityRelations}
       />
     </CmsDetailPage>
   )


### PR DESCRIPTION
Closes #27

Summary
- Adds a searchable shadcn Command/Popover entity picker for section contents.
- Makes /ponix/sections/[id] a section-local curation surface with cleaner relation copy and no repeated section column.
- Adds automatic next sort-order defaults when adding entities to a section.
- Shows the section public preview on the section detail page using the current section relations.
- Prevents duplicate section/entity rows by updating the existing section_entities relation for the same section/entity pair.

Checks
- git diff --check
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm run build

Supabase impact
- Content rows only: section_entities insert/update/delete through existing PONIX admin server actions.
- No migration, RLS, auth, storage, or service-role changes.