### PR TITLE
Improve composer relation inspector UX

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -150,3 +150,18 @@
     transform: translateZ(0) rotate(0deg) translateY(-4px) scale(1.02);
   }
 }
+
+@layer utilities {
+  @keyframes accordion-down {
+    from {
+      height: 0;
+    }
+    to {
+      height: var(--radix-accordion-content-height);
+    }
+  }
+
+  .animate-accordion-down {
+    animation: accordion-down 180ms ease-out;
+  }
+}

--- a/app/ponix/pages/[id]/compose/page.tsx
+++ b/app/ponix/pages/[id]/compose/page.tsx
@@ -16,6 +16,12 @@ import {
   updateSectionEntityRelationAction,
 } from "@/app/ponix/relations/actions"
 import { updateCmsSectionAction } from "@/app/ponix/sections/actions"
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -387,23 +393,37 @@ function SectionEntityWorkspace({
 
         <Separator />
 
-        {relations.sectionEntities.length ? (
-          <ul className="space-y-2">
-            {relations.sectionEntities.map((relation) => (
-              <SectionEntityRelationEditor
-                key={relation.id}
-                relation={relation}
-                redirectTo={redirectTo}
-                typeOptions={relationTypeOptions}
-                slotOptions={slotOptions}
-              />
-            ))}
-          </ul>
-        ) : (
-          <p className="rounded-md border bg-muted/30 p-4 text-sm text-muted-foreground">
-            아직 연결된 데이터가 없습니다.
-          </p>
-        )}
+        <div className="space-y-3">
+          <div className="flex items-end justify-between gap-3">
+            <div>
+              <h2 className="font-medium">Linked entities</h2>
+              <p className="text-xs text-muted-foreground">
+                목록에서 항목을 고른 뒤 연결 정보만 펼쳐 수정합니다.
+              </p>
+            </div>
+            <Badge variant="outline" className="rounded-full">
+              {relations.sectionEntities.length}
+            </Badge>
+          </div>
+
+          {relations.sectionEntities.length ? (
+            <Accordion type="single" collapsible className="space-y-2">
+              {relations.sectionEntities.map((relation) => (
+                <SectionEntityRelationEditor
+                  key={relation.id}
+                  relation={relation}
+                  redirectTo={redirectTo}
+                  typeOptions={relationTypeOptions}
+                  slotOptions={slotOptions}
+                />
+              ))}
+            </Accordion>
+          ) : (
+            <p className="rounded-md border bg-muted/30 p-4 text-sm text-muted-foreground">
+              아직 연결된 데이터가 없습니다.
+            </p>
+          )}
+        </div>
 
         <div>
           <div className="mb-3 flex items-center gap-2">
@@ -434,24 +454,56 @@ function SectionEntityRelationEditor({
   const slotListId = `relation-slots-${relation.id}`
 
   return (
-    <li className="rounded-xl border bg-background/70 p-3 shadow-xs">
-      <div className="mb-3 flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <Link
-            href={`/ponix/entities/${relation.entityId}`}
-            className="line-clamp-1 text-sm font-medium underline-offset-4 hover:underline"
-          >
-            {relation.entity?.title ?? relation.entityId}
-          </Link>
-          <p className="font-mono text-xs text-muted-foreground">
-            {relation.entity?.schemaKey ?? "schema"}
-          </p>
+    <AccordionItem
+      value={relation.id}
+      className="rounded-xl border bg-background/70 px-3 shadow-xs"
+      data-composer-relation-item={relation.id}
+    >
+      <AccordionTrigger
+        className="gap-3 py-3 hover:no-underline"
+        data-composer-relation-trigger={relation.id}
+      >
+        <div className="grid min-w-0 flex-1 gap-2 text-left">
+          <div className="flex min-w-0 items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="line-clamp-1 text-sm font-medium">
+                {relation.entity?.title ?? relation.entityId}
+              </p>
+              <p className="font-mono text-xs text-muted-foreground">
+                {relation.entity?.schemaKey ?? "schema"}
+              </p>
+            </div>
+            <Badge variant="outline" className="rounded-full">
+              {relation.entity?.published ? "published" : "draft"}
+            </Badge>
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            <Badge
+              variant="secondary"
+              className="rounded-full font-mono text-[10px]"
+            >
+              {relation.slot}
+            </Badge>
+            <Badge
+              variant="outline"
+              className="rounded-full font-mono text-[10px]"
+            >
+              {relation.relationType}
+            </Badge>
+            <Badge
+              variant="outline"
+              className="rounded-full font-mono text-[10px]"
+            >
+              #{relation.sortOrder}
+            </Badge>
+          </div>
         </div>
-        <Badge variant="outline" className="rounded-full">
-          {relation.entity?.published ? "published" : "draft"}
-        </Badge>
-      </div>
+      </AccordionTrigger>
 
+      <AccordionContent
+        className="space-y-3 pb-3"
+        data-composer-relation-editor={relation.id}
+      >
       <form
         action={updateSectionEntityRelationAction}
         className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(0,0.9fr)_5.5rem]"
@@ -513,7 +565,7 @@ function SectionEntityRelationEditor({
         />
       </form>
 
-      <form action={deleteSectionEntityRelationAction} className="mt-2">
+      <form action={deleteSectionEntityRelationAction}>
         <input type="hidden" name="redirect_to" value={redirectTo} />
         <input type="hidden" name="relation_id" value={relation.id} />
         <Button
@@ -525,7 +577,8 @@ function SectionEntityRelationEditor({
           이 섹션에서 제거
         </Button>
       </form>
-    </li>
+      </AccordionContent>
+    </AccordionItem>
   )
 }
 

--- a/components/ui/accordion.tsx
+++ b/components/ui/accordion.tsx
@@ -55,7 +55,7 @@ function AccordionContent({
   return (
     <AccordionPrimitive.Content
       data-slot="accordion-content"
-      className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm"
+      className="data-[state=closed]:hidden data-[state=open]:animate-accordion-down overflow-hidden text-sm"
       {...props}
     >
       <div className={cn('pt-0 pb-4', className)}>{children}</div>


### PR DESCRIPTION
Closes #59

## Summary
- Change the composer sidebar linked-entity area from always-open relation forms to a compact accordion list.
- Keep relation type, slot, order, save, remove, and entity detail actions available inside the expanded row.
- Add the missing accordion open animation utility and hide closed accordion content reliably.

## Verification
- pnpm exec tsc --noEmit
- pnpm run lint
- git diff --check
- pnpm run build
- CMUX browser QA on /ponix/pages/548d1d30-6bfd-4930-8d0d-dc1f6a7969c4/compose?section=home-stage-highlights:
  - collapsed state: 4 linked rows, 0 visible relation edit inputs
  - first row expanded: relation_type / slot / sort_order visible, save/remove/detail controls present
  - second row expanded: exactly 1 open editor, 3 visible relation inputs

## Mutation safety
- Did not submit add, save, or delete relation actions.