### PR TITLE
Bypass Next optimizer for Supabase Storage images

### DIFF
--- a/components/content-image.tsx
+++ b/components/content-image.tsx
@@ -1,0 +1,49 @@
+import Image, { type ImageProps } from "next/image"
+
+type ContentImageProps = Omit<ImageProps, "src"> & {
+  src: string
+}
+
+const configuredSupabaseHost = (() => {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+
+  if (!supabaseUrl) return null
+
+  try {
+    return new URL(supabaseUrl).hostname
+  } catch {
+    return null
+  }
+})()
+
+export function shouldBypassImageOptimization(src: string) {
+  try {
+    const url = new URL(src)
+    const isConfiguredSupabaseHost =
+      configuredSupabaseHost !== null && url.hostname === configuredSupabaseHost
+    const isSupabaseHost = url.hostname.endsWith(".supabase.co")
+
+    return (
+      (isConfiguredSupabaseHost || isSupabaseHost) &&
+      url.pathname.startsWith("/storage/v1/object/")
+    )
+  } catch {
+    return false
+  }
+}
+
+export function ContentImage({
+  src,
+  alt,
+  unoptimized,
+  ...props
+}: ContentImageProps) {
+  return (
+    <Image
+      {...props}
+      src={src}
+      alt={alt}
+      unoptimized={unoptimized ?? shouldBypassImageOptimization(src)}
+    />
+  )
+}

--- a/components/home-section.tsx
+++ b/components/home-section.tsx
@@ -1,12 +1,12 @@
 "use client"
 
-import Image from "next/image"
 import Link from "next/link"
 import type { CSSProperties, ReactNode } from "react"
 import {
   AdminSectionFrame,
   type AdminSectionControl,
 } from "@/components/admin-section-frame"
