### PR TITLE
Improve composer save feedback

### DIFF
--- a/app/ponix/_components/cms-save-controls.tsx
+++ b/app/ponix/_components/cms-save-controls.tsx
@@ -10,18 +10,20 @@ import { cn } from "@/lib/utils"
 export function CmsSaveNotice({
   saved,
   error,
+  errorTitle = "저장하지 못했습니다",
   savedTitle = "저장되었습니다",
   savedDescription = "변경 사항이 반영되었습니다.",
 }: {
   saved?: boolean
   error?: string
+  errorTitle?: string
   savedTitle?: string
   savedDescription?: string
 }) {
   if (error) {
     return (
       <Alert variant="destructive" className="rounded-xl shadow-sm">
-        <AlertTitle>저장하지 못했습니다</AlertTitle>
+        <AlertTitle>{errorTitle}</AlertTitle>
         <AlertDescription>{error}</AlertDescription>
       </Alert>
     )

--- a/app/ponix/_components/ponix-shell.tsx
+++ b/app/ponix/_components/ponix-shell.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import type { CSSProperties, ReactNode } from "react"
+import { useEffect, type CSSProperties, type ReactNode } from "react"
 import {
   Activity,
   ArrowUpRight,
@@ -82,6 +82,8 @@ const navGroups = [
   },
 ]
 
+const composerTransientParams = ["saved", "relation_message", "relation_error"]
+
 function isActivePath(pathname: string, href: string) {
   if (href === "/ponix") return pathname === href
   return pathname === href || pathname.startsWith(`${href}/`)
@@ -89,6 +91,28 @@ function isActivePath(pathname: string, href: string) {
 
 export function PonixShell({ memberName, children }: PonixShellProps) {
   const pathname = usePathname()
+
+  useEffect(() => {
+    if (!pathname.includes("/compose")) return
+
+    const url = new URL(window.location.href)
+    let changed = false
+
+    for (const param of composerTransientParams) {
+      if (url.searchParams.has(param)) {
+        url.searchParams.delete(param)
+        changed = true
+      }
+    }
+
+    if (changed) {
+      window.history.replaceState(
+        null,
+        "",
+        `${url.pathname}${url.search}${url.hash}`,
+      )
+    }
+  }, [pathname])
 
   return (
     <SidebarProvider

--- a/app/ponix/pages/[id]/compose/composer-save-feedback.tsx
+++ b/app/ponix/pages/[id]/compose/composer-save-feedback.tsx
@@ -1,0 +1,84 @@
+import { CmsSaveNotice } from "@/app/ponix/_components/cms-save-controls"
+
+export function ComposerSaveFeedback({
+  sectionSaved,
+  relationMessage,
+  relationError,
+}: {
+  sectionSaved: boolean
+  relationMessage?: string
+  relationError?: string
+}) {
+  if (relationError) {
+    return (
+      <div data-composer-save-feedback="error">
+        <CmsSaveNotice
+          error={operatorRelationError(relationError)}
+          errorTitle="연결 데이터를 바꾸지 못했습니다"
+        />
+      </div>
+    )
+  }
+
+  if (relationMessage) {
+    return (
+      <div data-composer-save-feedback="relation">
+        <CmsSaveNotice
+          saved
+          savedTitle="연결 데이터를 반영했습니다"
+          savedDescription={operatorRelationMessage(relationMessage)}
+        />
+      </div>
+    )
+  }
+
+  if (sectionSaved) {
+    return (
+      <div data-composer-save-feedback="section">
+        <CmsSaveNotice
+          saved
+          savedTitle="섹션 문구를 저장했습니다"
+          savedDescription="캔버스와 공개 페이지에서 새 내용이 보이도록 갱신했습니다."
+        />
+      </div>
+    )
+  }
+
+  return null
+}
+
+function operatorRelationMessage(message: string) {
+  const normalized = message.trim().toLowerCase()
+
+  if (normalized.includes("removed")) {
+    return "선택한 데이터가 이 섹션에서 빠졌습니다."
+  }
+
+  if (normalized.includes("saved")) {
+    return "이 섹션의 데이터 연결과 노출 순서를 저장했습니다."
+  }
+
+  return message
+}
+
+function operatorRelationError(message: string) {
+  const normalized = message.trim()
+
+  if (!normalized) {
+    return "연결 정보를 다시 확인한 뒤 저장해 주세요."
+  }
+
+  if (normalized.includes("required")) {
+    return "필수 항목이 비어 있습니다. 연결할 데이터와 관계 정보를 확인해 주세요."
+  }
+
+  if (normalized.includes("integer")) {
+    return "순서는 정수로 입력해야 합니다."
+  }
+
+  if (normalized.includes("not found")) {
+    return "대상 연결을 찾지 못했습니다. 화면을 새로고침한 뒤 다시 시도해 주세요."
+  }
+
+  return normalized
+}

--- a/app/ponix/pages/[id]/compose/page.tsx
+++ b/app/ponix/pages/[id]/compose/page.tsx
@@ -5,10 +5,8 @@ import { Database, Layers3, PencilLine } from "lucide-react"
 
 import { CmsEntityPicker } from "@/app/ponix/_components/cms-entity-picker"
 import { renderFieldInput } from "@/app/ponix/_components/cms-section-form"
-import {
-  CmsSaveNotice,
-  CmsSubmitButton,
-} from "@/app/ponix/_components/cms-save-controls"
+import { CmsSubmitButton } from "@/app/ponix/_components/cms-save-controls"
+import { ComposerSaveFeedback } from "@/app/ponix/pages/[id]/compose/composer-save-feedback"
 import { PonixComposerWorkspace } from "@/app/ponix/pages/[id]/compose/composer-workspace"
 import {
   addSectionEntityRelationAction,
@@ -176,18 +174,11 @@ function SectionInspector({
 }) {
   return (
     <aside className="space-y-4 xl:sticky xl:top-40 xl:max-h-[calc(100svh-10rem)] xl:overflow-auto xl:pr-1">
-      <CmsSaveNotice
-        saved={saved}
-        error={relationError}
-        savedDescription="선택한 섹션 정보가 저장되었습니다."
+      <ComposerSaveFeedback
+        sectionSaved={saved}
+        relationMessage={relationMessage}
+        relationError={relationError}
       />
-      {relationMessage && (
-        <CmsSaveNotice
-          saved
-          savedTitle="연결을 반영했습니다"
-          savedDescription={relationMessage}
-        />
-      )}
       <Card className="overflow-hidden rounded-2xl bg-card/95 shadow-sm">
         <CardHeader className="border-b bg-muted/20">
           <p className="caps text-muted-foreground">선택한 섹션</p>


### PR DESCRIPTION
Closes #63

## Summary
- Add a composer-specific feedback component that maps section/relation mutation results to operator-facing Korean notices.
- Keep the selected section in the URL while clearing transient saved/relation query params from the address bar.
- Allow CmsSaveNotice to accept a custom error title.

## Verification
- pnpm exec tsc --noEmit
- pnpm run lint
- git diff --check
- pnpm run build
- CMUX browser QA:
  - section save query shows 섹션 문구를 저장했습니다 and removes saved while preserving section
  - relation success query shows 연결 데이터를 반영했습니다 and removes relation_message while preserving section
  - relation error query shows 연결 데이터를 바꾸지 못했습니다 and removes relation_error while preserving section

## Mutation safety
- Did not submit add, save, or delete actions during QA.