### PR TITLE
Fix PONIX entity graph relation filters

### DIFF
--- a/lib/cms/content.ts
+++ b/lib/cms/content.ts
@@ -879,7 +879,6 @@ async function loadPageSectionRelationsFromEntityGraph({
   let query = supabase
     .from("entity_relations")
     .select(ENTITY_RELATION_SELECT, { count: "exact" })
-    .is("source_table", null)
     .eq("source_table", "page_sections")
 
   if (pageShadowId) query = query.eq("from_entity_id", pageShadowId)
@@ -1040,6 +1039,7 @@ async function loadEntityRelations({
   let query = supabase
     .from("entity_relations")
     .select(ENTITY_RELATION_SELECT, { count: "exact" })
+    .is("source_table", null)
 
   if (fromEntityId) {
     query = query.eq("from_entity_id", fromEntityId)


### PR DESCRIPTION
## Summary

- Fix bridge-backed page-section relation reads to query source_table = page_sections without also requiring null.
- Keep generic entity relation reads scoped to source_table is null so mirrored CMS composition relations do not leak into domain relation lists.

## Verification

- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm run build
- Authenticated CMUX /ponix/pages/:id showed Page structure, Entity graph synced, 6 / 6 mirror rows, home-hero, Save.
- Authenticated CMUX /ponix/pages/:id/compose showed Edit in context, Shown data, Entity graph synced, Dream Theater - Octavarium, iframe.

## Safety

- No Supabase schema or data writes.
- Relation mutation submit was intentionally not clicked because it would write production Supabase rows.

Closes #47