### PR TITLE
Make composer section switching client-side

### DIFF
--- a/app/ponix/pages/[id]/compose/composer-workspace.tsx
+++ b/app/ponix/pages/[id]/compose/composer-workspace.tsx
@@ -1,0 +1,259 @@
+"use client"
+
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react"
+import Link from "next/link"
+import { ArrowUpRight } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { ScrollArea } from "@/components/ui/scroll-area"
+
+type ComposerSection = {
+  id: string
+  key: string
+  title: string | null
+}
+
+export function PonixComposerWorkspace({
+  pageId,
+  title,
+  slug,
+  kind,
+  sections,
+  initialSelectedKey,
+  children,
+}: {
+  pageId: string
+  title: string
+  slug: string
+  kind: string
+  sections: ComposerSection[]
+  initialSelectedKey: string | null
+  children: ReactNode
+}) {
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+  const panelsRef = useRef<HTMLDivElement>(null)
+  const [selectedKey, setSelectedKey] = useState(initialSelectedKey)
+  const selectedSection = useMemo(
+    () => sections.find((section) => section.key === selectedKey) ?? null,
+    [sections, selectedKey],
+  )
+
+  useEffect(() => {
+    const root = panelsRef.current
+    if (!root) return
+
+    root
+      .querySelectorAll<HTMLElement>("[data-composer-panel]")
+      .forEach((panel) => {
+        const selected = panel.dataset.composerPanel === selectedKey
+        panel.hidden = !selected
+        panel.dataset.state = selected ? "selected" : "idle"
+      })
+  }, [selectedKey])
+
+  useEffect(() => {
+    const frame = iframeRef.current
+    if (!frame?.contentWindow || !selectedKey) return
+
+    frame.contentWindow.postMessage(
+      { type: "ponix:set-selected-section", sectionKey: selectedKey },
+      window.location.origin,
+    )
+  }, [selectedKey])
+
+  useEffect(() => {
+    function handleMessage(event: MessageEvent) {
+      if (event.origin !== window.location.origin) return
+      if (!isSectionMessage(event.data, "ponix:select-section")) return
+
+      selectSection(event.data.sectionKey)
+    }
+
+    window.addEventListener("message", handleMessage)
+    return () => window.removeEventListener("message", handleMessage)
+  })
+
+  function selectSection(sectionKey: string) {
+    if (!sections.some((section) => section.key === sectionKey)) return
+
+    setSelectedKey(sectionKey)
+    window.history.replaceState(null, "", composeHref(pageId, sectionKey))
+  }
+
+  return (
+    <>
+      <ComposerHeader
+        pageId={pageId}
+        title={title}
+        slug={slug}
+        kind={kind}
+        sectionCount={sections.length}
+      />
+
+      <div className="grid min-h-[calc(100svh-13rem)] gap-5 xl:grid-cols-[minmax(0,1fr)_25rem]">
+        <Card className="overflow-hidden rounded-2xl bg-card/95 shadow-sm">
+          <CardHeader className="border-b bg-muted/20 px-5 py-5 md:px-6">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+              <div>
+                <p className="caps text-muted-foreground">Live canvas</p>
+                <CardTitle className="font-serif text-3xl italic md:text-4xl">
+                  Edit in context
+                </CardTitle>
+                <CardDescription>
+                  실제 사이트 화면을 보며 섹션을 고르고, 오른쪽에서 바로 정리합니다.
+                </CardDescription>
+              </div>
+              <Button asChild variant="outline" className="w-fit rounded-full">
+                <Link href={`/ponix/preview/pages/${pageId}`}>
+                  Preview route
+                  <ArrowUpRight className="size-4" />
+                </Link>
+              </Button>
+            </div>
+            <SectionRail
+              pageId={pageId}
+              sections={sections}
+              selectedKey={selectedSection?.key ?? null}
+              onSelect={selectSection}
+            />
+          </CardHeader>
+          <CardContent className="bg-[#f7f1e8] p-0">
+            <iframe
+              ref={iframeRef}
+              title={`${title} live canvas`}
+              src={canvasHref(pageId, initialSelectedKey)}
+              className="h-[calc(100svh-18rem)] min-h-[42rem] w-full border-0 bg-background"
+            />
+          </CardContent>
+        </Card>
+
+        <div ref={panelsRef}>{children}</div>
+      </div>
+    </>
+  )
+}
+
+function ComposerHeader({
+  pageId,
+  title,
+  slug,
+  kind,
+  sectionCount,
+}: {
+  pageId: string
+  title: string
+  slug: string
+  kind: string
+  sectionCount: number
+}) {
+  return (
+    <div className="relative overflow-hidden rounded-2xl border bg-card/95 p-5 shadow-sm md:p-7">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_8%_0%,color-mix(in_oklch,var(--accent)_12%,transparent),transparent_34%),linear-gradient(135deg,color-mix(in_oklch,var(--secondary)_84%,transparent),transparent_42%)]" />
+      <div className="relative flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <p className="caps mb-3 text-muted-foreground">PONIX / Composer</p>
+          <h1 className="font-serif text-[clamp(3rem,6vw,5.5rem)] italic leading-[0.86] tracking-tight">
+            {title}
+          </h1>
+          <div className="mt-4 flex flex-wrap items-center gap-2">
+            <span className="rounded-full bg-secondary px-2.5 py-0.5 font-mono text-xs text-secondary-foreground">
+              /{slug}
+            </span>
+            <span className="rounded-full border px-2.5 py-0.5 text-xs">
+              {kind}
+            </span>
+            <span className="rounded-full border px-2.5 py-0.5 text-xs">
+              {sectionCount} sections
+            </span>
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button asChild variant="outline" className="rounded-full">
+            <Link href={`/ponix/pages/${pageId}`}>Record</Link>
+          </Button>
+          <Button asChild className="rounded-full">
+            <Link href={`/ponix/pages/${pageId}/edit`}>Page settings</Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function SectionRail({
+  pageId,
+  sections,
+  selectedKey,
+  onSelect,
+}: {
+  pageId: string
+  sections: ComposerSection[]
+  selectedKey: string | null
+  onSelect: (sectionKey: string) => void
+}) {
+  if (!sections.length) {
+    return null
+  }
+
+  return (
+    <ScrollArea className="mt-5 whitespace-nowrap">
+      <div className="flex gap-2 pb-2">
+        {sections.map((section, index) => {
+          const selected = section.key === selectedKey
+
+          return (
+            <Button
+              key={section.id}
+              type="button"
+              variant={selected ? "default" : "outline"}
+              size="sm"
+              className="rounded-full"
+              aria-current={selected ? "true" : undefined}
+              onClick={() => onSelect(section.key)}
+              data-composer-section-button={section.key}
+              data-href={composeHref(pageId, section.key)}
+            >
+              <span className="tabular-nums">
+                {String(index + 1).padStart(2, "0")}
+              </span>
+              {section.title ?? section.key}
+            </Button>
+          )
+        })}
+      </div>
+    </ScrollArea>
+  )
+}
+
+function canvasHref(pageId: string, sectionKey: string | null) {
+  const params = sectionKey
+    ? `?section=${encodeURIComponent(sectionKey)}`
+    : ""
+
+  return `/ponix-canvas/pages/${pageId}${params}`
+}
+
+function composeHref(pageId: string, sectionKey: string) {
+  return `/ponix/pages/${pageId}/compose?section=${encodeURIComponent(sectionKey)}`
+}
+
+function isSectionMessage(
+  value: unknown,
+  type: "ponix:select-section" | "ponix:set-selected-section",
+): value is { type: string; sectionKey: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "type" in value &&
+    "sectionKey" in value &&
+    value.type === type &&
+    typeof value.sectionKey === "string"
+  )
+}

