### PR TITLE
[CMS] Add audit trail foundation

### DIFF
--- a/app/ponix/page.tsx
+++ b/app/ponix/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { loadRecentCmsAuditEvents, type CmsAuditEvent } from "@/lib/cms/audit"
 import { requireCmsAdmin } from "@/lib/cms/auth"
 import {
   getCmsSchemaStats,
@@ -21,7 +22,10 @@ export const metadata: Metadata = {
 }
 
 export default async function PonixPage() {
-  const member = await requireCmsAdmin("/ponix")
+  const [member, audit] = await Promise.all([
+    requireCmsAdmin("/ponix"),
+    loadRecentCmsAuditEvents(),
+  ])
   const stats = getCmsSchemaStats()
   const schemaGroups: Array<{
     kind: CmsSchemaKind
@@ -147,7 +151,84 @@ export default async function PonixPage() {
             )
           })}
         </div>
+
+        <Card className="mt-5 rounded-md border bg-card/95 shadow-xl">
+          <CardHeader>
+            <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+              <div>
+                <CardTitle className="font-serif text-3xl italic">
+                  Recent audit trail
+                </CardTitle>
+                <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                  Append-only CMS changes recorded at the database boundary.
+                </p>
+              </div>
+              <Badge
+                variant={audit.available ? "outline" : "secondary"}
+                className="w-fit rounded-full"
+              >
+                {audit.available ? "Audit enabled" : "Migration pending"}
+              </Badge>
+            </div>
+          </CardHeader>
+          <CardContent>
+            {audit.events.length > 0 ? (
+              <div className="divide-y rounded-md border">
+                {audit.events.map((event) => (
+                  <AuditEventRow key={event.id} event={event} />
+                ))}
+              </div>
+            ) : (
+              <p className="rounded-md border bg-background/60 p-4 text-sm leading-relaxed text-muted-foreground">
+                {audit.available
+                  ? "No CMS changes have been recorded yet."
+                  : "The audit migration has not been applied to this database yet. PONIX remains usable; audit events will appear after the migration is applied."}
+              </p>
+            )}
+          </CardContent>
+        </Card>
       </section>
     </main>
   )
+}
+
+function AuditEventRow({ event }: { event: CmsAuditEvent }) {
+  return (
+    <div className="grid gap-3 bg-background/50 p-4 md:grid-cols-[10rem_minmax(0,1fr)_12rem] md:items-center">
+      <div>
+        <Badge variant="outline" className="rounded-full">
+          {event.action}
+        </Badge>
+        <p className="mt-2 text-xs text-muted-foreground">
+          {formatAuditTime(event.createdAt)}
+        </p>
+      </div>
+      <div className="min-w-0">
+        <p className="font-medium">
+          {event.targetTable}
+          {event.targetId && (
+            <span className="ml-2 font-mono text-xs text-muted-foreground">
+              {event.targetId.slice(0, 8)}
+            </span>
+          )}
+        </p>
+        <p className="mt-1 truncate text-xs text-muted-foreground">
+          {event.changedKeys.length > 0
+            ? event.changedKeys.join(", ")
+            : "No top-level field diff"}
+        </p>
+      </div>
+      <p className="font-mono text-xs text-muted-foreground md:text-right">
+        {event.actorMemberId ? event.actorMemberId.slice(0, 8) : "system"}
+      </p>
+    </div>
+  )
+}
+
+function formatAuditTime(value: string) {
+  return new Intl.DateTimeFormat("ko-KR", {
+    dateStyle: "short",
+    timeStyle: "short",
+    timeZone: "Asia/Seoul",
+  }).format(new Date(value))
 }

