### PR TITLE
Complete composer entity editing flow UX

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -149,6 +149,28 @@
   .tilt-card:hover {
     transform: translateZ(0) rotate(0deg) translateY(-4px) scale(1.02);
   }
+
+  [data-ponix-entity] {
+    outline: 0 solid transparent;
+    outline-offset: 0;
+    transition:
+      outline-color 180ms ease,
+      outline-width 180ms ease,
+      outline-offset 180ms ease,
+      box-shadow 180ms ease;
+  }
+
+  [data-ponix-entity][data-ponix-entity-state='selected'] {
+    outline-color: var(--accent);
+    outline-width: 3px;
+    outline-offset: 6px;
+    box-shadow: 0 0 0 10px color-mix(in_oklch, var(--accent) 16%, transparent);
+  }
+
+  [data-composer-entity-id][data-composer-entity-state='selected'] {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 4px color-mix(in_oklch, var(--accent) 14%, transparent);
+  }
 }
 
 @layer utilities {

--- a/app/ponix/pages/[id]/compose/composer-workspace.tsx
+++ b/app/ponix/pages/[id]/compose/composer-workspace.tsx
@@ -39,7 +39,9 @@ export function PonixComposerWorkspace({
 }) {
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const panelsRef = useRef<HTMLDivElement>(null)
+  const dirtyRef = useRef(false)
   const [selectedKey, setSelectedKey] = useState(initialSelectedKey)
+  const [selectedEntityId, setSelectedEntityId] = useState<string | null>(null)
   const selectedSection = useMemo(
     () => sections.find((section) => section.key === selectedKey) ?? null,
     [sections, selectedKey],
@@ -69,6 +71,93 @@ export function PonixComposerWorkspace({
   }, [selectedKey])
 
   useEffect(() => {
+    const delays = [0, 150, 500, 1000]
+    const timers = delays.map((delay) =>
+      window.setTimeout(() => {
+        highlightEntityInFrame(iframeRef.current, selectedEntityId)
+        iframeRef.current?.contentWindow?.postMessage(
+          { type: "ponix:set-selected-entity", entityId: selectedEntityId },
+          window.location.origin,
+        )
+      }, delay),
+    )
+
+    return () => {
+      timers.forEach((timer) => window.clearTimeout(timer))
+    }
+  }, [selectedEntityId])
+
+  useEffect(() => {
+    const root = panelsRef.current
+    if (!root) return
+
+    root
+      .querySelectorAll<HTMLElement>("[data-composer-entity-id]")
+      .forEach((row) => {
+        const selected = row.dataset.composerEntityId === selectedEntityId
+        row.dataset.composerEntityState = selected ? "selected" : "idle"
+      })
+  }, [selectedEntityId])
+
+  useEffect(() => {
+    const root = panelsRef.current
+    if (!root) return
+    const panelRoot = root
+
+    function markDirty(event: Event) {
+      const target = event.target
+      if (!(target instanceof HTMLElement)) return
+      if (!target.closest("[data-composer-track-dirty]")) return
+
+      dirtyRef.current = true
+      panelRoot.dataset.composerDirty = "true"
+    }
+
+    function clearDirty(event: Event) {
+      const target = event.target
+      if (!(target instanceof HTMLElement)) return
+      if (!target.closest("[data-composer-track-dirty]")) return
+
+      dirtyRef.current = false
+      delete panelRoot.dataset.composerDirty
+    }
+
+    function selectEntity(event: Event) {
+      const target = event.target
+      if (!(target instanceof HTMLElement)) return
+
+      const row = target.closest<HTMLElement>("[data-composer-entity-id]")
+      const entityId = row?.dataset.composerEntityId
+      if (!entityId) return
+
+      setSelectedEntityId(entityId)
+    }
+
+    function handleBeforeUnload(event: BeforeUnloadEvent) {
+      if (!dirtyRef.current) return
+
+      event.preventDefault()
+      event.returnValue = ""
+    }
+
+    root.addEventListener("input", markDirty)
+    root.addEventListener("change", markDirty)
+    root.addEventListener("submit", clearDirty)
+    root.addEventListener("click", selectEntity)
+    root.addEventListener("focusin", selectEntity)
+    window.addEventListener("beforeunload", handleBeforeUnload)
+
+    return () => {
+      root.removeEventListener("input", markDirty)
+      root.removeEventListener("change", markDirty)
+      root.removeEventListener("submit", clearDirty)
+      root.removeEventListener("click", selectEntity)
+      root.removeEventListener("focusin", selectEntity)
+      window.removeEventListener("beforeunload", handleBeforeUnload)
+    }
+  }, [])
+
+  useEffect(() => {
     function handleMessage(event: MessageEvent) {
       if (event.origin !== window.location.origin) return
       if (!isSectionMessage(event.data, "ponix:select-section")) return
@@ -82,9 +171,41 @@ export function PonixComposerWorkspace({
 
   function selectSection(sectionKey: string) {
     if (!sections.some((section) => section.key === sectionKey)) return
+    if (
+      dirtyRef.current &&
+      !window.confirm("저장하지 않은 변경사항이 있습니다. 섹션을 이동할까요?")
+    ) {
+      return
+    }
 
+    dirtyRef.current = false
+    delete panelsRef.current?.dataset.composerDirty
+    highlightEntityInFrame(iframeRef.current, null)
+    iframeRef.current?.contentWindow?.postMessage(
+      { type: "ponix:set-selected-entity", entityId: null },
+      window.location.origin,
+    )
     setSelectedKey(sectionKey)
+    setSelectedEntityId(null)
     window.history.replaceState(null, "", composeHref(pageId, sectionKey))
+  }
+
+  function syncCanvasFrame() {
+    const target = iframeRef.current?.contentWindow
+    if (!target) return
+
+    if (selectedKey) {
+      target.postMessage(
+        { type: "ponix:set-selected-section", sectionKey: selectedKey },
+        window.location.origin,
+      )
+    }
+
+    highlightEntityInFrame(iframeRef.current, selectedEntityId)
+    target.postMessage(
+      { type: "ponix:set-selected-entity", entityId: selectedEntityId },
+      window.location.origin,
+    )
   }
 
   return (
@@ -129,12 +250,15 @@ export function PonixComposerWorkspace({
               ref={iframeRef}
               title={`${title} live canvas`}
               src={canvasHref(pageId, initialSelectedKey)}
+              onLoad={syncCanvasFrame}
               className="h-[calc(100svh-18rem)] min-h-[42rem] w-full border-0 bg-background"
             />
           </CardContent>
         </Card>
 
-        <div ref={panelsRef}>{children}</div>
+        <div ref={panelsRef} data-composer-panels>
+          {children}
+        </div>
       </div>
     </>
   )
@@ -242,6 +366,41 @@ function canvasHref(pageId: string, sectionKey: string | null) {
 
 function composeHref(pageId: string, sectionKey: string) {
   return `/ponix/pages/${pageId}/compose?section=${encodeURIComponent(sectionKey)}`
+}
+
+function highlightEntityInFrame(
+  frame: HTMLIFrameElement | null,
+  entityId: string | null,
+) {
+  const frameWindow = frame?.contentWindow
+  const frameDocument = frame?.contentDocument
+  if (!frameWindow || !frameDocument) return
+
+  const nodes =
+    frameDocument.querySelectorAll<HTMLElement>("[data-ponix-entity]")
+  let firstMatch: HTMLElement | null = null
+
+  nodes.forEach((node) => {
+    const selected = Boolean(entityId) && node.dataset.ponixEntity === entityId
+    if (selected && !firstMatch) {
+      firstMatch = node
+    }
+    node.dataset.ponixEntityState = selected ? "selected" : "idle"
+  })
+
+  const target = firstMatch as HTMLElement | null
+  if (!target) return
+
+  const rect = target.getBoundingClientRect()
+  const top =
+    frameWindow.scrollY +
+    rect.top -
+    Math.max(24, (frameWindow.innerHeight - rect.height) / 2)
+
+  frameWindow.scrollTo({
+    top: Math.max(0, top),
+    behavior: "smooth",
+  })
 }
 
 function isSectionMessage(

--- a/app/ponix/pages/[id]/compose/page.tsx
+++ b/app/ponix/pages/[id]/compose/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next"
 import Link from "next/link"
 import { notFound } from "next/navigation"
-import { Database, Layers3, PencilLine } from "lucide-react"
+import { ArrowDown, ArrowUp, Database, Layers3, PencilLine } from "lucide-react"
 
 import { CmsEntityPicker } from "@/app/ponix/_components/cms-entity-picker"
 import { renderFieldInput } from "@/app/ponix/_components/cms-section-form"
@@ -278,7 +278,11 @@ function SectionQuickEditCard({
             </AccordionTrigger>
           </CardHeader>
           <AccordionContent className="p-5" data-composer-copy-editor>
-            <form action={updateCmsSectionAction} className="space-y-4">
+            <form
+              action={updateCmsSectionAction}
+              className="space-y-4"
+              data-composer-track-dirty
+            >
               <input type="hidden" name="section_id" value={detail.row.id} />
               <input type="hidden" name="redirect_to" value={redirectTo} />
               <div className="max-h-[32rem] space-y-4 overflow-auto pr-1">
@@ -350,7 +354,11 @@ function SectionEntityWorkspace({
         )}
       </CardHeader>
       <CardContent className="space-y-5 p-5">
-        <form action={addSectionEntityRelationAction} className="space-y-4">
+        <form
+          action={addSectionEntityRelationAction}
+          className="space-y-4"
+          data-composer-track-dirty
+        >
           <input type="hidden" name="redirect_to" value={redirectTo} />
           <input type="hidden" name="section_id" value={section.id} />
           <CmsEntityPicker
@@ -417,10 +425,16 @@ function SectionEntityWorkspace({
 
           {relations.sectionEntities.length ? (
             <Accordion type="single" collapsible className="space-y-2">
-              {relations.sectionEntities.map((relation) => (
+              {relations.sectionEntities.map((relation, index) => (
                 <SectionEntityRelationEditor
                   key={relation.id}
                   relation={relation}
+                  previousSortOrder={
+                    relations.sectionEntities[index - 1]?.sortOrder ?? null
+                  }
+                  nextSortOrder={
+                    relations.sectionEntities[index + 1]?.sortOrder ?? null
+                  }
                   redirectTo={redirectTo}
                   typeOptions={relationTypeOptions}
                   slotOptions={slotOptions}
@@ -475,23 +489,32 @@ function SectionAdvancedSettingsCard({ section }: { section: GraphSection }) {
 
 function SectionEntityRelationEditor({
   relation,
+  previousSortOrder,
+  nextSortOrder,
   redirectTo,
   typeOptions,
   slotOptions,
 }: {
   relation: CmsSectionRelationContext["sectionEntities"][number]
+  previousSortOrder: number | null
+  nextSortOrder: number | null
   redirectTo: string
   typeOptions: string[]
   slotOptions: string[]
 }) {
   const typeListId = `relation-types-${relation.id}`
   const slotListId = `relation-slots-${relation.id}`
+  const moveUpSortOrder =
+    previousSortOrder === null ? null : previousSortOrder - 1
+  const moveDownSortOrder =
+    nextSortOrder === null ? null : nextSortOrder + 1
 
   return (
     <AccordionItem
       value={relation.id}
       className="rounded-xl border bg-background/70 px-3 shadow-xs"
       data-composer-relation-item={relation.id}
+      data-composer-entity-id={relation.entityId}
     >
       <AccordionTrigger
         className="gap-3 py-3 hover:no-underline"
@@ -538,81 +561,192 @@ function SectionEntityRelationEditor({
         className="space-y-3 pb-3"
         data-composer-relation-editor={relation.id}
       >
-      <form
-        action={updateSectionEntityRelationAction}
-        className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(0,0.9fr)_5.5rem]"
-      >
-        <input type="hidden" name="redirect_to" value={redirectTo} />
-        <input type="hidden" name="relation_id" value={relation.id} />
-        <div className="space-y-1.5">
-          <Label htmlFor={`relation-type-${relation.id}`} className="text-xs">
-            Type
-          </Label>
-          <Input
-            id={`relation-type-${relation.id}`}
-            name="relation_type"
-            defaultValue={relation.relationType}
-            list={typeListId}
-            className="h-9 bg-card"
-          />
-        </div>
-        <div className="space-y-1.5">
-          <Label htmlFor={`relation-slot-${relation.id}`} className="text-xs">
-            Slot
-          </Label>
-          <Input
-            id={`relation-slot-${relation.id}`}
-            name="slot"
-            defaultValue={relation.slot}
-            list={slotListId}
-            className="h-9 bg-card"
-          />
-        </div>
-        <div className="space-y-1.5">
-          <Label htmlFor={`relation-order-${relation.id}`} className="text-xs">
-            Order
-          </Label>
-          <Input
-            id={`relation-order-${relation.id}`}
-            name="sort_order"
-            type="number"
-            defaultValue={relation.sortOrder}
-            className="h-9 bg-card"
-          />
-        </div>
-        <div className="flex gap-2 sm:col-span-3">
-          <CmsSubmitButton
-            className="h-9 flex-1 rounded-full"
-            pendingLabel="반영 중..."
-          >
-            연결 정보 저장
-          </CmsSubmitButton>
-          <Button asChild variant="outline" className="h-9 rounded-full">
-            <Link href={`/ponix/entities/${relation.entityId}`}>데이터 보기</Link>
-          </Button>
-        </div>
-        <RelationDatalists
-          typeOptions={typeOptions}
-          slotOptions={slotOptions}
-          typeListId={typeListId}
-          slotListId={slotListId}
-        />
-      </form>
-
-      <form action={deleteSectionEntityRelationAction}>
-        <input type="hidden" name="redirect_to" value={redirectTo} />
-        <input type="hidden" name="relation_id" value={relation.id} />
-        <Button
-          type="submit"
-          size="sm"
-          variant="ghost"
-          className="h-8 px-2 text-destructive hover:text-destructive"
+        <div
+          className="rounded-xl border bg-muted/30 p-3"
+          data-composer-entity-quick-view={relation.entityId}
         >
-          이 섹션에서 제거
-        </Button>
-      </form>
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="text-xs font-medium text-muted-foreground">
+                데이터
+              </p>
+              <p className="mt-1 line-clamp-1 text-sm font-medium">
+                {relation.entity?.title ?? relation.entityId}
+              </p>
+              {(relation.entity?.subtitle || relation.entity?.summary) && (
+                <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted-foreground">
+                  {relation.entity?.subtitle ?? relation.entity?.summary}
+                </p>
+              )}
+            </div>
+            <Badge
+              variant="secondary"
+              className="rounded-full font-mono text-[10px]"
+            >
+              {relation.entity?.entityType ?? "entity"}
+            </Badge>
+          </div>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <Button
+              asChild
+              variant="outline"
+              size="sm"
+              className="h-8 rounded-full"
+            >
+              <Link href={`/ponix/entities/${relation.entityId}`}>
+                상세 보기
+              </Link>
+            </Button>
+            <Button
+              asChild
+              variant="outline"
+              size="sm"
+              className="h-8 rounded-full"
+            >
+              <Link href={`/ponix/entities/${relation.entityId}/edit`}>
+                데이터 수정
+              </Link>
+            </Button>
+          </div>
+        </div>
+
+        <form
+          action={updateSectionEntityRelationAction}
+          className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(0,0.9fr)_5.5rem]"
+          data-composer-track-dirty
+        >
+          <input type="hidden" name="redirect_to" value={redirectTo} />
+          <input type="hidden" name="relation_id" value={relation.id} />
+          <div className="space-y-1.5">
+            <Label htmlFor={`relation-type-${relation.id}`} className="text-xs">
+              Type
+            </Label>
+            <Input
+              id={`relation-type-${relation.id}`}
+              name="relation_type"
+              defaultValue={relation.relationType}
+              list={typeListId}
+              className="h-9 bg-card"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor={`relation-slot-${relation.id}`} className="text-xs">
+              Slot
+            </Label>
+            <Input
+              id={`relation-slot-${relation.id}`}
+              name="slot"
+              defaultValue={relation.slot}
+              list={slotListId}
+              className="h-9 bg-card"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label
+              htmlFor={`relation-order-${relation.id}`}
+              className="text-xs"
+            >
+              Order
+            </Label>
+            <Input
+              id={`relation-order-${relation.id}`}
+              name="sort_order"
+              type="number"
+              defaultValue={relation.sortOrder}
+              className="h-9 bg-card"
+            />
+          </div>
+          <div className="flex gap-2 sm:col-span-3">
+            <CmsSubmitButton
+              className="h-9 flex-1 rounded-full"
+              pendingLabel="반영 중..."
+            >
+              연결 정보 저장
+            </CmsSubmitButton>
+            <Button asChild variant="outline" className="h-9 rounded-full">
+              <Link href={`/ponix/entities/${relation.entityId}/edit`}>
+                데이터 수정
+              </Link>
+            </Button>
+          </div>
+          <RelationDatalists
+            typeOptions={typeOptions}
+            slotOptions={slotOptions}
+            typeListId={typeListId}
+            slotListId={slotListId}
+          />
+        </form>
+
+        <div className="grid gap-2 sm:grid-cols-2" data-composer-order-controls>
+          <RelationMoveForm
+            relationId={relation.id}
+            redirectTo={redirectTo}
+            sortOrder={moveUpSortOrder}
+            label="위로"
+            icon="up"
+          />
+          <RelationMoveForm
+            relationId={relation.id}
+            redirectTo={redirectTo}
+            sortOrder={moveDownSortOrder}
+            label="아래로"
+            icon="down"
+          />
+        </div>
+
+        <form action={deleteSectionEntityRelationAction}>
+          <input type="hidden" name="redirect_to" value={redirectTo} />
+          <input type="hidden" name="relation_id" value={relation.id} />
+          <Button
+            type="submit"
+            size="sm"
+            variant="ghost"
+            className="h-8 px-2 text-destructive hover:text-destructive"
+          >
+            이 섹션에서 제거
+          </Button>
+        </form>
       </AccordionContent>
     </AccordionItem>
+  )
+}
+
+function RelationMoveForm({
+  relationId,
+  redirectTo,
+  sortOrder,
+  label,
+  icon,
+}: {
+  relationId: string
+  redirectTo: string
+  sortOrder: number | null
+  label: string
+  icon: "up" | "down"
+}) {
+  const Icon = icon === "up" ? ArrowUp : ArrowDown
+
+  return (
+    <form action={updateSectionEntityRelationAction}>
+      <input type="hidden" name="redirect_to" value={redirectTo} />
+      <input type="hidden" name="relation_id" value={relationId} />
+      <input
+        type="hidden"
+        name="sort_order"
+        value={sortOrder === null ? "" : String(sortOrder)}
+        data-composer-move-sort-order={label}
+      />
+      <Button
+        type="submit"
+        size="sm"
+        variant="outline"
+        disabled={sortOrder === null}
+        className="h-8 w-full rounded-full"
+      >
+        <Icon className="size-3.5" />
+        {label}
+      </Button>
+    </form>
   )
 }
 

--- a/components/admin-section-frame.tsx
+++ b/components/admin-section-frame.tsx
@@ -46,6 +46,15 @@ export function AdminSectionFrame({
       }
     }
 
+    function handleEntityMessage(event: MessageEvent) {
+      if (event.origin !== window.location.origin) return
+      if (!isEntityMessage(event.data, "ponix:set-selected-entity")) return
+
+      requestAnimationFrame(() => {
+        highlightEntityInCanvas(event.data.entityId)
+      })
+    }
+
     function handleLocalEvent(event: Event) {
       if (!(event instanceof CustomEvent)) return
       const detail = event.detail
@@ -54,9 +63,11 @@ export function AdminSectionFrame({
     }
 
     window.addEventListener("message", handleMessage)
+    window.addEventListener("message", handleEntityMessage)
     window.addEventListener("ponix:set-selected-section", handleLocalEvent)
     return () => {
       window.removeEventListener("message", handleMessage)
+      window.removeEventListener("message", handleEntityMessage)
       window.removeEventListener("ponix:set-selected-section", handleLocalEvent)
     }
   }, [control, sectionKey])
@@ -140,6 +151,33 @@ export function AdminSectionFrame({
   )
 }
 
+function highlightEntityInCanvas(entityId: string | null) {
+  const nodes = document.querySelectorAll<HTMLElement>("[data-ponix-entity]")
+  let firstMatch: HTMLElement | null = null
+
+  nodes.forEach((node) => {
+    const selected = Boolean(entityId) && node.dataset.ponixEntity === entityId
+    if (selected && !firstMatch) {
+      firstMatch = node
+    }
+    node.dataset.ponixEntityState = selected ? "selected" : "idle"
+  })
+
+  const target = firstMatch as HTMLElement | null
+  if (!target) return
+
+  const rect = target.getBoundingClientRect()
+  const top =
+    window.scrollY +
+    rect.top -
+    Math.max(24, (window.innerHeight - rect.height) / 2)
+
+  window.scrollTo({
+    top: Math.max(0, top),
+    behavior: "smooth",
+  })
+}
+
 function scrollSectionIntoCanvasView(sectionKey: string) {
   const section = document.querySelector<HTMLElement>(
     `[data-ponix-section="${CSS.escape(sectionKey)}"]`,
@@ -170,5 +208,19 @@ function isSectionMessage(
     "sectionKey" in value &&
     value.type === type &&
     typeof value.sectionKey === "string"
+  )
+}
+
+function isEntityMessage(
+  value: unknown,
+  type: "ponix:set-selected-entity",
+): value is { type: string; entityId: string | null } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "type" in value &&
+    "entityId" in value &&
+    value.type === type &&
+    (typeof value.entityId === "string" || value.entityId === null)
   )
 }

--- a/components/home-section.tsx
+++ b/components/home-section.tsx
@@ -36,6 +36,7 @@ export type HomeStatCard =
 
 export type HomeVideo = {
   id: string
+  entityId?: string
   title: string
   thumbnailUrl?: string
   watchUrl?: string
@@ -300,6 +301,8 @@ export function HomeSection({
             href={homeFeaturedVideo.watchUrl ?? watchUrl(homeFeaturedVideo.id)}
             target="_blank"
             rel="noopener noreferrer"
+            data-ponix-entity={homeFeaturedVideo.entityId}
+            data-ponix-entity-kind="video"
             className="col-span-12 md:col-span-7 group flex flex-col gap-4 animate-in fade-in-0 slide-in-from-bottom-3 duration-700 delay-100"
           >
             <div className="relative aspect-video overflow-hidden border bg-muted rounded-md">
@@ -384,6 +387,8 @@ export function HomeSection({
                 href={v.watchUrl ?? watchUrl(v.id)}
                 target="_blank"
                 rel="noopener noreferrer"
+                data-ponix-entity={v.entityId}
+                data-ponix-entity-kind="video"
                 className="group flex flex-col gap-3"
               >
                 <div className="relative aspect-video overflow-hidden border bg-muted rounded-md">

--- a/lib/data/content-graph.ts
+++ b/lib/data/content-graph.ts
@@ -135,6 +135,7 @@ export type HistoryMilestoneItem = {
 }
 
 export type HomeCurationVideo = Video & {
+  entityId?: string
   caption?: string
 }
 
@@ -1064,6 +1065,7 @@ function homeVideoFromSectionItem(
   const props = jsonObject(item.props)
   return {
     ...video,
+    entityId: item.entity.id,
     caption: stringValue(props, "caption") ?? undefined,
   }
 }

--- a/lib/data/home-overview.ts
+++ b/lib/data/home-overview.ts
@@ -20,6 +20,7 @@ import { formatViews, type Video } from "@/lib/data/videos"
 import { createPublicClient } from "@/lib/supabase/public"
 
 type HomeVideoSource = Video & {
+  entityId?: string
   caption?: string
 }
 
@@ -101,6 +102,7 @@ function videoTitle(video: HomeVideoSource) {
 function mapHomeVideo(video: HomeVideoSource, caption?: string) {
   return {
     id: video.id,
+    entityId: video.entityId,
     title: videoTitle(video),
     thumbnailUrl: video.thumbnailUrl,
     watchUrl: video.watchUrl,


### PR DESCRIPTION
Closes #65

## Summary
- Link composer relation rows to matching canvas entities with selected-row and selected-canvas highlighting.
- Add quick entity summary plus detail/edit links inside relation accordions.
- Add unsaved-change guard for section switches and lightweight relation order controls.
- Propagate home video entity ids so public renderers can expose canvas highlight targets.

## QA
- pnpm exec tsc --noEmit
- pnpm run lint
- git diff --check
- pnpm run build
- CMUX browser QA: active relation row highlights matching iframe canvas entity after streaming load.
- CMUX browser QA: quick entity view/edit links and up/down move controls are visible.
- CMUX browser QA: dirty guard blocks section switch on cancel, switches on confirm, and clears stale canvas highlight.

## Notes
- Reorder buttons reuse the existing relation update action and were not submitted against production data during QA.