### PR TITLE
[CMS] Normalize entity thumbnail uploads

### DIFF
--- a/app/ponix/_components/cms-entity-create-form.tsx
+++ b/app/ponix/_components/cms-entity-create-form.tsx
@@ -134,8 +134,8 @@ function ThumbnailCard() {
           Thumbnail upload
         </CardTitle>
         <CardDescription>
-          An uploaded image is stored in Supabase Storage and saved as the
-          entity thumbnail URL.
+          An uploaded image is stored in the shared images bucket and saved as
+          the entity thumbnail URL.
         </CardDescription>
       </CardHeader>
       <CardContent className="px-6 py-6">
@@ -143,7 +143,8 @@ function ThumbnailCard() {
           <Label htmlFor="thumbnail_file">Upload image</Label>
           <ProfileImageInput id="thumbnail_file" name="thumbnail_file" />
           <p className="text-xs leading-relaxed text-muted-foreground">
-            You can also paste a URL in the thumbnail field below.
+            You can also paste a URL in the thumbnail field below for
+            already-hosted assets.
           </p>
         </div>
       </CardContent>

--- a/app/ponix/_components/cms-entity-form.tsx
+++ b/app/ponix/_components/cms-entity-form.tsx
@@ -163,8 +163,8 @@ function ThumbnailCard({ detail }: { detail: CmsEntityDetail }) {
           Thumbnail upload
         </CardTitle>
         <CardDescription>
-          Uploading a new image stores it in Supabase Storage and replaces
-          <code> thumbnail_url</code>.
+          Uploading a new image stores it in the shared images bucket and
+          replaces <code>thumbnail_url</code>.
         </CardDescription>
       </CardHeader>
       <CardContent className="grid gap-5 px-6 py-6 md:grid-cols-[12rem_minmax(0,1fr)]">
@@ -187,7 +187,7 @@ function ThumbnailCard({ detail }: { detail: CmsEntityDetail }) {
           <ProfileImageInput id="thumbnail_file" name="thumbnail_file" />
           <p className="text-xs leading-relaxed text-muted-foreground">
             Leave empty to keep the current URL. Manual URL edits are available
-            in Entity fields.
+            in Entity fields for already-hosted assets.
           </p>
         </div>
       </CardContent>

--- a/app/ponix/entities/actions.ts
+++ b/app/ponix/entities/actions.ts
@@ -34,6 +34,7 @@ type ParsedValue =
     }
 
 const maxThumbnailSize = 5 * 1024 * 1024
+const entityThumbnailBucket = "images"
 
 function stringField(formData: FormData, key: string) {
   const value = formData.get(key)
@@ -251,17 +252,6 @@ function extensionFromImage(file: File) {
   return "jpg"
 }
 
-function thumbnailBucket(entity: EntityRow) {
-  if (
-    entity.entity_type === "performance" ||
-    entity.schema_key.startsWith("performance/")
-  ) {
-    return "posters"
-  }
-
-  return "photos"
-}
-
 async function uploadThumbnailIfPresent({
   supabase,
   entity,
@@ -288,15 +278,17 @@ async function uploadThumbnailIfPresent({
     })
   }
 
-  const bucket = thumbnailBucket(entity)
   const extension = extensionFromImage(file)
   const safeKey = (entity.slug ?? entity.id).replace(/[^a-zA-Z0-9._-]+/g, "-")
-  const path = `entities/${entity.id}/${safeKey}-thumbnail-${Date.now()}.${extension}`
-  const { error } = await supabase.storage.from(bucket).upload(path, file, {
-    cacheControl: "3600",
-    contentType: file.type || `image/${extension}`,
-    upsert: true,
-  })
+  const safeType = entity.entity_type.replace(/[^a-zA-Z0-9._-]+/g, "-")
+  const path = `entities/${safeType}/${entity.id}/${safeKey}-thumbnail-${Date.now()}.${extension}`
+  const { error } = await supabase.storage
+    .from(entityThumbnailBucket)
+    .upload(path, file, {
+      cacheControl: "3600",
+      contentType: file.type || `image/${extension}`,
+      upsert: true,
+    })
 
   if (error) {
     redirectWithParams(editPath, {
@@ -304,7 +296,7 @@ async function uploadThumbnailIfPresent({
     })
   }
 
-  return supabase.storage.from(bucket).getPublicUrl(path).data.publicUrl
+  return supabase.storage.from(entityThumbnailBucket).getPublicUrl(path).data.publicUrl
 }
 
 export async function createCmsEntityAction(formData: FormData) {


### PR DESCRIPTION
Closes #31

Summary
- Routes CMS entity thumbnail uploads into the shared public `images` bucket.
- Saves the returned public Storage URL back into `entities.thumbnail_url`.
- Keeps manual thumbnail URL edits available for already-hosted assets.

Validation
- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `git diff --check`
- `pnpm run build`

Guardrails
- No Supabase schema changes.
- No Storage object deletion or migration.
- No RLS/policy changes.