### PR TITLE
[CMS] Show record-level audit history in PONIX

### DIFF
--- a/app/ponix/_components/cms-audit-card.tsx
+++ b/app/ponix/_components/cms-audit-card.tsx
@@ -1,0 +1,131 @@
+import { Badge } from "@/components/ui/badge"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import type { CmsAuditEvent, CmsAuditEventList } from "@/lib/cms/audit"
+
+export function CmsAuditTrailCard({
+  audit,
+  title = "Audit trail",
+  description = "Append-only CMS changes recorded at the database boundary.",
+  emptyMessage = "No CMS changes have been recorded yet.",
+}: {
+  audit: CmsAuditEventList
+  title?: string
+  description?: string
+  emptyMessage?: string
+}) {
+  return (
+    <Card className="rounded-md border bg-card/95 shadow-xl">
+      <CardHeader>
+        <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+          <div>
+            <CardTitle className="font-serif text-3xl italic">{title}</CardTitle>
+            <CardDescription className="mt-2 leading-relaxed">
+              {description}
+            </CardDescription>
+          </div>
+          <Badge
+            variant={audit.available ? "outline" : "secondary"}
+            className="w-fit rounded-full"
+          >
+            {audit.available ? "Audit enabled" : "Migration pending"}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {audit.events.length > 0 ? (
+          <div className="divide-y rounded-md border">
+            {audit.events.map((event) => (
+              <AuditEventRow key={event.id} event={event} />
+            ))}
+          </div>
+        ) : (
+          <p className="rounded-md border bg-background/60 p-4 text-sm leading-relaxed text-muted-foreground">
+            {audit.available
+              ? emptyMessage
+              : "Audit storage is not available in this database yet. PONIX remains usable."}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function AuditEventRow({ event }: { event: CmsAuditEvent }) {
+  const before = stringify(event.beforeData)
+  const after = stringify(event.afterData)
+
+  return (
+    <div className="bg-background/50 p-4">
+      <div className="grid gap-3 md:grid-cols-[10rem_minmax(0,1fr)_12rem] md:items-center">
+        <div>
+          <Badge variant="outline" className="rounded-full">
+            {event.action}
+          </Badge>
+          <p className="mt-2 text-xs text-muted-foreground">
+            {formatAuditTime(event.createdAt)}
+          </p>
+        </div>
+        <div className="min-w-0">
+          <p className="font-medium">
+            {event.targetTable}
+            {event.targetId && (
+              <span className="ml-2 font-mono text-xs text-muted-foreground">
+                {event.targetId.slice(0, 8)}
+              </span>
+            )}
+          </p>
+          <p className="mt-1 truncate text-xs text-muted-foreground">
+            {event.changedKeys.length > 0
+              ? event.changedKeys.join(", ")
+              : "No top-level field diff"}
+          </p>
+        </div>
+        <p className="font-mono text-xs text-muted-foreground md:text-right">
+          {event.actorMemberId ? event.actorMemberId.slice(0, 8) : "system"}
+        </p>
+      </div>
+
+      {(before || after) && (
+        <details className="mt-4 rounded-md border bg-muted/25 p-3">
+          <summary className="cursor-pointer text-xs font-medium uppercase tracking-[0.24em] text-muted-foreground">
+            Row snapshots
+          </summary>
+          <div className="mt-3 grid gap-3 lg:grid-cols-2">
+            <SnapshotBlock label="Before" value={before} />
+            <SnapshotBlock label="After" value={after} />
+          </div>
+        </details>
+      )}
+    </div>
+  )
+}
+
+function SnapshotBlock({ label, value }: { label: string; value: string | null }) {
+  return (
+    <div>
+      <p className="caps mb-2 text-muted-foreground">{label}</p>
+      <pre className="max-h-56 overflow-auto rounded-md border bg-background/70 p-3 text-xs leading-relaxed">
+        {value ?? "null"}
+      </pre>
+    </div>
+  )
+}
+
+function formatAuditTime(value: string) {
+  return new Intl.DateTimeFormat("ko-KR", {
+    dateStyle: "short",
+    timeStyle: "short",
+    timeZone: "Asia/Seoul",
+  }).format(new Date(value))
+}
+
+function stringify(value: unknown) {
+  if (value === null || value === undefined) return null
+  return JSON.stringify(value, null, 2) ?? String(value)
+}

--- a/app/ponix/_components/cms-detail.tsx
+++ b/app/ponix/_components/cms-detail.tsx
@@ -19,6 +19,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
+import type { CmsAuditEventList } from "@/lib/cms/audit"
 import type { CmsContentDetail } from "@/lib/cms/content"
 import {
   getCmsSchema,
@@ -26,6 +27,7 @@ import {
   type CmsFieldSource,
 } from "@/lib/cms/schema-registry"
 
+import { CmsAuditTrailCard } from "./cms-audit-card"
 import { formatCmsDate, PublishBadge, SchemaBadge } from "./cms-list"
 
 const sourceLabels: Record<CmsFieldSource, string> = {
@@ -40,12 +42,14 @@ export function CmsDetailPage({
   backHref,
   backLabel,
   actions,
+  audit,
   children,
 }: {
   detail: CmsContentDetail
   backHref: string
   backLabel: string
   actions?: ReactNode
+  audit?: CmsAuditEventList
   children?: ReactNode
 }) {
   const schema = getCmsSchema(detail.schemaKey)
@@ -150,6 +154,15 @@ export function CmsDetailPage({
                 </dl>
               </CardContent>
             </Card>
+
+            {audit && (
+              <CmsAuditTrailCard
+                audit={audit}
+                title="Record audit"
+                description="Recent changes for this CMS record."
+                emptyMessage="No changes have been recorded for this record yet."
+              />
+            )}
 
             <Card className="rounded-md bg-card/95 shadow-xl">
               <CardHeader>

--- a/app/ponix/entities/[id]/page.tsx
+++ b/app/ponix/entities/[id]/page.tsx
@@ -9,6 +9,7 @@ import {
   relationMutationState,
   SectionEntityRelationsCard,
 } from "@/app/ponix/_components/cms-relations"
+import { loadCmsAuditEventsForTarget } from "@/lib/cms/audit"
 import { requireCmsAdmin } from "@/lib/cms/auth"
 import {
   loadCmsEntityDetail,
@@ -36,10 +37,11 @@ export default async function PonixEntityRecordPage({
   const { id } = await params
 
   await requireCmsAdmin(`/ponix/entities/${id}`)
-  const [detail, relations, options, search] = await Promise.all([
+  const [detail, relations, options, audit, search] = await Promise.all([
     loadCmsEntityDetail(id),
     loadCmsEntityRelations(id),
     loadCmsRelationEditorOptions(),
+    loadCmsAuditEventsForTarget({ targetTable: "entities", targetId: id }),
     searchParams,
   ])
   const mutation = relationMutationState(search)
@@ -53,6 +55,7 @@ export default async function PonixEntityRecordPage({
       detail={detail}
       backHref="/ponix/entities"
       backLabel="All entities"
+      audit={audit}
       actions={
         <Link
           href={`/ponix/entities/${id}/edit`}

--- a/app/ponix/page.tsx
+++ b/app/ponix/page.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from "next"
 import Link from "next/link"
 
+import { CmsAuditTrailCard } from "@/app/ponix/_components/cms-audit-card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { loadRecentCmsAuditEvents, type CmsAuditEvent } from "@/lib/cms/audit"
+import { loadRecentCmsAuditEvents } from "@/lib/cms/audit"
 import { requireCmsAdmin } from "@/lib/cms/auth"
 import {
   getCmsSchemaStats,
@@ -152,83 +153,10 @@ export default async function PonixPage() {
           })}
         </div>
 
-        <Card className="mt-5 rounded-md border bg-card/95 shadow-xl">
-          <CardHeader>
-            <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
-              <div>
-                <CardTitle className="font-serif text-3xl italic">
-                  Recent audit trail
-                </CardTitle>
-                <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
-                  Append-only CMS changes recorded at the database boundary.
-                </p>
-              </div>
-              <Badge
-                variant={audit.available ? "outline" : "secondary"}
-                className="w-fit rounded-full"
-              >
-                {audit.available ? "Audit enabled" : "Migration pending"}
-              </Badge>
-            </div>
-          </CardHeader>
-          <CardContent>
-            {audit.events.length > 0 ? (
-              <div className="divide-y rounded-md border">
-                {audit.events.map((event) => (
-                  <AuditEventRow key={event.id} event={event} />
-                ))}
-              </div>
-            ) : (
-              <p className="rounded-md border bg-background/60 p-4 text-sm leading-relaxed text-muted-foreground">
-                {audit.available
-                  ? "No CMS changes have been recorded yet."
-                  : "The audit migration has not been applied to this database yet. PONIX remains usable; audit events will appear after the migration is applied."}
-              </p>
-            )}
-          </CardContent>
-        </Card>
+        <div className="mt-5">
+          <CmsAuditTrailCard audit={audit} title="Recent audit trail" />
+        </div>
       </section>
     </main>
   )
-}
-
-function AuditEventRow({ event }: { event: CmsAuditEvent }) {
-  return (
-    <div className="grid gap-3 bg-background/50 p-4 md:grid-cols-[10rem_minmax(0,1fr)_12rem] md:items-center">
-      <div>
-        <Badge variant="outline" className="rounded-full">
-          {event.action}
-        </Badge>
-        <p className="mt-2 text-xs text-muted-foreground">
-          {formatAuditTime(event.createdAt)}
-        </p>
-      </div>
-      <div className="min-w-0">
-        <p className="font-medium">
-          {event.targetTable}
-          {event.targetId && (
-            <span className="ml-2 font-mono text-xs text-muted-foreground">
-              {event.targetId.slice(0, 8)}
-            </span>
-          )}
-        </p>
-        <p className="mt-1 truncate text-xs text-muted-foreground">
-          {event.changedKeys.length > 0
-            ? event.changedKeys.join(", ")
-            : "No top-level field diff"}
-        </p>
-      </div>
-      <p className="font-mono text-xs text-muted-foreground md:text-right">
-        {event.actorMemberId ? event.actorMemberId.slice(0, 8) : "system"}
-      </p>
-    </div>
-  )
-}
-
-function formatAuditTime(value: string) {
-  return new Intl.DateTimeFormat("ko-KR", {
-    dateStyle: "short",
-    timeStyle: "short",
-    timeZone: "Asia/Seoul",
-  }).format(new Date(value))
 }

--- a/app/ponix/pages/[id]/page.tsx
+++ b/app/ponix/pages/[id]/page.tsx
@@ -8,6 +8,7 @@ import {
   RelationMutationNotice,
   relationMutationState,
 } from "@/app/ponix/_components/cms-relations"
+import { loadCmsAuditEventsForTarget } from "@/lib/cms/audit"
 import { requireCmsAdmin } from "@/lib/cms/auth"
 import {
   loadCmsPageDetail,
@@ -35,10 +36,11 @@ export default async function PonixPageRecordPage({
   const { id } = await params
 
   await requireCmsAdmin(`/ponix/pages/${id}`)
-  const [detail, relations, options, search] = await Promise.all([
+  const [detail, relations, options, audit, search] = await Promise.all([
     loadCmsPageDetail(id),
     loadCmsPageRelations(id),
     loadCmsRelationEditorOptions(),
+    loadCmsAuditEventsForTarget({ targetTable: "pages", targetId: id }),
     searchParams,
   ])
   const mutation = relationMutationState(search)
@@ -52,6 +54,7 @@ export default async function PonixPageRecordPage({
       detail={detail}
       backHref="/ponix/pages"
       backLabel="All pages"
+      audit={audit}
       actions={
         <div className="flex flex-wrap gap-2">
           <Link

--- a/app/ponix/sections/[id]/page.tsx
+++ b/app/ponix/sections/[id]/page.tsx
@@ -10,6 +10,7 @@ import {
   relationMutationState,
   SectionEntityRelationsCard,
 } from "@/app/ponix/_components/cms-relations"
+import { loadCmsAuditEventsForTarget } from "@/lib/cms/audit"
 import { requireCmsAdmin } from "@/lib/cms/auth"
 import {
   loadCmsRelationEditorOptions,
@@ -38,10 +39,11 @@ export default async function PonixSectionRecordPage({
   const { id } = await params
 
   await requireCmsAdmin(`/ponix/sections/${id}`)
-  const [detail, relations, options, search] = await Promise.all([
+  const [detail, relations, options, audit, search] = await Promise.all([
     loadCmsSectionDetail(id),
     loadCmsSectionRelations(id),
     loadCmsRelationEditorOptions(),
+    loadCmsAuditEventsForTarget({ targetTable: "sections", targetId: id }),
     searchParams,
   ])
   const mutation = relationMutationState(search)
@@ -57,6 +59,7 @@ export default async function PonixSectionRecordPage({
       detail={detail}
       backHref="/ponix/sections"
       backLabel="All sections"
+      audit={audit}
       actions={
         <Link
           href={`/ponix/sections/${id}/edit`}

--- a/lib/cms/audit.ts
+++ b/lib/cms/audit.ts
@@ -1,4 +1,8 @@
 import { createClient } from "@/lib/supabase/server"
+import type { Database, Json } from "@/lib/supabase/types"
+
+export type CmsAuditTargetTable =
+  Database["public"]["Tables"]["cms_audit_events"]["Row"]["target_table"]
 
 export type CmsAuditEvent = {
   id: string
@@ -8,12 +12,27 @@ export type CmsAuditEvent = {
   targetTable: string
   targetId: string | null
   changedKeys: string[]
+  beforeData: Json | null
+  afterData: Json | null
 }
 
 export type CmsAuditEventList = {
   available: boolean
   events: CmsAuditEvent[]
 }
+
+type CmsAuditEventProjection = Pick<
+  Database["public"]["Tables"]["cms_audit_events"]["Row"],
+  | "id"
+  | "created_at"
+  | "actor_member_id"
+  | "action"
+  | "target_table"
+  | "target_id"
+  | "changed_keys"
+  | "before_data"
+  | "after_data"
+>
 
 export async function loadRecentCmsAuditEvents(
   limit = 8,
@@ -22,7 +41,7 @@ export async function loadRecentCmsAuditEvents(
   const { data, error } = await supabase
     .from("cms_audit_events")
     .select(
-      "id, created_at, actor_member_id, action, target_table, target_id, changed_keys",
+      "id, created_at, actor_member_id, action, target_table, target_id, changed_keys, before_data, after_data",
     )
     .order("created_at", { ascending: false })
     .limit(limit)
@@ -35,14 +54,50 @@ export async function loadRecentCmsAuditEvents(
 
   return {
     available: true,
-    events: (data ?? []).map((event) => ({
-      id: event.id,
-      createdAt: event.created_at,
-      actorMemberId: event.actor_member_id,
-      action: event.action,
-      targetTable: event.target_table,
-      targetId: event.target_id,
-      changedKeys: event.changed_keys,
-    })),
+    events: (data ?? []).map(mapAuditEvent),
+  }
+}
+
+export async function loadCmsAuditEventsForTarget({
+  targetTable,
+  targetId,
+  limit = 6,
+}: {
+  targetTable: CmsAuditTargetTable
+  targetId: string
+  limit?: number
+}): Promise<CmsAuditEventList> {
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from("cms_audit_events")
+    .select(
+      "id, created_at, actor_member_id, action, target_table, target_id, changed_keys, before_data, after_data",
+    )
+    .eq("target_table", targetTable)
+    .eq("target_id", targetId)
+    .order("created_at", { ascending: false })
+    .limit(limit)
+
+  if (error) {
+    return { available: false, events: [] }
+  }
+
+  return {
+    available: true,
+    events: (data ?? []).map(mapAuditEvent),
+  }
+}
+
+function mapAuditEvent(event: CmsAuditEventProjection): CmsAuditEvent {
+  return {
+    id: event.id,
+    createdAt: event.created_at,
+    actorMemberId: event.actor_member_id,
+    action: event.action,
+    targetTable: event.target_table,
+    targetId: event.target_id,
+    changedKeys: event.changed_keys,
+    beforeData: event.before_data,
+    afterData: event.after_data,
   }
 }


### PR DESCRIPTION
Closes #37

## Summary

- Adds a reusable PONIX audit trail card with changed keys and before/after row snapshots behind a disclosure.
- Adds a target-filtered audit loader for `cms_audit_events` using normal Supabase RLS.
- Shows record-specific audit history on page, section, and entity detail screens while keeping the global PONIX feed on the same component.

## Supabase Impact

- No schema or production data changes in this PR.
- Reads the already-applied append-only `cms_audit_events` table.
- No service-role usage, rollback controls, restore controls, or destructive actions.

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `git diff --check`
- `pnpm run build`

## Not Tested

- Authenticated browser smoke test was not exercised in this run.
