### PR TITLE
[CMS] Add page metadata editor

### DIFF
--- a/app/ponix/_components/cms-page-form.tsx
+++ b/app/ponix/_components/cms-page-form.tsx
@@ -1,0 +1,280 @@
+import Link from "next/link"
+
+import { updateCmsPageAction } from "@/app/ponix/pages/actions"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import type { CmsContentDetail } from "@/lib/cms/content"
+import {
+  cmsPageFieldInputName,
+  getEditablePageFields,
+  getPageEditorSchema,
+  getPageFieldValue,
+  type CmsEditablePageField,
+} from "@/lib/cms/page-editor"
+
+type CmsPageDetail = Extract<CmsContentDetail, { kind: "page" }>
+
+export function CmsPageEditorPage({
+  detail,
+  error,
+}: {
+  detail: CmsPageDetail
+  error?: string
+}) {
+  const schema = getPageEditorSchema()
+  const editableFields = getEditablePageFields()
+  const columnFields = editableFields.filter((field) => field.source === "column")
+  const propsFields = editableFields.filter((field) => field.source === "props")
+
+  return (
+    <main className="relative min-h-[calc(100vh-5rem)] overflow-hidden">
+      <div className="pointer-events-none absolute inset-0 -z-10">
+        <div className="absolute right-[-10rem] top-10 h-96 w-96 rounded-full bg-accent/10 blur-3xl" />
+        <div className="absolute left-[-8rem] bottom-0 h-80 w-80 rounded-full bg-muted blur-3xl" />
+      </div>
+
+      <section className="mx-auto max-w-5xl px-6 py-16 md:px-8 md:py-24">
+        <div className="mb-10 flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+          <div>
+            <p className="caps mb-5">PONIX / Edit page</p>
+            <h1 className="font-serif text-[clamp(3.25rem,8vw,6.5rem)] italic leading-[0.84] tracking-tight">
+              {detail.title}
+            </h1>
+            <p className="mt-5 max-w-2xl text-sm leading-relaxed text-muted-foreground md:text-base">
+              Edit route-level copy, publish state, and registered page props.
+            </p>
+            <div className="mt-6 flex flex-wrap items-center gap-2">
+              <Badge variant="outline" className="rounded-full font-mono">
+                /{detail.row.slug === "home" ? "" : detail.row.slug}
+              </Badge>
+              <Badge variant="secondary" className="rounded-full">
+                {schema?.label ?? "Unregistered schema"}
+              </Badge>
+            </div>
+          </div>
+          <Button asChild variant="outline" className="w-fit rounded-full">
+            <Link href={`/ponix/pages/${detail.row.id}`}>Back to page</Link>
+          </Button>
+        </div>
+
+        {!schema ? (
+          <Alert variant="destructive">
+            <AlertTitle>Schema is not editable</AlertTitle>
+            <AlertDescription>
+              The default page schema is not registered as a page editor schema.
+            </AlertDescription>
+          </Alert>
+        ) : (
+          <form action={updateCmsPageAction} className="space-y-6">
+            <input type="hidden" name="page_id" value={detail.row.id} />
+
+            {error && (
+              <Alert variant="destructive">
+                <AlertTitle>Save failed</AlertTitle>
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+
+            <Card className="rounded-md bg-card/95 shadow-xl">
+              <CardHeader className="border-b">
+                <CardTitle className="font-serif text-3xl italic">
+                  Locked route
+                </CardTitle>
+                <CardDescription>
+                  Page slug controls the public route and stays locked in this
+                  editor.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="grid gap-4 px-6 py-6 md:grid-cols-2">
+                <ReadonlyMeta label="Slug" value={detail.row.slug} />
+                <ReadonlyMeta label="ID" value={detail.row.id} />
+              </CardContent>
+            </Card>
+
+            <EditorCard
+              title="Page fields"
+              description="Route-level copy and publish state."
+              fields={columnFields}
+              detail={detail}
+            />
+
+            <EditorCard
+              title="Page props"
+              description="Schema-registered JSON props for page-level metadata."
+              fields={propsFields}
+              detail={detail}
+            />
+
+            <div className="flex flex-col gap-3 rounded-md border bg-card/95 p-4 shadow-xl sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-sm text-muted-foreground">
+                Saving updates this page row only. Section composition stays
+                untouched.
+              </p>
+              <div className="flex gap-2">
+                <Button asChild type="button" variant="outline">
+                  <Link href={`/ponix/pages/${detail.row.id}`}>Cancel</Link>
+                </Button>
+                <Button type="submit">Save page</Button>
+              </div>
+            </div>
+          </form>
+        )}
+      </section>
+    </main>
+  )
+}
+
+function EditorCard({
+  title,
+  description,
+  fields,
+  detail,
+}: {
+  title: string
+  description: string
+  fields: CmsEditablePageField[]
+  detail: CmsPageDetail
+}) {
+  return (
+    <Card className="rounded-md bg-card/95 shadow-xl">
+      <CardHeader className="border-b">
+        <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+          <div>
+            <CardTitle className="font-serif text-3xl italic">{title}</CardTitle>
+            <CardDescription>{description}</CardDescription>
+          </div>
+          <p className="caps text-muted-foreground">{fields.length} fields</p>
+        </div>
+      </CardHeader>
+      <CardContent className="grid gap-5 px-6 py-6 md:grid-cols-2">
+        {fields.length > 0 ? (
+          fields.map((field) => (
+            <EditorField key={`${field.source}:${field.key}`} field={field} detail={detail} />
+          ))
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            No editable fields in this group.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function EditorField({
+  field,
+  detail,
+}: {
+  field: CmsEditablePageField
+  detail: CmsPageDetail
+}) {
+  const id = `page-${field.source}-${field.key}`
+  const name = cmsPageFieldInputName(field)
+  const value = getPageFieldValue(detail.row, field)
+  const wide = field.type === "textarea" || field.type === "json"
+
+  return (
+    <div className={wide ? "space-y-2 md:col-span-2" : "space-y-2"}>
+      <div className="flex items-center gap-2">
+        <Label htmlFor={id}>{field.label}</Label>
+        {field.required && (
+          <Badge variant="outline" className="rounded-full">
+            Required
+          </Badge>
+        )}
+      </div>
+      {renderFieldInput({ field, id, name, value })}
+      <p className="font-mono text-xs text-muted-foreground">
+        {field.source}.{field.key}
+      </p>
+      {field.description && (
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          {field.description}
+        </p>
+      )}
+    </div>
+  )
+}
+
+function renderFieldInput({
+  field,
+  id,
+  name,
+  value,
+}: {
+  field: CmsEditablePageField
+  id: string
+  name: string
+  value: unknown
+}) {
+  if (field.type === "boolean") {
+    return (
+      <div className="flex h-11 items-center gap-3 rounded-md border bg-background/70 px-3">
+        <input type="hidden" name={name} value="false" />
+        <Checkbox
+          id={id}
+          name={name}
+          value="true"
+          defaultChecked={Boolean(value)}
+        />
+        <Label htmlFor={id} className="text-sm font-normal">
+          Published
+        </Label>
+      </div>
+    )
+  }
+
+  if (field.type === "textarea" || field.type === "json") {
+    return (
+      <Textarea
+        id={id}
+        name={name}
+        defaultValue={fieldDefaultText(field, value)}
+        rows={field.type === "json" ? 10 : 5}
+        className="bg-background/70"
+      />
+    )
+  }
+
+  return (
+    <Input
+      id={id}
+      name={name}
+      defaultValue={fieldDefaultText(field, value)}
+      className="h-11 bg-background/70"
+    />
+  )
+}
+
+function fieldDefaultText(field: CmsEditablePageField, value: unknown) {
+  if (value === null || value === undefined) {
+    return ""
+  }
+
+  if (field.type === "json") {
+    return JSON.stringify(value, null, 2)
+  }
+
+  return String(value)
+}
+
+function ReadonlyMeta({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border bg-background/60 p-4">
+      <p className="caps mb-2 text-muted-foreground">{label}</p>
+      <p className="break-all font-mono text-xs">{value}</p>
+    </div>
+  )
+}

--- a/app/ponix/pages/[id]/edit/page.tsx
+++ b/app/ponix/pages/[id]/edit/page.tsx
@@ -1,0 +1,40 @@
+import type { Metadata } from "next"
+import { notFound } from "next/navigation"
+
+import { CmsPageEditorPage } from "@/app/ponix/_components/cms-page-form"
+import { requireCmsAdmin } from "@/lib/cms/auth"
+import { loadCmsPageDetail } from "@/lib/cms/content"
+
+export const metadata: Metadata = {
+  title: "PONIX Edit Page | 브레멘 Bremen",
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
+
+type PonixEditPageRecordPageProps = {
+  params: Promise<{ id: string }>
+  searchParams?: Promise<Record<string, string | string[] | undefined>>
+}
+
+export default async function PonixEditPageRecordPage({
+  params,
+  searchParams,
+}: PonixEditPageRecordPageProps) {
+  const { id } = await params
+
+  await requireCmsAdmin(`/ponix/pages/${id}/edit`)
+  const [detail, search] = await Promise.all([
+    loadCmsPageDetail(id),
+    searchParams,
+  ])
+
+  if (!detail || detail.kind !== "page") {
+    notFound()
+  }
+
+  const error = typeof search?.error === "string" ? search.error : undefined
+
+  return <CmsPageEditorPage detail={detail} error={error} />
+}

--- a/app/ponix/pages/[id]/page.tsx
+++ b/app/ponix/pages/[id]/page.tsx
@@ -53,12 +53,20 @@ export default async function PonixPageRecordPage({
       backHref="/ponix/pages"
       backLabel="All pages"
       actions={
-        <Link
-          href={`/ponix/preview/pages/${id}`}
-          className="inline-flex h-9 items-center justify-center rounded-full bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-xs transition-colors hover:bg-primary/90"
-        >
-          Preview page
-        </Link>
+        <div className="flex flex-wrap gap-2">
+          <Link
+            href={`/ponix/pages/${id}/edit`}
+            className="inline-flex h-9 items-center justify-center rounded-full border border-input bg-background px-4 py-2 text-sm font-medium shadow-xs transition-colors hover:bg-accent hover:text-accent-foreground"
+          >
+            Edit page
+          </Link>
+          <Link
+            href={`/ponix/preview/pages/${id}`}
+            className="inline-flex h-9 items-center justify-center rounded-full bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-xs transition-colors hover:bg-primary/90"
+          >
+            Preview page
+          </Link>
+        </div>
       }
     >
       <RelationMutationNotice

--- a/app/ponix/pages/actions.ts
+++ b/app/ponix/pages/actions.ts
@@ -1,0 +1,231 @@
+"use server"
+
+import { revalidatePath, updateTag } from "next/cache"
+import { redirect } from "next/navigation"
+
+import { requireCmsAdmin } from "@/lib/cms/auth"
+import {
+  cmsPageFieldInputName,
+  getEditablePageFields,
+  getPageEditorSchema,
+  jsonObject,
+  type CmsEditablePageField,
+  type CmsJsonObject,
+} from "@/lib/cms/page-editor"
+import { PUBLIC_CONTENT_CACHE_TAG } from "@/lib/data/public-cache"
+import { createClient } from "@/lib/supabase/server"
+import type { Database, Json } from "@/lib/supabase/types"
+
+type PageUpdate = Database["public"]["Tables"]["pages"]["Update"]
+
+type ParsedValue =
+  | {
+      ok: true
+      empty: boolean
+      value: Json
+    }
+  | {
+      ok: false
+      error: string
+    }
+
+function stringField(formData: FormData, key: string) {
+  const value = formData.get(key)
+  return typeof value === "string" ? value.trim() : ""
+}
+
+function redirectWithParams(path: string, params: Record<string, string>): never {
+  const [pathname, currentSearch = ""] = path.split("?")
+  const search = new URLSearchParams(currentSearch)
+
+  for (const [key, value] of Object.entries(params)) {
+    search.set(key, value)
+  }
+
+  redirect(`${pathname}?${search.toString()}`)
+}
+
+function revalidatePageSurfaces(pageId: string, slug?: string) {
+  revalidatePath("/")
+  revalidatePath("/performances")
+  revalidatePath("/performances/updates")
+  revalidatePath("/videos")
+  revalidatePath("/photos")
+  revalidatePath("/history")
+
+  if (slug && slug !== "home") {
+    revalidatePath(`/${slug}`)
+  }
+
+  updateTag(PUBLIC_CONTENT_CACHE_TAG)
+  revalidatePath("/ponix")
+  revalidatePath("/ponix/pages")
+  revalidatePath(`/ponix/pages/${pageId}`)
+  revalidatePath(`/ponix/pages/${pageId}/edit`)
+}
+
+function parseBoolean(formData: FormData, field: CmsEditablePageField): ParsedValue {
+  const values = formData.getAll(cmsPageFieldInputName(field))
+
+  return {
+    ok: true,
+    empty: false,
+    value: values.includes("true"),
+  }
+}
+
+function parseJson(formData: FormData, field: CmsEditablePageField): ParsedValue {
+  const value = stringField(formData, cmsPageFieldInputName(field))
+
+  if (!value) {
+    if (field.required) {
+      return { ok: false, error: `${field.label} is required.` }
+    }
+
+    return { ok: true, empty: true, value: null }
+  }
+
+  try {
+    return {
+      ok: true,
+      empty: false,
+      value: JSON.parse(value) as Json,
+    }
+  } catch {
+    return { ok: false, error: `${field.label} must be valid JSON.` }
+  }
+}
+
+function parseTextLike(
+  formData: FormData,
+  field: CmsEditablePageField,
+): ParsedValue {
+  const value = stringField(formData, cmsPageFieldInputName(field))
+
+  if (!value) {
+    if (field.required) {
+      return { ok: false, error: `${field.label} is required.` }
+    }
+
+    return { ok: true, empty: true, value: null }
+  }
+
+  return {
+    ok: true,
+    empty: false,
+    value,
+  }
+}
+
+function parseFieldValue(
+  formData: FormData,
+  field: CmsEditablePageField,
+): ParsedValue {
+  if (field.type === "boolean") {
+    return parseBoolean(formData, field)
+  }
+
+  if (field.type === "json") {
+    return parseJson(formData, field)
+  }
+
+  return parseTextLike(formData, field)
+}
+
+function updatePropsValue(
+  props: CmsJsonObject,
+  field: CmsEditablePageField,
+  parsed: ParsedValue & { ok: true },
+) {
+  if (parsed.empty) {
+    delete props[field.key]
+    return
+  }
+
+  props[field.key] = parsed.value
+}
+
+export async function updateCmsPageAction(formData: FormData) {
+  const pageId = stringField(formData, "page_id")
+
+  if (!pageId) {
+    redirectWithParams("/ponix/pages", {
+      error: "Missing page id.",
+    })
+  }
+
+  const editPath = `/ponix/pages/${pageId}/edit`
+  await requireCmsAdmin(editPath)
+
+  const schema = getPageEditorSchema()
+  if (!schema) {
+    redirectWithParams(editPath, {
+      error: "The page editor schema is not registered.",
+    })
+  }
+
+  const supabase = await createClient()
+  const { data: page, error: loadError } = await supabase
+    .from("pages")
+    .select("*")
+    .eq("id", pageId)
+    .maybeSingle()
+
+  if (loadError || !page) {
+    redirectWithParams(editPath, {
+      error: "Page not found.",
+    })
+  }
+
+  const fields = getEditablePageFields()
+  const props = jsonObject(page.props)
+  const update: PageUpdate = {}
+
+  for (const field of fields) {
+    const parsed = parseFieldValue(formData, field)
+
+    if (!parsed.ok) {
+      redirectWithParams(editPath, {
+        error: parsed.error,
+      })
+    }
+
+    if (field.source === "props") {
+      updatePropsValue(props, field, parsed)
+      continue
+    }
+
+    if (field.key === "published") {
+      update.published = Boolean(parsed.value)
+    }
+
+    if (field.key === "title") {
+      update.title = String(parsed.value)
+    }
+
+    if (field.key === "subtitle") {
+      update.subtitle = parsed.value === null ? null : String(parsed.value)
+    }
+
+    if (field.key === "description") {
+      update.description = parsed.value === null ? null : String(parsed.value)
+    }
+  }
+
+  update.props = props
+
+  const { error: updateError } = await supabase
+    .from("pages")
+    .update(update)
+    .eq("id", pageId)
+
+  if (updateError) {
+    redirectWithParams(editPath, {
+      error: "Page save failed.",
+    })
+  }
+
+  revalidatePageSurfaces(pageId, page.slug)
+
+  redirect(`/ponix/pages/${pageId}`)
+}

--- a/app/ponix/pages/page.tsx
+++ b/app/ponix/pages/page.tsx
@@ -35,7 +35,7 @@ export default async function PonixPagesPage() {
     <CmsListPage
       eyebrow="PONIX / Pages"
       title="Pages"
-      description="Route-level content records. This view is read-only; edits and publish controls are intentionally not available yet."
+      description="Route-level records for page copy, publish state, and section composition."
     >
       <CmsTableCard title="Page records" meta={`${pages.length} records`}>
         <Table>

--- a/lib/cms/page-editor.ts
+++ b/lib/cms/page-editor.ts
@@ -1,0 +1,75 @@
+import type {
+  CmsFieldDefinition,
+  CmsSchemaDefinition,
+} from "@/lib/cms/schema-registry"
+import { getCmsSchema } from "@/lib/cms/schema-registry"
+import type { Database, Json } from "@/lib/supabase/types"
+
+type PageRow = Database["public"]["Tables"]["pages"]["Row"]
+
+const editablePageColumns = new Set([
+  "title",
+  "subtitle",
+  "description",
+  "published",
+])
+
+export type CmsEditablePageField = CmsFieldDefinition & {
+  source: "column" | "props"
+}
+
+export type CmsJsonObject = Record<string, Json>
+
+export function cmsPageFieldInputName(field: CmsFieldDefinition) {
+  return `cms:${field.source}:${field.key}`
+}
+
+export function getPageEditorSchema(): CmsSchemaDefinition | null {
+  const schema = getCmsSchema("page/default/v1")
+
+  if (!schema || schema.kind !== "page" || schema.table !== "pages") {
+    return null
+  }
+
+  return schema
+}
+
+export function getEditablePageFields() {
+  const schema = getPageEditorSchema()
+
+  if (!schema) {
+    return []
+  }
+
+  return schema.fields.filter((field): field is CmsEditablePageField => {
+    if (field.readOnly) {
+      return false
+    }
+
+    if (field.source === "props") {
+      return true
+    }
+
+    return field.source === "column" && editablePageColumns.has(field.key)
+  })
+}
+
+export function jsonObject(value: Json): CmsJsonObject {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {}
+  }
+
+  return { ...(value as CmsJsonObject) }
+}
+
+export function getPageFieldValue(
+  page: PageRow,
+  field: CmsEditablePageField,
+) {
+  if (field.source === "props") {
+    return jsonObject(page.props)[field.key]
+  }
+
+  const row = page as unknown as Record<string, unknown>
+  return row[field.key]
+}


### PR DESCRIPTION
Closes #33

Summary
- Adds registered page editor helpers for `page/default/v1`.
- Adds guarded page update server action for title, subtitle, description, publish state, and page props.
- Adds `/ponix/pages/[id]/edit` and page detail entry points while keeping slug locked.

Validation
- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `git diff --check`
- `pnpm run build`

Guardrails
- No page create/delete flow.
- No Supabase schema changes.
- No RLS/policy changes.