### PR TITLE
[CMS] Improve audit diff viewer

### DIFF
--- a/app/ponix/_components/cms-audit-card.tsx
+++ b/app/ponix/_components/cms-audit-card.tsx
@@ -8,6 +8,8 @@ import {
 } from "@/components/ui/card"
 import type { CmsAuditEvent, CmsAuditEventList } from "@/lib/cms/audit"
 
+const LOW_PRIORITY_FIELDS = new Set(["created_at", "updated_at"])
+
 export function CmsAuditTrailCard({
   audit,
   title = "Audit trail",
@@ -59,6 +61,7 @@ export function CmsAuditTrailCard({
 function AuditEventRow({ event }: { event: CmsAuditEvent }) {
   const before = stringify(event.beforeData)
   const after = stringify(event.afterData)
+  const diffs = auditDiffs(event)
 
   return (
     <div className="bg-background/50 p-4">
@@ -91,6 +94,18 @@ function AuditEventRow({ event }: { event: CmsAuditEvent }) {
         </p>
       </div>
 
+      {diffs.length > 0 ? (
+        <div className="mt-4 grid gap-3">
+          {diffs.map((diff) => (
+            <DiffBlock key={diff.key} diff={diff} />
+          ))}
+        </div>
+      ) : (
+        <p className="mt-4 rounded-md border bg-muted/25 p-3 text-sm text-muted-foreground">
+          No field-level diff is available for this event.
+        </p>
+      )}
+
       {(before || after) && (
         <details className="mt-4 rounded-md border bg-muted/25 p-3">
           <summary className="cursor-pointer text-xs font-medium uppercase tracking-[0.24em] text-muted-foreground">
@@ -102,6 +117,64 @@ function AuditEventRow({ event }: { event: CmsAuditEvent }) {
           </div>
         </details>
       )}
+    </div>
+  )
+}
+
+type AuditDiff = {
+  key: string
+  before: unknown
+  after: unknown
+  lowPriority: boolean
+}
+
+function DiffBlock({ diff }: { diff: AuditDiff }) {
+  return (
+    <div
+      className={
+        diff.lowPriority
+          ? "rounded-md border border-dashed bg-muted/15 p-3"
+          : "rounded-md border bg-background/70 p-3"
+      }
+    >
+      <div className="mb-3 flex flex-wrap items-center gap-2">
+        <span className="font-mono text-xs font-medium">{diff.key}</span>
+        {diff.lowPriority && (
+          <Badge variant="secondary" className="rounded-full">
+            system
+          </Badge>
+        )}
+      </div>
+      <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] md:items-start">
+        <ValueBlock label="Before" value={diff.before} muted={diff.lowPriority} />
+        <span className="hidden pt-8 text-muted-foreground md:block">→</span>
+        <ValueBlock label="After" value={diff.after} muted={diff.lowPriority} />
+      </div>
+    </div>
+  )
+}
+
+function ValueBlock({
+  label,
+  value,
+  muted,
+}: {
+  label: string
+  value: unknown
+  muted: boolean
+}) {
+  return (
+    <div>
+      <p className="caps mb-2 text-muted-foreground">{label}</p>
+      <div
+        className={
+          muted
+            ? "max-h-40 overflow-auto rounded-md border bg-muted/25 p-3 font-mono text-xs leading-relaxed text-muted-foreground"
+            : "max-h-40 overflow-auto rounded-md border bg-card p-3 text-sm leading-relaxed"
+        }
+      >
+        {formatValue(value)}
+      </div>
     </div>
   )
 }
@@ -128,4 +201,48 @@ function formatAuditTime(value: string) {
 function stringify(value: unknown) {
   if (value === null || value === undefined) return null
   return JSON.stringify(value, null, 2) ?? String(value)
+}
+
+function auditDiffs(event: CmsAuditEvent): AuditDiff[] {
+  const before = asRecord(event.beforeData)
+  const after = asRecord(event.afterData)
+
+  return event.changedKeys.map((key) => ({
+    key,
+    before: before?.[key],
+    after: after?.[key],
+    lowPriority: LOW_PRIORITY_FIELDS.has(key),
+  }))
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null
+  }
+
+  return value as Record<string, unknown>
+}
+
+function formatValue(value: unknown) {
+  if (value === null || value === undefined || value === "") {
+    return <span className="text-muted-foreground">Empty</span>
+  }
+
+  if (typeof value === "boolean") {
+    return (
+      <Badge variant={value ? "default" : "outline"} className="rounded-full">
+        {value ? "true" : "false"}
+      </Badge>
+    )
+  }
+
+  if (typeof value === "object") {
+    return (
+      <pre className="whitespace-pre-wrap break-words font-mono text-xs">
+        {stringify(value)}
+      </pre>
+    )
+  }
+
+  return <span className="whitespace-pre-wrap break-words">{String(value)}</span>
 }


### PR DESCRIPTION
Closes #39

## Summary

- Renders audit `changed_keys` as field-level before/after diff blocks.
- Marks low-priority system fields such as `updated_at` with a `system` badge.
- Keeps full before/after row snapshots available behind the existing disclosure.

## Supabase Impact

- No schema or production data changes.
- Continues to read `cms_audit_events` through existing RLS.
- No service-role usage, restore controls, rollback controls, or destructive actions.

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `git diff --check`
- `pnpm run build`

## Not Tested

- Browser smoke test against the Vercel preview URL has not been run yet.
