### PR TITLE
Normalize CMS content around entity schemas

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,7 @@ Use migrations for durable changes. Direct dashboard edits are acceptable for em
 
 Good Supabase changes:
 
+- Add/update `entity_schemas` through reviewed migrations when introducing a durable CMS content shape
 - Add/update `entities`
 - Update `sections` copy, props, renderer metadata, or publish status
 - Link content with `section_entities`

--- a/docs/content-graph.md
+++ b/docs/content-graph.md
@@ -1,6 +1,6 @@
 # Content Graph
 
-The site is built around a CMS-friendly graph:
+The site is currently built around a CMS-friendly graph:
 
 ```txt
 pages
@@ -10,10 +10,24 @@ pages
         -> entities
 ```
 
+The target model is a smaller entity graph:
+
+```txt
+entity_schemas
+  -> entities
+    -> entity_relations
+      -> entities
+```
+
+`pages`, `sections`, `page_sections`, and `section_entities` remain in use during
+the transition. New CMS architecture work should avoid deepening those special
+tables unless the change is explicitly about preserving the bridge.
+
 ## Tables
 
 | Table | Purpose |
 | --- | --- |
+| `entity_schemas` | DB-backed schema registry for page, section, entity, and relation records. This is the long-term source for CMS form metadata and validation. |
 | `pages` | Routable page records such as `home`, `performances`, `videos`, `photos`, `history`, and `site`. |
 | `sections` | Renderer blocks with `section_type`, copy, and renderer props. |
 | `page_sections` | Ordered section placement on pages. |
@@ -46,14 +60,57 @@ Required DB content should fail visibly when missing. Do not reintroduce mock fa
 
 CMS forms should not infer editable fields directly from arbitrary JSONB.
 
-Use `lib/cms/schema-registry.ts` as the code-level contract for:
+There are now two layers:
+
+- `entity_schemas` is the DB-backed registry foundation. It stores stable
+  `schema_key`, `kind`, version, label, renderer hint, relation slots, and future
+  JSON field/validation definitions.
+- `lib/cms/schema-registry.ts` is still the active code-level field contract for
+  PONIX forms until the DB-backed registry is fully populated and wired into the
+  editor.
+
+Use the registry contract for:
 
 - `sections.props`
 - `entities.data`
 - `section_entities.props`
 - `entity_relations.props`
 
-Each registry entry defines the schema key, field source, field type, required/read-only status, and select options. Future CMS editor screens should render fields from this registry before adding write actions.
+Each registry entry defines the schema key, field source, field type,
+required/read-only status, and select options. Future CMS editor screens should
+prefer `entity_schemas` as the metadata source, with the code registry as the
+reviewed renderer/field fallback.
+
+## Entity Schema Direction
+
+The long-term content contract is:
+
+```txt
+entity_schemas
+- what kind of content this is
+- which fields are editable
+- how the data should be validated
+- which renderer key may display it
+
+entities
+- shared identity and display columns
+- schema_id / schema_key
+- flexible data jsonb
+
+entity_relations
+- ordered links between entities
+- schema_id / schema_key
+- slot, relation_type, sort_order
+- relation props as relation-specific data
+```
+
+For now, `entities.schema_key` remains the public compatibility key and
+`entities.schema_id` resolves it to `entity_schemas`. `entity_relations` also has
+a default relation schema. Do not remove the text `schema_key` fields until all
+loaders, CMS forms, migrations, and production data have moved to schema IDs.
+
+Renderer implementations remain in React code. Database schemas may name a
+`renderer_key`, but they must not define executable UI behavior.
 
 ## Where Data Belongs
 

--- a/docs/supabase-setup.md
+++ b/docs/supabase-setup.md
@@ -161,6 +161,30 @@ pnpm dlx supabase db push
 
 Maintainers using Supabase MCP can apply the same migration SQL with `apply_migration`, but the migration file must still be committed.
 