--- a/docs/cms-audit.md
+++ b/docs/cms-audit.md
@@ -1,0 +1,71 @@
+# CMS Audit and Revision Strategy
+
+PONIX CMS writes are admin-gated, but they still mutate shared content rows.
+The audit layer is intentionally append-only and recovery-focused: it records
+what changed, but it does not add broad rollback controls in the first slice.
+
+## First Slice
+
+Migration `20260505000039_cms_audit_events.sql` adds
+`public.cms_audit_events` and database triggers on:
+
+- `pages`
+- `sections`
+- `entities`
+- `page_sections`
+- `section_entities`
+- `entity_relations`
+
+Each audit event stores:
+
+- `actor_member_id`: current member resolved from Supabase Auth when available
+- `action`: `insert`, `update`, or `delete`
+- `target_table` and `target_id`
+- `before_data` and `after_data` row snapshots
+- `changed_keys`: top-level row keys that changed
+- `metadata`: reserved JSONB object for future narrow annotations
+
+## Why Trigger-Based
+
+The CMS already has several write paths. Trigger-based audit logging keeps the
+recording behavior close to the data boundary, so future PONIX actions do not
+silently bypass audit logging.
+
+The app may still surface audit events, but app UI is not the authority for
+creating them.
+
+## RLS and Access
+
+`cms_audit_events` has RLS enabled.
+
+- Admin members can read audit events.
+- Admin members can insert audit events if a future server action needs a
+  narrow manual annotation.
+- Trigger writes run through a private `security definer` function.
+
+No public CMS route exposes this data.
+
+## Migration Safety
+
+The app treats the audit table as best-effort until the migration is applied.
+If production deploys before the migration, PONIX still loads and simply hides
+the recent-audit surface.
+
+Production migration application still requires maintainer review and an
+explicit migration apply step.
+
+## Non-Goals
+
+- No broad restore or rollback UI.
+- No destructive delete controls.
+- No logging of auth tokens, secrets, or request payloads.
+- No auditing of `members` or auth tables in this slice.
+
+## Future Work
+
+Useful next slices:
+
+- Detail-page audit history for one record.
+- Admin-only diff viewer for `before_data` and `after_data`.
+- Narrow restore flow with explicit field-level preview and confirmation.
+- Scheduled retention/export policy if the audit table grows too large.

--- a/docs/supabase-setup.md
+++ b/docs/supabase-setup.md
@@ -112,6 +112,7 @@ Good names:
 - `update_home_join_copy`
 - `link_new_performance_recordings`
 - `tighten_member_profile_policy`
+- `add_cms_audit_events`
 
 Bad names:
 