+import { ContentImage } from "@/components/content-image"
 import { Reveal } from "@/components/reveal"
 import {
   CalendarBlank,
@@ -170,7 +170,7 @@ function StatCardView({ card }: { card: HomeStatCard }) {
     >
       <div className="relative basis-[55%] grow-0 shrink-0 bg-muted overflow-hidden">
         {imageSrc && (
-          <Image
+          <ContentImage
             src={imageSrc}
             alt={card.label}
             fill
@@ -303,7 +303,7 @@ export function HomeSection({
             className="col-span-12 md:col-span-7 group flex flex-col gap-4 animate-in fade-in-0 slide-in-from-bottom-3 duration-700 delay-100"
           >
             <div className="relative aspect-video overflow-hidden border bg-muted rounded-md">
-              <Image
+              <ContentImage
                 src={homeFeaturedVideo.thumbnailUrl ?? thumbnailUrl(homeFeaturedVideo.id, "max")}
                 alt={homeFeaturedVideo.title}
                 fill
@@ -387,7 +387,7 @@ export function HomeSection({
                 className="group flex flex-col gap-3"
               >
                 <div className="relative aspect-video overflow-hidden border bg-muted rounded-md">
-                  <Image
+                  <ContentImage
                     src={v.thumbnailUrl ?? thumbnailUrl(v.id, "max")}
                     alt={`${v.artist ?? "Bremen"} - ${v.song ?? v.title}`}
                     fill

--- a/components/performances-section.tsx
+++ b/components/performances-section.tsx
@@ -1,5 +1,4 @@
 import type { ElementType } from "react"
-import Image from "next/image"
 import Link from "next/link"
 import {
   ArrowRight,
@@ -11,6 +10,7 @@ import {
   AdminSectionFrame,
   type AdminSectionControl,
 } from "@/components/admin-section-frame"
+import { ContentImage } from "@/components/content-image"
 import {
   Carousel,
   CarouselContent,
@@ -80,7 +80,7 @@ function PlaylistCard({
     <article className="lift-card group flex h-full flex-col overflow-hidden rounded-md border bg-card shadow-sm hover:shadow-xl">
       <div className="relative aspect-video bg-muted">
         {playlist.coverUrl ? (
-          <Image
+          <ContentImage
             src={playlist.coverUrl}
             alt={playlist.title}
             fill
@@ -297,7 +297,7 @@ export function StageMoments({
             >
               <div className="relative aspect-[3/4] bg-muted">
                 {photo.thumbnailUrl && (
-                  <Image
+                  <ContentImage
                     src={photo.thumbnailUrl}
                     alt={photo.title}
                     fill
@@ -331,7 +331,7 @@ export function PerformanceUpdateCard({
     <article className="lift-card group grid h-full grid-cols-1 overflow-hidden rounded-md border bg-card shadow-sm hover:shadow-xl sm:grid-cols-[10rem_1fr]">
       <div className="relative min-h-52 bg-muted sm:min-h-full">
         {update.thumbnailUrl ? (
-          <Image
+          <ContentImage
             src={update.thumbnailUrl}
             alt={update.title}
             fill

--- a/components/photos-section.tsx
+++ b/components/photos-section.tsx
@@ -1,12 +1,12 @@
 "use client"
 
-import Image from "next/image"
 import { useState } from "react"
 import { CaretLeft, CaretRight } from "@phosphor-icons/react/dist/ssr"
 import {
   AdminSectionFrame,
   type AdminSectionControl,
 } from "@/components/admin-section-frame"
+import { ContentImage } from "@/components/content-image"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -167,7 +167,7 @@ export function PhotoGallerySurface({
                   )}
                 >
                   {photo.thumbnailUrl && (
-                    <Image
+                    <ContentImage
                       src={photo.thumbnailUrl}
                       alt={photo.title}
                       fill
@@ -217,7 +217,7 @@ export function PhotoGallerySurface({
                 )}
               >
                 {current.thumbnailUrl ? (
-                  <Image
+                  <ContentImage
                     src={current.thumbnailUrl}
                     alt={current.title}
                     fill

--- a/components/videos-section.tsx
+++ b/components/videos-section.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import Image from "next/image"
 import { useSearchParams } from "next/navigation"
 import { Suspense, useDeferredValue, useState, type CSSProperties } from "react"
 import {
@@ -16,6 +15,7 @@ import {
   AdminSectionFrame,
   type AdminSectionControl,
 } from "@/components/admin-section-frame"
+import { ContentImage } from "@/components/content-image"
 import {
   Command,
   CommandEmpty,
@@ -157,7 +157,7 @@ function VideoCard({
         className="lift-card group flex h-full flex-col overflow-hidden rounded-md border bg-card shadow-sm hover:shadow-xl"
       >
         <div className="relative aspect-video overflow-hidden bg-muted">
-          <Image
+          <ContentImage
             src={videoThumbnailUrl(video, "mq")}
             alt={video.raw_title}
             fill
@@ -216,7 +216,7 @@ function FeaturedVideoCard({ video }: { video: Video }) {
         className="tilt-card group flex h-full flex-col overflow-hidden rounded-md border bg-card shadow-sm hover:shadow-xl"
       >
         <div className="relative aspect-[16/10] overflow-hidden bg-muted">
-          <Image
+          <ContentImage
             src={videoThumbnailUrl(video, "max")}
             alt={video.raw_title}
             fill
@@ -266,7 +266,7 @@ function PickRow({ video, index }: { video: Video; index: number }) {
         className="group flex items-start gap-4 border-b py-4 transition-colors hover:border-foreground"
       >
         <div className="relative h-20 w-32 shrink-0 overflow-hidden rounded-sm bg-muted">
-          <Image
+          <ContentImage
             src={videoThumbnailUrl(video, "mq")}
             alt={video.raw_title}
             fill


### PR DESCRIPTION
## Summary

- Add a shared ContentImage wrapper that preserves next/image but marks Supabase Storage object URLs as unoptimized.
- Move home, performance, video, and photo content thumbnails onto the wrapper.
- Avoid broad Next optimizer private/local IP access changes.

## Verification

- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm run build
- CMUX /ponix/pages/:id/compose found 7 Supabase Storage images and 0 optimized Supabase URLs.
- CMUX / found 7 Supabase Storage images and 0 optimized Supabase URLs.
- Dev log after reload showed 200 responses without new upstream image private-IP errors.

## Safety

- No Supabase schema, data, or Storage policy change.
- Next image optimizer network boundary is not loosened.

Closes #49