--- a/app/ponix/pages/[id]/compose/page.tsx
+++ b/app/ponix/pages/[id]/compose/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next"
 import Link from "next/link"
 import { notFound } from "next/navigation"
-import { ArrowUpRight, Database, Layers3, PencilLine } from "lucide-react"
+import { Database, Layers3, PencilLine } from "lucide-react"
 
 import { CmsEntityPicker } from "@/app/ponix/_components/cms-entity-picker"
 import { renderFieldInput } from "@/app/ponix/_components/cms-section-form"
@@ -9,6 +9,7 @@ import {
   CmsSaveNotice,
   CmsSubmitButton,
 } from "@/app/ponix/_components/cms-save-controls"
+import { PonixComposerWorkspace } from "@/app/ponix/pages/[id]/compose/composer-workspace"
 import {
   addSectionEntityRelationAction,
   deleteSectionEntityRelationAction,
@@ -25,7 +26,6 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
-import { ScrollArea } from "@/components/ui/scroll-area"
 import { Separator } from "@/components/ui/separator"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -79,164 +79,69 @@ export default async function PonixPageComposerPage({
     preview.graph.sections[0] ??
     null
   const selectedKey = selectedSection?.key ?? null
-  const [sectionDetail, sectionRelations, relationOptions] = selectedSection
-    ? await Promise.all([
-        loadCmsSectionDetail(selectedSection.id),
-        loadCmsSectionRelations(selectedSection.id),
-        loadCmsRelationEditorOptions(),
-      ])
-    : [null, null, null]
-  const composeUrl = selectedKey ? composeHref(id, selectedKey) : `/ponix/pages/${id}/compose`
+  const [relationOptions, sectionContexts] = await Promise.all([
+    loadCmsRelationEditorOptions(),
+    Promise.all(
+      preview.graph.sections.map(async (section) => {
+        const [sectionDetail, sectionRelations] = await Promise.all([
+          loadCmsSectionDetail(section.id),
+          loadCmsSectionRelations(section.id),
+        ])
+
+        return {
+          section,
+          sectionDetail:
+            sectionDetail?.kind === "section" ? sectionDetail : null,
+          sectionRelations,
+        }
+      }),
+    ),
+  ])
+  const sectionSaved = searchValue(search?.saved) === "section"
+  const relationMessage = searchValue(search?.relation_message) ?? undefined
+  const relationError = searchValue(search?.relation_error) ?? undefined
 
   return (
     <section className="mx-auto flex w-full max-w-[104rem] flex-col gap-5">
-      <ComposerHeader
+      <PonixComposerWorkspace
         pageId={id}
         title={preview.page.title}
         slug={preview.page.slug}
         kind={preview.kind}
-        sectionCount={preview.graph.sections.length}
-      />
-
-      <div className="grid min-h-[calc(100svh-13rem)] gap-5 xl:grid-cols-[minmax(0,1fr)_25rem]">
-        <Card className="overflow-hidden rounded-2xl bg-card/95 shadow-sm">
-          <CardHeader className="border-b bg-muted/20 px-5 py-5 md:px-6">
-            <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-              <div>
-                <p className="caps text-muted-foreground">Live canvas</p>
-                <CardTitle className="font-serif text-3xl italic md:text-4xl">
-                  Edit in context
-                </CardTitle>
-                <CardDescription>
-                  실제 사이트 화면을 보며 섹션을 고르고, 오른쪽에서 바로 정리합니다.
-                </CardDescription>
-              </div>
-              <Button asChild variant="outline" className="w-fit rounded-full">
-                <Link href={`/ponix/preview/pages/${id}`}>
-                  Preview route
-                  <ArrowUpRight className="size-4" />
-                </Link>
-              </Button>
-            </div>
-            <SectionRail
+        sections={preview.graph.sections.map((section) => ({
+          id: section.id,
+          key: section.key,
+          title: section.title,
+        }))}
+        initialSelectedKey={selectedKey}
+      >
+        {sectionContexts.map(({ section, sectionDetail, sectionRelations }) => (
+          <div
+            key={section.id}
+            data-composer-panel={section.key}
+            data-state={section.key === selectedKey ? "selected" : "idle"}
+            hidden={section.key !== selectedKey}
+          >
+            <SectionInspector
               pageId={id}
-              sections={preview.graph.sections}
-              selectedKey={selectedKey}
+              pageSlug={preview.page.slug}
+              section={section}
+              sectionDetail={sectionDetail}
+              relations={sectionRelations}
+              relationOptions={relationOptions}
+              redirectTo={composeHref(id, section.key)}
+              saved={section.key === selectedKey && sectionSaved}
+              relationMessage={
+                section.key === selectedKey ? relationMessage : undefined
+              }
+              relationError={
+                section.key === selectedKey ? relationError : undefined
+              }
             />
-          </CardHeader>
-          <CardContent className="bg-[#f7f1e8] p-0">
-            <iframe
-              title={`${preview.page.title} live canvas`}
-              src={canvasHref(id, selectedKey)}
-              className="h-[calc(100svh-18rem)] min-h-[42rem] w-full border-0 bg-background"
-            />
-          </CardContent>
-        </Card>
-
-        <SectionInspector
-          pageId={id}
-          pageSlug={preview.page.slug}
-          section={selectedSection}
-          sectionDetail={
-            sectionDetail?.kind === "section" ? sectionDetail : null
-          }
-          relations={sectionRelations}
-          relationOptions={relationOptions}
-          redirectTo={composeUrl}
-          saved={search?.saved === "section"}
-          relationMessage={searchValue(search?.relation_message) ?? undefined}
-          relationError={searchValue(search?.relation_error) ?? undefined}
-        />
-      </div>
-    </section>
-  )
-}
-
-function ComposerHeader({
-  pageId,
-  title,
-  slug,
-  kind,
-  sectionCount,
-}: {
-  pageId: string
-  title: string
-  slug: string
-  kind: string
-  sectionCount: number
-}) {
-  return (
-    <div className="relative overflow-hidden rounded-2xl border bg-card/95 p-5 shadow-sm md:p-7">
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_8%_0%,color-mix(in_oklch,var(--accent)_12%,transparent),transparent_34%),linear-gradient(135deg,color-mix(in_oklch,var(--secondary)_84%,transparent),transparent_42%)]" />
-      <div className="relative flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
-        <div>
-          <p className="caps mb-3 text-muted-foreground">PONIX / Composer</p>
-          <h1 className="font-serif text-[clamp(3rem,6vw,5.5rem)] italic leading-[0.86] tracking-tight">
-            {title}
-          </h1>
-          <div className="mt-4 flex flex-wrap items-center gap-2">
-            <Badge variant="secondary" className="rounded-full font-mono">
-              /{slug}
-            </Badge>
-            <Badge variant="outline" className="rounded-full">
-              {kind}
-            </Badge>
-            <Badge variant="outline" className="rounded-full">
-              {sectionCount} sections
-            </Badge>
           </div>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          <Button asChild variant="outline" className="rounded-full">
-            <Link href={`/ponix/pages/${pageId}`}>Record</Link>
-          </Button>
-          <Button asChild className="rounded-full">
-            <Link href={`/ponix/pages/${pageId}/edit`}>Page settings</Link>
-          </Button>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-function SectionRail({
-  pageId,
-  sections,
-  selectedKey,
-}: {
-  pageId: string
-  sections: GraphSection[]
-  selectedKey: string | null
-}) {
-  if (!sections.length) {
-    return null
-  }
-
-  return (
-    <ScrollArea className="mt-5 whitespace-nowrap">
-      <div className="flex gap-2 pb-2">
-        {sections.map((section, index) => {
-          const selected = section.key === selectedKey
-
-          return (
-            <Button
-              key={section.id}
-              asChild
-              variant={selected ? "default" : "outline"}
-              size="sm"
-              className="rounded-full"
-            >
-              <Link href={composeHref(pageId, section.key)}>
-                <span className="tabular-nums">
-                  {String(index + 1).padStart(2, "0")}
-                </span>
-                {section.title ?? section.key}
-              </Link>
-            </Button>
-          )
-        })}
-      </div>
-    </ScrollArea>
+        ))}
+      </PonixComposerWorkspace>
+    </section>
   )
 }
 
@@ -701,14 +606,6 @@ function MetaRow({
 
 function composeHref(pageId: string, sectionKey: string) {
   return `/ponix/pages/${pageId}/compose?section=${encodeURIComponent(sectionKey)}`
-}
-
-function canvasHref(pageId: string, sectionKey: string | null) {
-  const params = sectionKey
-    ? `?section=${encodeURIComponent(sectionKey)}`
-    : ""
-
-  return `/ponix-canvas/pages/${pageId}${params}`
 }
 
 function searchValue(value: string | string[] | undefined) {

--- a/components/admin-section-frame.tsx
+++ b/components/admin-section-frame.tsx
@@ -1,8 +1,7 @@
 "use client"
 
-import Link from "next/link"
 import { useRouter } from "next/navigation"
-import type { MouseEvent, ReactNode } from "react"
+import { useEffect, useState, type MouseEvent, type ReactNode } from "react"
 import { PencilLine } from "lucide-react"
 
 import { Badge } from "@/components/ui/badge"
@@ -29,13 +28,65 @@ export function AdminSectionFrame({
   children: ReactNode
 }) {
   const router = useRouter()
+  const [activeKey, setActiveKey] = useState(control?.selectedKey ?? null)
+
+  useEffect(() => {
+    if (!control) return
+
+    function handleMessage(event: MessageEvent) {
+      if (event.origin !== window.location.origin) return
+      if (!isSectionMessage(event.data, "ponix:set-selected-section")) return
+
+      setActiveKey(event.data.sectionKey)
+
+      if (event.data.sectionKey === sectionKey) {
+        requestAnimationFrame(() => {
+          document
+            .querySelector(`[data-ponix-section="${CSS.escape(sectionKey)}"]`)
+            ?.scrollIntoView({ block: "center", behavior: "smooth" })
+        })
+      }
+    }
+
+    function handleLocalEvent(event: Event) {
+      if (!(event instanceof CustomEvent)) return
+      const detail = event.detail
+      if (!isSectionMessage(detail, "ponix:set-selected-section")) return
+      setActiveKey(detail.sectionKey)
+    }
+
+    window.addEventListener("message", handleMessage)
+    window.addEventListener("ponix:set-selected-section", handleLocalEvent)
+    return () => {
+      window.removeEventListener("message", handleMessage)
+      window.removeEventListener("ponix:set-selected-section", handleLocalEvent)
+    }
+  }, [control, sectionKey])
 
   if (!control) {
     return <>{children}</>
   }
 
-  const selected = control.selectedKey === sectionKey
+  const selected = activeKey === sectionKey
   const href = sectionComposerHref(control.pageId, sectionKey)
+
+  function selectSection() {
+    window.dispatchEvent(
+      new CustomEvent("ponix:set-selected-section", {
+        detail: { type: "ponix:set-selected-section", sectionKey },
+      }),
+    )
+
+    if (window.parent && window.parent !== window) {
+      window.parent.postMessage(
+        { type: "ponix:select-section", sectionKey },
+        window.location.origin,
+      )
+      return
+    }
+
+    router.push(href)
+  }
 
   function handleClick(event: MouseEvent<HTMLDivElement>) {
     const target = event.target
@@ -52,12 +103,7 @@ export function AdminSectionFrame({
       return
     }
 
-    if (window.parent && window.parent !== window) {
-      window.parent.location.href = href
-      return
-    }
-
-    router.push(href)
+    selectSection()
   }
 
   return (
@@ -72,8 +118,9 @@ export function AdminSectionFrame({
       )}
     >
       <div className="pointer-events-none sticky top-3 z-30 flex justify-end">
-        <Link
-          href={href}
+        <button
+          type="button"
+          onClick={selectSection}
           className={cn(
             "pointer-events-auto -mb-9 inline-flex translate-y-3 items-center gap-2 rounded-full border bg-background/92 px-3 py-1.5 text-xs shadow-sm backdrop-blur transition",
             "opacity-0 group-hover/ponix:translate-y-0 group-hover/ponix:opacity-100",
@@ -88,9 +135,23 @@ export function AdminSectionFrame({
           >
             {sectionKey}
           </Badge>
-        </Link>
+        </button>
       </div>
       {children}
     </div>
+  )
+}
+
+function isSectionMessage(
+  value: unknown,
+  type: "ponix:select-section" | "ponix:set-selected-section",
+): value is { type: string; sectionKey: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "type" in value &&
+    "sectionKey" in value &&
+    value.type === type &&
+    typeof value.sectionKey === "string"
   )
 }


### PR DESCRIPTION
## Summary

- Move PONIX composer section selection into a client workspace so section rail clicks no longer navigate the App Router route.
- Preload section inspector panels once, then show/hide them client-side.
- Replace iframe parent-location navigation with postMessage selection sync so canvas highlights update without reloading the iframe document.

## Verification

- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm run build
- Authenticated CMUX switched home-hero → home-stage-highlights → home-join.
- During switching, parent URL, selected rail button, visible inspector panel, and canvas highlight changed.
- During switching, iframe src stayed on the original canvas URL and an iframe window marker stayed unchanged.
- Dev log showed no additional compose/canvas GET during client-side switching after the initial page/canvas load.

## Safety

- No DB migration.
- No Supabase policy changes.
- No production content mutation buttons clicked during QA.

Closes #55