### PR TITLE
Fix composer canvas scroll isolation

### DIFF
--- a/components/admin-section-frame.tsx
+++ b/components/admin-section-frame.tsx
@@ -41,9 +41,7 @@ export function AdminSectionFrame({
 
       if (event.data.sectionKey === sectionKey) {
         requestAnimationFrame(() => {
-          document
-            .querySelector(`[data-ponix-section="${CSS.escape(sectionKey)}"]`)
-            ?.scrollIntoView({ block: "center", behavior: "smooth" })
+          scrollSectionIntoCanvasView(sectionKey)
         })
       }
     }
@@ -140,6 +138,25 @@ export function AdminSectionFrame({
       {children}
     </div>
   )
+}
+
+function scrollSectionIntoCanvasView(sectionKey: string) {
+  const section = document.querySelector<HTMLElement>(
+    `[data-ponix-section="${CSS.escape(sectionKey)}"]`,
+  )
+
+  if (!section) return
+
+  const rect = section.getBoundingClientRect()
+  const top =
+    window.scrollY +
+    rect.top -
+    Math.max(24, (window.innerHeight - rect.height) / 2)
+
+  window.scrollTo({
+    top: Math.max(0, top),
+    behavior: "smooth",
+  })
 }
 
 function isSectionMessage(


### PR DESCRIPTION
Closes #57

## Summary
- Replace iframe-local section selection scrolling from element.scrollIntoView to explicit iframe window.scrollTo calculation.
- Keep composer parent page scroll stable while the live canvas scrolls to the selected section.

## Verification
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm run build
- CMUX authenticated rail selection: parentY stayed 220, iframeY moved to 2632, URL changed, marker stayed unchanged.
- CMUX authenticated iframe section click: parentY stayed 220, iframeY moved to 998, URL changed, marker stayed unchanged.