### PR TITLE
[CMS] Add draft preview mode

### DIFF
--- a/app/ponix/pages/[id]/page.tsx
+++ b/app/ponix/pages/[id]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next"
+import Link from "next/link"
 import { notFound } from "next/navigation"
 
 import { CmsDetailPage } from "@/app/ponix/_components/cms-detail"
@@ -51,6 +52,14 @@ export default async function PonixPageRecordPage({
       detail={detail}
       backHref="/ponix/pages"
       backLabel="All pages"
+      actions={
+        <Link
+          href={`/ponix/preview/pages/${id}`}
+          className="inline-flex h-9 items-center justify-center rounded-full bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-xs transition-colors hover:bg-primary/90"
+        >
+          Preview page
+        </Link>
+      }
     >
       <RelationMutationNotice
         message={mutation.message}

--- a/app/ponix/preview/pages/[id]/page.tsx
+++ b/app/ponix/preview/pages/[id]/page.tsx
@@ -1,0 +1,155 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { notFound } from "next/navigation"
+
+import { HistorySection } from "@/components/history-section"
+import { PerformancesSection } from "@/components/performances-section"
+import { PhotosSection } from "@/components/photos-section"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { VideosSection } from "@/components/videos-section"
+import { requireCmsAdmin } from "@/lib/cms/auth"
+import {
+  loadDraftPreviewPage,
+  type DraftPreviewPageContent,
+} from "@/lib/data/content-graph"
+
+export const metadata: Metadata = {
+  title: "PONIX Draft Preview | 브레멘 Bremen",
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
+
+type PonixPagePreviewProps = {
+  params: Promise<{ id: string }>
+}
+
+export default async function PonixPagePreview({ params }: PonixPagePreviewProps) {
+  const { id } = await params
+
+  await requireCmsAdmin(`/ponix/preview/pages/${id}`)
+  const preview = await loadDraftPreviewPage(id)
+
+  if (!preview) {
+    notFound()
+  }
+
+  return (
+    <div>
+      <PreviewBanner preview={preview} pageId={id} />
+      {renderPreview(preview)}
+    </div>
+  )
+}
+
+function renderPreview(preview: DraftPreviewPageContent) {
+  if (preview.kind === "performances") {
+    return (
+      <PerformancesSection
+        page={preview.page}
+        sections={preview.sections}
+        playlists={preview.playlists}
+      />
+    )
+  }
+
+  if (preview.kind === "videos") {
+    return (
+      <VideosSection
+        page={preview.page}
+        sections={preview.sections}
+        videos={preview.libraryVideos}
+        featuredVideos={preview.featuredVideos}
+        popularVideos={preview.popularVideos}
+      />
+    )
+  }
+
+  if (preview.kind === "photos") {
+    return (
+      <PhotosSection
+        page={preview.page}
+        sections={preview.sections}
+        photos={preview.photos}
+      />
+    )
+  }
+
+  if (preview.kind === "history") {
+    return (
+      <HistorySection
+        page={preview.page}
+        sections={preview.sections}
+        milestones={preview.milestones}
+      />
+    )
+  }
+
+  return (
+    <section className="mx-auto max-w-6xl px-6 py-16 md:px-8 md:py-24">
+      <div className="mb-10">
+        <p className="caps mb-5 text-muted-foreground">Generic page preview</p>
+        <h1 className="font-serif text-[clamp(3.25rem,8vw,6.5rem)] italic leading-[0.84] tracking-tight">
+          {preview.page.title}
+        </h1>
+        {preview.page.description && (
+          <p className="mt-5 max-w-2xl text-sm leading-relaxed text-muted-foreground md:text-base">
+            {preview.page.description}
+          </p>
+        )}
+      </div>
+      <ul className="grid gap-4 md:grid-cols-2">
+        {preview.graph.sections.map((section) => (
+          <li key={section.id} className="rounded-md border bg-card p-5">
+            <div className="mb-4 flex flex-wrap gap-2">
+              <Badge variant="outline">{section.key}</Badge>
+              <Badge variant="secondary">{section.sectionType}</Badge>
+            </div>
+            <h2 className="font-serif text-3xl italic">
+              {section.title ?? section.key}
+            </h2>
+            {section.subtitle && (
+              <p className="mt-2 text-sm text-muted-foreground">
+                {section.subtitle}
+              </p>
+            )}
+            <p className="caps mt-5 text-muted-foreground">
+              {section.items.length} entities
+            </p>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+function PreviewBanner({
+  preview,
+  pageId,
+}: {
+  preview: DraftPreviewPageContent
+  pageId: string
+}) {
+  return (
+    <aside className="sticky top-20 z-40 border-b bg-background/92 backdrop-blur-md">
+      <div className="mx-auto flex max-w-6xl flex-col gap-3 px-6 py-4 md:flex-row md:items-center md:justify-between md:px-8">
+        <div>
+          <div className="mb-1 flex flex-wrap items-center gap-2">
+            <Badge>Draft preview</Badge>
+            <Badge variant="outline" className="font-mono">
+              {preview.kind}
+            </Badge>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            PONIX admin preview. Public routes still hide unpublished content.
+          </p>
+        </div>
+        <Button asChild variant="outline" className="w-fit rounded-full">
+          <Link href={`/ponix/pages/${pageId}`}>Back to page record</Link>
+        </Button>
+      </div>
+    </aside>
+  )
+}

--- a/lib/data/content-graph.ts
+++ b/lib/data/content-graph.ts
@@ -241,6 +241,24 @@ export type HistoryPageContent = {
   milestones: HistoryMilestoneItem[]
 }
 
+export type DraftPreviewPageContent =
+  | ({ kind: "performances" } & PerformancePageContent)
+  | ({ kind: "videos" } & VideoPageContent)
+  | ({ kind: "photos" } & PhotoPageContent)
+  | ({ kind: "history" } & HistoryPageContent)
+  | {
+      kind: "generic"
+      page: ContentPageConfig
+      sections: ContentSectionConfig[]
+      graph: GraphPage
+    }
+
+type GraphPageLoadOptions = {
+  id?: string
+  slug?: string
+  includeDrafts?: boolean
+}
+
 function hasSupabaseEnv() {
   return Boolean(
     process.env.NEXT_PUBLIC_SUPABASE_URL &&
@@ -453,17 +471,32 @@ function contentSectionFromGraph(section: GraphSection): ContentSectionConfig {
   }
 }
 
-async function loadGraphPageUncached(slug: string): Promise<GraphPage | null> {
+async function loadGraphPageUncached(
+  query: string | GraphPageLoadOptions,
+): Promise<GraphPage | null> {
   if (!hasSupabaseEnv()) return null
 
   try {
+    const options = typeof query === "string" ? { slug: query } : query
+    const includeDrafts = Boolean(options.includeDrafts)
     const supabase = createPublicClient()
-    const { data: page, error: pageError } = await supabase
+    let pageQuery = supabase
       .from("pages")
       .select("*")
-      .eq("slug", slug)
-      .eq("published", true)
-      .maybeSingle()
+
+    if (options.id) {
+      pageQuery = pageQuery.eq("id", options.id)
+    } else if (options.slug) {
+      pageQuery = pageQuery.eq("slug", options.slug)
+    } else {
+      return null
+    }
+
+    if (!includeDrafts) {
+      pageQuery = pageQuery.eq("published", true)
+    }
+
+    const { data: page, error: pageError } = await pageQuery.maybeSingle()
 
     if (pageError || !page) return null
 
@@ -478,11 +511,16 @@ async function loadGraphPageUncached(slug: string): Promise<GraphPage | null> {
     }
 
     const sectionIds = pageSections.map((pageSection) => pageSection.section_id)
-    const { data: sections, error: sectionsError } = await supabase
+    let sectionsQuery = supabase
       .from("sections")
       .select("*")
       .in("id", sectionIds)
-      .eq("published", true)
+
+    if (!includeDrafts) {
+      sectionsQuery = sectionsQuery.eq("published", true)
+    }
+
+    const { data: sections, error: sectionsError } = await sectionsQuery
 
     if (sectionsError || !sections?.length) {
       return { page, sections: [] }
@@ -496,13 +534,21 @@ async function loadGraphPageUncached(slug: string): Promise<GraphPage | null> {
     if (sectionEntitiesError) return { page, sections: [] }
 
     const entityIds = [...new Set((sectionEntities ?? []).map((item) => item.entity_id))]
-    const { data: entities, error: entitiesError } = entityIds.length
-      ? await supabase
-          .from("entities")
-          .select("*")
-          .in("id", entityIds)
-          .eq("published", true)
-      : { data: [], error: null }
+    let entitiesResult: {
+      data: EntityRow[] | null
+      error: { message: string } | null
+    } = { data: [], error: null }
+
+    if (entityIds.length) {
+      let entitiesQuery = supabase.from("entities").select("*").in("id", entityIds)
+
+      if (!includeDrafts) {
+        entitiesQuery = entitiesQuery.eq("published", true)
+      }
+
+      entitiesResult = await entitiesQuery
+    }
+    const { data: entities, error: entitiesError } = entitiesResult
 
     if (entitiesError) return { page, sections: [] }
 
@@ -864,8 +910,10 @@ function homeActivityFromSectionItem(
   }
 }
 
-async function loadPerformanceSlugsById() {
-  const page = await loadGraphPage("performances")
+async function loadPerformanceSlugsById(includeDrafts = false) {
+  const page = includeDrafts
+    ? await loadGraphPageUncached({ slug: "performances", includeDrafts: true })
+    : await loadGraphPage("performances")
   const entries = sectionItems(page, "performances-archive")
     .map((item) => item.entity)
     .filter((entity) => entity.entity_type === "performance")
@@ -915,7 +963,10 @@ async function loadHomeCurationUncached(): Promise<HomeCuration | null> {
   }
 }
 
-async function loadPerformancePlaylistsFromPage(page: GraphPage | null) {
+async function loadPerformancePlaylistsFromPage(
+  page: GraphPage | null,
+  options: { includeDrafts?: boolean } = {},
+) {
   const performanceEntities = sectionItems(page, "performances-archive")
     .map((item) => item.entity)
     .filter((entity) => entity.entity_type === "performance")
@@ -931,6 +982,7 @@ async function loadPerformancePlaylistsFromPage(page: GraphPage | null) {
   )
 
   try {
+    const includeDrafts = Boolean(options.includeDrafts)
     const supabase = createPublicClient()
     const performanceIds = performanceEntities.map((entity) => entity.id)
     const { data: relations, error: relationsError } = await supabase
@@ -944,13 +996,25 @@ async function loadPerformancePlaylistsFromPage(page: GraphPage | null) {
     const relatedIds = [
       ...new Set((relations ?? []).map((relation) => relation.to_entity_id)),
     ]
-    const { data: relatedEntities, error: relatedEntitiesError } = relatedIds.length
-      ? await supabase
-          .from("entities")
-          .select("*")
-          .in("id", relatedIds)
-          .eq("published", true)
-      : { data: [], error: null }
+    let relatedEntitiesResult: {
+      data: EntityRow[] | null
+      error: { message: string } | null
+    } = { data: [], error: null }
+
+    if (relatedIds.length) {
+      let relatedEntitiesQuery = supabase
+        .from("entities")
+        .select("*")
+        .in("id", relatedIds)
+
+      if (!includeDrafts) {
+        relatedEntitiesQuery = relatedEntitiesQuery.eq("published", true)
+      }
+
+      relatedEntitiesResult = await relatedEntitiesQuery
+    }
+    const { data: relatedEntities, error: relatedEntitiesError } =
+      relatedEntitiesResult
 
     if (relatedEntitiesError) return null
 
@@ -1098,6 +1162,85 @@ async function loadVideoPageUncached(): Promise<VideoPageContent | null> {
     featuredVideos,
     popularVideos,
     libraryVideos,
+  }
+}
+
+export async function loadDraftPreviewPage(
+  pageId: string,
+): Promise<DraftPreviewPageContent | null> {
+  const page = await loadGraphPageUncached({
+    id: pageId,
+    includeDrafts: true,
+  })
+
+  if (!page) return null
+
+  const contentPage = contentPageFromGraph(page.page)
+  const sections = page.sections.map((section) => contentSectionFromGraph(section))
+
+  if (page.page.slug === "performances") {
+    return {
+      kind: "performances",
+      page: contentPage,
+      sections,
+      playlists:
+        (await loadPerformancePlaylistsFromPage(page, { includeDrafts: true })) ??
+        [],
+    }
+  }
+
+  if (page.page.slug === "videos") {
+    const performanceSlugById = await loadPerformanceSlugsById(true)
+
+    return {
+      kind: "videos",
+      page: contentPage,
+      sections,
+      featuredVideos: videosFromSectionItems(
+        sectionItems(page, "videos-featured"),
+        performanceSlugById,
+      ),
+      popularVideos: videosFromSectionItems(
+        sectionItems(page, "videos-popular"),
+        performanceSlugById,
+      ),
+      libraryVideos: sortVideoArchive(
+        videosFromSectionItems(
+          sectionItems(page, "videos-library"),
+          performanceSlugById,
+        ),
+      ),
+    }
+  }
+
+  if (page.page.slug === "photos") {
+    return {
+      kind: "photos",
+      page: contentPage,
+      sections,
+      photos: sectionItems(page, "photos-gallery")
+        .map((item) => photoFromEntity(item.entity))
+        .filter((photo): photo is PhotoArchiveItem => Boolean(photo)),
+    }
+  }
+
+  if (page.page.slug === "history") {
+    return {
+      kind: "history",
+      page: contentPage,
+      sections,
+      milestones: sectionItems(page, "history-timeline")
+        .map((item) => historyFromEntity(item.entity))
+        .filter((item): item is HistoryMilestoneItem => Boolean(item))
+        .sort((left, right) => left.order - right.order),
+    }
+  }
+
+  return {
+    kind: "generic",
+    page: contentPage,
+    sections,
+    graph: page,
   }
 }
 


### PR DESCRIPTION
Closes #29

Summary
- Adds admin-only /ponix/preview/pages/[id] draft preview route.
- Adds Preview page action to PONIX page detail records.
- Adds explicit uncached draft graph loading that includes unpublished pages, sections, and entities only for the preview route.
- Keeps public cached graph loading published-only by default.
- Reuses public renderers for performances, videos, photos, and history pages, with a generic preview fallback for non-renderer pages.

Checks
- git diff --check
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm run build

Supabase impact
- No schema, RLS, auth, storage, or content row changes.
- Read-only preview loading only.