+## Entity Schema Registry
+
+`entity_schemas` is the durable DB registry for CMS content shapes. Change it
+through migrations, not one-off dashboard edits, because schema changes affect
+editor forms, validation, renderer compatibility, and future content migrations.
+
+Safe pattern:
+
+1. Add or update a versioned `schema_key`, such as `video/youtube/v1`.
+2. Keep existing schema keys active until all rows and renderers have migrated.
+3. Keep the text `schema_key` compatibility columns until all loaders and PONIX
+   forms use `schema_id`.
+4. Keep renderer code reviewed in the app. DB rows may store a `renderer_key`,
+   but must not define executable React behavior.
+5. Apply production schema registry migrations only after review.
+
+Avoid:
+
+- Renaming or deactivating schema keys while rows still reference them.
+- Making `fields` or `validation` incompatible with the deployed PONIX editor.
+- Using the schema registry to bypass RLS, ownership, or member-specific tables.
+- Moving `members` into generic entities; member auth/profile data remains
+  domain-specific.
+
 ## CMS Audit Trail
 
 PONIX CMS write auditing is documented in `docs/cms-audit.md`.

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -64,6 +64,57 @@ export type Database = {
           },
         ]
       }
+      entity_schemas: {
+        Row: {
+          active: boolean
+          created_at: string
+          description: string
+          fields: Json
+          id: string
+          kind: string
+          label: string
+          relation_slots: string[]
+          renderer_key: string | null
+          schema_key: string
+          table_name: string
+          updated_at: string
+          validation: Json
+          version: number
+        }
+        Insert: {
+          active?: boolean
+          created_at?: string
+          description?: string
+          fields?: Json
+          id?: string
+          kind: string
+          label: string
+          relation_slots?: string[]
+          renderer_key?: string | null
+          schema_key: string
+          table_name: string
+          updated_at?: string
+          validation?: Json
+          version?: number
+        }
+        Update: {
+          active?: boolean
+          created_at?: string
+          description?: string
+          fields?: Json
+          id?: string
+          kind?: string
+          label?: string
+          relation_slots?: string[]
+          renderer_key?: string | null
+          schema_key?: string
+          table_name?: string
+          updated_at?: string
+          validation?: Json
+          version?: number
+        }
+        Relationships: []
+      }
       entities: {
         Row: {
           created_at: string
@@ -72,6 +123,7 @@ export type Database = {
           id: string
           owner_member_id: string | null
           published: boolean
+          schema_id: string | null
           schema_key: string
           slug: string | null
           sort_at: string
@@ -88,6 +140,7 @@ export type Database = {
           id?: string
           owner_member_id?: string | null
           published?: boolean
+          schema_id?: string | null
           schema_key?: string
           slug?: string | null
           sort_at?: string
@@ -104,6 +157,7 @@ export type Database = {
           id?: string
           owner_member_id?: string | null
           published?: boolean
+          schema_id?: string | null
           schema_key?: string
           slug?: string | null
           sort_at?: string
@@ -121,6 +175,13 @@ export type Database = {
             referencedRelation: "members"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "entities_schema_id_fkey"
+            columns: ["schema_id"]
+            isOneToOne: false
+            referencedRelation: "entity_schemas"
+            referencedColumns: ["id"]
+          },
         ]
       }
       entity_relations: {
@@ -131,6 +192,8 @@ export type Database = {
           id: string
           props: Json
           relation_type: string
+          schema_id: string | null
+          schema_key: string
           slot: string
           sort_order: number
           to_entity_id: string
@@ -143,6 +206,8 @@ export type Database = {
           id?: string
           props?: Json
           relation_type: string
+          schema_id?: string | null
+          schema_key?: string
           slot?: string
           sort_order?: number
           to_entity_id: string
@@ -155,6 +220,8 @@ export type Database = {
           id?: string
           props?: Json
           relation_type?: string
+          schema_id?: string | null
+          schema_key?: string
           slot?: string
           sort_order?: number
           to_entity_id?: string
@@ -173,6 +240,13 @@ export type Database = {
             columns: ["from_entity_id"]
             isOneToOne: false
             referencedRelation: "entities"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "entity_relations_schema_id_fkey"
+            columns: ["schema_id"]
+            isOneToOne: false
+            referencedRelation: "entity_schemas"
             referencedColumns: ["id"]
           },
           {

--- a/supabase/migrations/20260506000040_entity_schema_registry.sql
+++ b/supabase/migrations/20260506000040_entity_schema_registry.sql
@@ -1,0 +1,492 @@
+-- Bremen — DB-backed entity schema registry foundation.
+--
+-- This migration is intentionally additive. It starts moving the CMS model
+-- toward:
+--   entity_schemas
+--   entities
+--   entity_relations
+--
+-- Existing pages / sections / page_sections / section_entities remain active
+-- while the public renderers and PONIX editors are migrated incrementally.
+
+create table if not exists public.entity_schemas (
+  id             uuid primary key default gen_random_uuid(),
+  schema_key     text not null unique,
+  kind           text not null,
+  version        int not null default 1,
+  label          text not null,
+  description    text not null default '',
+  table_name     text not null,
+  renderer_key   text,
+  fields         jsonb not null default '[]'::jsonb,
+  validation     jsonb not null default '{}'::jsonb,
+  relation_slots text[] not null default '{}',
+  active         boolean not null default true,
+  created_at     timestamptz not null default now(),
+  updated_at     timestamptz not null default now(),
+  check (length(btrim(schema_key)) > 0),
+  check (kind in ('page', 'section', 'entity', 'relation')),
+  check (version > 0),
+  check (length(btrim(label)) > 0),
+  check (
+    table_name in (
+      'pages',
+      'sections',
+      'entities',
+      'page_sections',
+      'section_entities',
+      'entity_relations'
+    )
+  ),
+  check (jsonb_typeof(fields) = 'array'),
+  check (jsonb_typeof(validation) = 'object')
+);
+
+create index if not exists entity_schemas_kind_active_idx
+  on public.entity_schemas(kind, active, schema_key);
+
+create trigger entity_schemas_set_updated_at
+  before update on public.entity_schemas
+  for each row
+  execute function public.set_updated_at();
+
+alter table public.entity_schemas enable row level security;
+
+drop policy if exists "entity_schemas_public_read"
+  on public.entity_schemas;
+create policy "entity_schemas_public_read"
+  on public.entity_schemas
+  for select
+  using (active = true);
+
+drop policy if exists "entity_schemas_admin_write"
+  on public.entity_schemas;
+create policy "entity_schemas_admin_write"
+  on public.entity_schemas
+  for all
+  using (private.is_admin())
+  with check (private.is_admin());
+
+insert into public.entity_schemas (
+  schema_key,
+  kind,
+  version,
+  label,
+  description,
+  table_name,
+  renderer_key,
+  relation_slots
+)
+values
+  (
+    'page/default/v1',
+    'page',
+    1,
+    'Page',
+    'Routable page record and page-level metadata.',
+    'pages',
+    'page',
+    array['sections']
+  )
+on conflict (schema_key) do update
+set kind = excluded.kind,
+    version = excluded.version,
+    label = excluded.label,
+    description = excluded.description,
+    table_name = excluded.table_name,
+    renderer_key = excluded.renderer_key,
+    relation_slots = excluded.relation_slots,
+    updated_at = now();
+
+insert into public.entity_schemas (
+  schema_key,
+  kind,
+  version,
+  label,
+  description,
+  table_name,
+  renderer_key,
+  relation_slots
+)
+select
+  section_schema.schema_key,
+  'section',
+  coalesce(nullif((regexp_match(section_schema.schema_key, '/v([0-9]+)$'))[1], '')::int, 1),
+  initcap(replace(replace(split_part(section_schema.schema_key, '/', 2), '-', ' '), '_', ' ')),
+  'Migrated from existing sections.schema_key. Field definitions still live in the code registry until the DB registry is fully populated.',
+  'sections',
+  section_schema.section_type,
+  array['default']
+from (
+  select distinct on (schema_key) schema_key, section_type
+  from public.sections
+  where schema_key is not null
+    and length(btrim(schema_key)) > 0
+  order by schema_key, section_type
+) as section_schema
+on conflict (schema_key) do update
+set kind = excluded.kind,
+    version = excluded.version,
+    label = excluded.label,
+    description = excluded.description,
+    table_name = excluded.table_name,
+    renderer_key = excluded.renderer_key,
+    updated_at = now();
+
+insert into public.entity_schemas (
+  schema_key,
+  kind,
+  version,
+  label,
+  description,
+  table_name,
+  renderer_key,
+  relation_slots
+)
+select
+  entity_schema.schema_key,
+  'entity',
+  coalesce(nullif((regexp_match(entity_schema.schema_key, '/v([0-9]+)$'))[1], '')::int, 1),
+  initcap(replace(split_part(entity_schema.schema_key, '/', 1), '_', ' ')),
+  'Migrated from existing entities.schema_key. Field definitions still live in the code registry until the DB registry is fully populated.',
+  'entities',
+  split_part(entity_schema.schema_key, '/', 1),
+  '{}'::text[]
+from (
+  select distinct schema_key
+  from public.entities
+  where schema_key is not null
+    and length(btrim(schema_key)) > 0
+) as entity_schema
+on conflict (schema_key) do update
+set kind = excluded.kind,
+    version = excluded.version,
+    label = excluded.label,
+    description = excluded.description,
+    table_name = excluded.table_name,
+    renderer_key = excluded.renderer_key,
+    updated_at = now();
+
+insert into public.entity_schemas (
+  schema_key,
+  kind,
+  version,
+  label,
+  description,
+  table_name,
+  renderer_key,
+  relation_slots
+)
+values
+  (
+    'performance/v1',
+    'entity',
+    1,
+    'Performance',
+    'Canonical performance or event record.',
+    'entities',
+    'performance',
+    '{}'::text[]
+  ),
+  (
+    'performance/scraped/v1',
+    'entity',
+    1,
+    'Scraped performance',
+    'Performance record generated from YouTube or Instagram source data.',
+    'entities',
+    'performance',
+    '{}'::text[]
+  ),
+  (
+    'video/v1',
+    'entity',
+    1,
+    'Video',
+    'YouTube recording entity.',
+    'entities',
+    'video',
+    '{}'::text[]
+  ),
+  (
+    'video/youtube/v1',
+    'entity',
+    1,
+    'YouTube video',
+    'YouTube recording imported from the Bremen channel.',
+    'entities',
+    'video',
+    '{}'::text[]
+  ),
+  (
+    'playlist/youtube/v1',
+    'entity',
+    1,
+    'YouTube playlist',
+    'YouTube playlist or performance collection imported from the Bremen channel.',
+    'entities',
+    'playlist',
+    '{}'::text[]
+  ),
+  (
+    'photo/v1',
+    'entity',
+    1,
+    'Photo',
+    'Generic photo entity.',
+    'entities',
+    'photo',
+    '{}'::text[]
+  ),
+  (
+    'photo/instagram-grid/v1',
+    'entity',
+    1,
+    'Instagram photo',
+    'Instagram-sourced gallery or performance update entity.',
+    'entities',
+    'photo',
+    '{}'::text[]
+  ),
+  (
+    'post/instagram/v1',
+    'entity',
+    1,
+    'Instagram post',
+    'Instagram-sourced post used for performance updates, notices, and gallery curation.',
+    'entities',
+    'post',
+    '{}'::text[]
+  ),
+  (
+    'stat/home-number/v1',
+    'entity',
+    1,
+    'Home stat',
+    'Statistic card used by the home stats section.',
+    'entities',
+    'stat',
+    '{}'::text[]
+  ),
+  (
+    'activity/home-card/v1',
+    'entity',
+    1,
+    'Home activity',
+    'Activity card used by the home activities section.',
+    'entities',
+    'activity',
+    '{}'::text[]
+  ),
+  (
+    'history/milestone/v1',
+    'entity',
+    1,
+    'History milestone',
+    'History timeline item.',
+    'entities',
+    'history',
+    '{}'::text[]
+  ),
+  (
+    'navigation/item/v1',
+    'entity',
+    1,
+    'Navigation item',
+    'Header navigation item.',
+    'entities',
+    'navigation',
+    '{}'::text[]
+  ),
+  (
+    'contact/site-footer/v1',
+    'entity',
+    1,
+    'Footer contact',
+    'Footer contact item.',
+    'entities',
+    'contact',
+    '{}'::text[]
+  ),
+  (
+    'social/site-footer/v1',
+    'entity',
+    1,
+    'Footer social link',
+    'Footer social link item.',
+    'entities',
+    'social',
+    '{}'::text[]
+  )
+on conflict (schema_key) do update
+set kind = excluded.kind,
+    version = excluded.version,
+    label = excluded.label,
+    description = excluded.description,
+    table_name = excluded.table_name,
+    renderer_key = excluded.renderer_key,
+    relation_slots = excluded.relation_slots,
+    updated_at = now();
+
+insert into public.entity_schemas (
+  schema_key,
+  kind,
+  version,
+  label,
+  description,
+  table_name,
+  renderer_key,
+  relation_slots
+)
+values
+  (
+    'relation/default/v1',
+    'relation',
+    1,
+    'Default relation',
+    'Fallback schema for existing entity_relations rows. Relation-specific schemas can be added once relation editing moves to DB-backed schema definitions.',
+    'entity_relations',
+    null,
+    array['default']
+  )
+on conflict (schema_key) do update
+set kind = excluded.kind,
+    version = excluded.version,
+    label = excluded.label,
+    description = excluded.description,
+    table_name = excluded.table_name,
+    renderer_key = excluded.renderer_key,
+    relation_slots = excluded.relation_slots,
+    updated_at = now();
+
+alter table public.entities
+  add column if not exists schema_id uuid
+    references public.entity_schemas(id) on delete restrict;
+
+create index if not exists entities_schema_id_idx
+  on public.entities(schema_id);
+
+update public.entities entity_ref
+set schema_id = schema_ref.id
+from public.entity_schemas schema_ref
+where entity_ref.schema_id is null
+  and schema_ref.kind = 'entity'
+  and schema_ref.schema_key = entity_ref.schema_key;
+
+alter table public.entity_relations
+  add column if not exists schema_key text not null default 'relation/default/v1',
+  add column if not exists schema_id uuid
+    references public.entity_schemas(id) on delete restrict;
+
+alter table public.entity_relations
+  drop constraint if exists entity_relations_schema_key_check;
+
+alter table public.entity_relations
+  add constraint entity_relations_schema_key_check
+  check (length(btrim(schema_key)) > 0);
+
+create index if not exists entity_relations_schema_id_idx
+  on public.entity_relations(schema_id);
+
+update public.entity_relations relation_ref
+set schema_id = schema_ref.id
+from public.entity_schemas schema_ref
+where relation_ref.schema_id is null
+  and schema_ref.kind = 'relation'
+  and schema_ref.schema_key = relation_ref.schema_key;
+
+create or replace function private.resolve_content_schema_id()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, private
+as $$
+declare
+  expected_kind text;
+  resolved_schema record;
+begin
+  if tg_table_name = 'entities' then
+    expected_kind := 'entity';
+  elsif tg_table_name = 'entity_relations' then
+    expected_kind := 'relation';
+  else
+    raise exception 'resolve_content_schema_id is not configured for table %', tg_table_name;
+  end if;
+
+  if new.schema_id is not null then
+    select id, schema_key, kind, active
+    into resolved_schema
+    from public.entity_schemas
+    where id = new.schema_id;
+
+    if not found then
+      raise exception 'Unknown schema id %', new.schema_id;
+    end if;
+
+    if resolved_schema.kind <> expected_kind then
+      raise exception 'Schema % has kind %, expected %',
+        resolved_schema.schema_key,
+        resolved_schema.kind,
+        expected_kind;
+    end if;
+
+    if resolved_schema.active is not true then
+      raise exception 'Schema % is not active', resolved_schema.schema_key;
+    end if;
+
+    new.schema_key := resolved_schema.schema_key;
+    return new;
+  end if;
+
+  select id, schema_key, kind
+  into resolved_schema
+  from public.entity_schemas
+  where schema_key = new.schema_key
+    and kind = expected_kind
+    and active = true;
+
+  if not found then
+    raise exception 'Unknown active % schema key %', expected_kind, new.schema_key;
+  end if;
+
+  new.schema_id := resolved_schema.id;
+  return new;
+end;
+$$;
+
+revoke all on function private.resolve_content_schema_id() from public;
+
+drop trigger if exists entities_resolve_schema_id on public.entities;
+create trigger entities_resolve_schema_id
+  before insert or update of schema_id, schema_key on public.entities
+  for each row
+  execute function private.resolve_content_schema_id();
+
+drop trigger if exists entity_relations_resolve_schema_id on public.entity_relations;
+create trigger entity_relations_resolve_schema_id
+  before insert or update of schema_id, schema_key on public.entity_relations
+  for each row
+  execute function private.resolve_content_schema_id();
+
+alter table public.cms_audit_events
+  drop constraint if exists cms_audit_events_target_table_check;
+
+alter table public.cms_audit_events
+  add constraint cms_audit_events_target_table_check
+  check (
+    target_table in (
+      'pages',
+      'sections',
+      'entities',
+      'entity_schemas',
+      'page_sections',
+      'section_entities',
+      'entity_relations'
+    )
+  );
+
+drop trigger if exists entity_schemas_cms_audit on public.entity_schemas;
+create trigger entity_schemas_cms_audit
+  after insert or update or delete on public.entity_schemas
+  for each row
+  execute function private.record_cms_audit_event();


### PR DESCRIPTION
Closes #41

## Summary

- Add an additive `entity_schemas` table as the DB-backed schema registry foundation.
- Link `entities` and `entity_relations` to schema rows through nullable `schema_id` columns while preserving `schema_key` compatibility.
- Seed existing page/section/entity schema keys and a default relation schema.
- Extend CMS audit target checks to include schema registry writes.
- Document the transition from `pages -> sections -> entities` to `entity_schemas -> entities -> entity_relations`.

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `pnpm run build`
- `git diff --check`
- PR checks pass: issue-linked PR check, Vercel, Vercel Preview Comments
- `pnpm dlx supabase --version` -> 2.98.2
- Local route smoke on `localhost:3000`: `/`, `/history`, `/performances`, `/videos`, `/photos`, `/members` -> 200; `/ponix` -> 307 `/login?next=%2Fponix`
- Supabase MCP read-only preflight: `entity_schemas` absent; required helper functions exist; 19 distinct section schema keys; 12 distinct entity schema keys; 0 blank/null entity schema keys; 409 entity relations

## Notes

This does not apply the migration to production. Production apply still needs explicit maintainer approval. Preview public route curl is blocked by Vercel SSO, so route smoke was run locally against the PR branch. Local Supabase migration apply was not verified because `pnpm dlx supabase db reset` could not connect to the local Docker/OrbStack daemon.