@@ -159,6 +160,13 @@ pnpm dlx supabase db push
 ```
 
 Maintainers using Supabase MCP can apply the same migration SQL with `apply_migration`, but the migration file must still be committed.
+
+## CMS Audit Trail
+
+PONIX CMS write auditing is documented in `docs/cms-audit.md`.
+The audit table is append-only and migration-backed. Do not add restore or
+rollback controls without a separate issue that defines the exact recovery
+behavior and safety checks.
 
 ## Type Generation
 

--- a/lib/cms/audit.ts
+++ b/lib/cms/audit.ts
@@ -1,0 +1,48 @@
+import { createClient } from "@/lib/supabase/server"
+
+export type CmsAuditEvent = {
+  id: string
+  createdAt: string
+  actorMemberId: string | null
+  action: string
+  targetTable: string
+  targetId: string | null
+  changedKeys: string[]
+}
+
+export type CmsAuditEventList = {
+  available: boolean
+  events: CmsAuditEvent[]
+}
+
+export async function loadRecentCmsAuditEvents(
+  limit = 8,
+): Promise<CmsAuditEventList> {
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from("cms_audit_events")
+    .select(
+      "id, created_at, actor_member_id, action, target_table, target_id, changed_keys",
+    )
+    .order("created_at", { ascending: false })
+    .limit(limit)
+
+  if (error) {
+    // The audit migration may be reviewed and applied after the app deploy.
+    // Keep PONIX usable until the migration is present in the target DB.
+    return { available: false, events: [] }
+  }
+
+  return {
+    available: true,
+    events: (data ?? []).map((event) => ({
+      id: event.id,
+      createdAt: event.created_at,
+      actorMemberId: event.actor_member_id,
+      action: event.action,
+      targetTable: event.target_table,
+      targetId: event.target_id,
+      changedKeys: event.changed_keys,
+    })),
+  }
+}

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -17,6 +17,53 @@ export type Database = {
   }
   public: {
     Tables: {
+      cms_audit_events: {
+        Row: {
+          action: string
+          actor_member_id: string | null
+          after_data: Json | null
+          before_data: Json | null
+          changed_keys: string[]
+          created_at: string
+          id: string
+          metadata: Json
+          target_id: string | null
+          target_table: string
+        }
+        Insert: {
+          action: string
+          actor_member_id?: string | null
+          after_data?: Json | null
+          before_data?: Json | null
+          changed_keys?: string[]
+          created_at?: string
+          id?: string
+          metadata?: Json
+          target_id?: string | null
+          target_table: string
+        }
+        Update: {
+          action?: string
+          actor_member_id?: string | null
+          after_data?: Json | null
+          before_data?: Json | null
+          changed_keys?: string[]
+          created_at?: string
+          id?: string
+          metadata?: Json
+          target_id?: string | null
+          target_table?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "cms_audit_events_actor_member_id_fkey"
+            columns: ["actor_member_id"]
+            isOneToOne: false
+            referencedRelation: "members"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       entities: {
         Row: {
           created_at: string

--- a/supabase/migrations/20260505000039_cms_audit_events.sql
+++ b/supabase/migrations/20260505000039_cms_audit_events.sql
@@ -1,0 +1,175 @@
+-- Bremen — append-only CMS audit trail for PONIX writes.
+--
+-- This migration is intentionally additive. It records CMS content graph
+-- mutations without adding restore/delete controls. Production application
+-- still requires maintainer review and an explicit migration apply step.
+
+create table if not exists public.cms_audit_events (
+  id              uuid primary key default gen_random_uuid(),
+  created_at      timestamptz not null default now(),
+  actor_member_id uuid references public.members(id) on delete set null,
+  action          text not null,
+  target_table    text not null,
+  target_id       uuid,
+  before_data     jsonb,
+  after_data      jsonb,
+  changed_keys    text[] not null default '{}',
+  metadata        jsonb not null default '{}'::jsonb,
+  check (action in ('insert', 'update', 'delete')),
+  check (
+    target_table in (
+      'pages',
+      'sections',
+      'entities',
+      'page_sections',
+      'section_entities',
+      'entity_relations'
+    )
+  ),
+  check (before_data is null or jsonb_typeof(before_data) = 'object'),
+  check (after_data is null or jsonb_typeof(after_data) = 'object'),
+  check (jsonb_typeof(metadata) = 'object')
+);
+
+create index if not exists cms_audit_events_created_at_idx
+  on public.cms_audit_events(created_at desc);
+
+create index if not exists cms_audit_events_target_idx
+  on public.cms_audit_events(target_table, target_id, created_at desc);
+
+create index if not exists cms_audit_events_actor_idx
+  on public.cms_audit_events(actor_member_id, created_at desc);
+
+alter table public.cms_audit_events enable row level security;
+
+drop policy if exists "cms_audit_events_admin_read"
+  on public.cms_audit_events;
+create policy "cms_audit_events_admin_read"
+  on public.cms_audit_events
+  for select
+  using (private.is_admin());
+
+drop policy if exists "cms_audit_events_admin_insert"
+  on public.cms_audit_events;
+create policy "cms_audit_events_admin_insert"
+  on public.cms_audit_events
+  for insert
+  with check (private.is_admin());
+
+create or replace function private.cms_audit_changed_keys(
+  old_row jsonb,
+  new_row jsonb
+)
+returns text[]
+language sql
+stable
+set search_path = public
+as $$
+  with keys as (
+    select key from jsonb_each(coalesce(old_row, '{}'::jsonb))
+    union
+    select key from jsonb_each(coalesce(new_row, '{}'::jsonb))
+  )
+  select coalesce(array_agg(key order by key), '{}'::text[])
+  from keys
+  where coalesce(old_row, '{}'::jsonb)->key
+    is distinct from coalesce(new_row, '{}'::jsonb)->key;
+$$;
+
+revoke all on function private.cms_audit_changed_keys(jsonb, jsonb) from public;
+
+create or replace function private.record_cms_audit_event()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, auth, private
+as $$
+declare
+  before_snapshot jsonb;
+  after_snapshot jsonb;
+  audit_action text;
+  row_id uuid;
+begin
+  if tg_op = 'INSERT' then
+    audit_action := 'insert';
+    before_snapshot := null;
+    after_snapshot := to_jsonb(new);
+    row_id := new.id;
+  elsif tg_op = 'UPDATE' then
+    audit_action := 'update';
+    before_snapshot := to_jsonb(old);
+    after_snapshot := to_jsonb(new);
+    row_id := new.id;
+  elsif tg_op = 'DELETE' then
+    audit_action := 'delete';
+    before_snapshot := to_jsonb(old);
+    after_snapshot := null;
+    row_id := old.id;
+  else
+    return null;
+  end if;
+
+  insert into public.cms_audit_events (
+    actor_member_id,
+    action,
+    target_table,
+    target_id,
+    before_data,
+    after_data,
+    changed_keys
+  )
+  values (
+    private.current_member_id(),
+    audit_action,
+    tg_table_name,
+    row_id,
+    before_snapshot,
+    after_snapshot,
+    private.cms_audit_changed_keys(before_snapshot, after_snapshot)
+  );
+
+  if tg_op = 'DELETE' then
+    return old;
+  end if;
+
+  return new;
+end;
+$$;
+
+revoke all on function private.record_cms_audit_event() from public;
+
+drop trigger if exists pages_cms_audit on public.pages;
+create trigger pages_cms_audit
+  after insert or update or delete on public.pages
+  for each row
+  execute function private.record_cms_audit_event();
+
+drop trigger if exists sections_cms_audit on public.sections;
+create trigger sections_cms_audit
+  after insert or update or delete on public.sections
+  for each row
+  execute function private.record_cms_audit_event();
+
+drop trigger if exists entities_cms_audit on public.entities;
+create trigger entities_cms_audit
+  after insert or update or delete on public.entities
+  for each row
+  execute function private.record_cms_audit_event();
+
+drop trigger if exists page_sections_cms_audit on public.page_sections;
+create trigger page_sections_cms_audit
+  after insert or update or delete on public.page_sections
+  for each row
+  execute function private.record_cms_audit_event();
+
+drop trigger if exists section_entities_cms_audit on public.section_entities;
+create trigger section_entities_cms_audit
+  after insert or update or delete on public.section_entities
+  for each row
+  execute function private.record_cms_audit_event();
+
+drop trigger if exists entity_relations_cms_audit on public.entity_relations;
+create trigger entity_relations_cms_audit
+  after insert or update or delete on public.entity_relations
+  for each row
+  execute function private.record_cms_audit_event();


### PR DESCRIPTION
Closes #35

Summary
- Adds an additive migration for append-only `cms_audit_events`.
- Records `pages`, `sections`, `entities`, and content relation mutations with DB triggers.
- Documents the audit/revision strategy and non-goals.
- Shows recent audit state in PONIX, with a migration-pending fallback so deploys remain safe before the DB migration is applied.

Validation
- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `git diff --check`
- `pnpm run build`
- Static migration stop-list grep: no `drop table`, `truncate`, `disable row level security`, broad `delete`, or broad `update`

Guardrails
- This PR does not apply the migration to production.
- No service-role client code.
- No restore/rollback UI.
- RLS remains enabled on the audit table.