### PR TITLE
Upgrade composer relation editing UX

### DIFF
--- a/app/ponix/entities/actions.ts
+++ b/app/ponix/entities/actions.ts
@@ -22,6 +22,15 @@ type EntityUpdate = Database["public"]["Tables"]["entities"]["Update"]
 type EntityInsert = Database["public"]["Tables"]["entities"]["Insert"]
 type EntityRow = Database["public"]["Tables"]["entities"]["Row"]
 
+type ActionResult =
+  | {
+      ok: true
+    }
+  | {
+      ok: false
+      error: string
+    }
+
 type ParsedValue =
   | {
       ok: true
@@ -304,6 +313,81 @@ async function uploadThumbnailIfPresent({
   return supabase.storage.from(entityThumbnailBucket).getPublicUrl(path).data.publicUrl
 }
 
+async function buildEntityUpdate({
+  formData,
+  entity,
+  editPath,
+  redirectOnError,
+}: {
+  formData: FormData
+  entity: EntityRow
+  editPath: string
+  redirectOnError: boolean
+}) {
+  const schema = getEntityEditorSchema(entity.schema_key)
+  if (!schema) {
+    const error = "This entity schema is not registered for editing."
+    if (redirectOnError) {
+      redirectWithParams(editPath, { error })
+    }
+    throw new Error(error)
+  }
+
+  const fields = getEditableEntityFields(entity.schema_key)
+  const data = jsonObject(entity.data)
+  const update: EntityUpdate = {}
+
+  for (const field of fields) {
+    const parsed = parseFieldValue(formData, field)
+
+    if (!parsed.ok) {
+      if (redirectOnError) {
+        redirectWithParams(editPath, {
+          error: parsed.error,
+        })
+      }
+      throw new Error(parsed.error)
+    }
+
+    if (field.source === "data") {
+      updateDataValue(data, field, parsed)
+      continue
+    }
+
+    if (field.key === "published") {
+      update.published = Boolean(parsed.value)
+    }
+
+    if (field.key === "slug") {
+      update.slug = parsed.value === null ? null : String(parsed.value)
+    }
+
+    if (field.key === "title") {
+      update.title = String(parsed.value)
+    }
+
+    if (field.key === "subtitle") {
+      update.subtitle = parsed.value === null ? null : String(parsed.value)
+    }
+
+    if (field.key === "summary") {
+      update.summary = parsed.value === null ? null : String(parsed.value)
+    }
+
+    if (field.key === "thumbnail_url") {
+      update.thumbnail_url =
+        parsed.value === null ? null : String(parsed.value)
+    }
+
+    if (field.key === "sort_at") {
+      update.sort_at = new Date(String(parsed.value)).toISOString()
+    }
+  }
+
+  update.data = data
+  return update
+}
+
 export async function createCmsEntityAction(formData: FormData) {
   const schemaKey = stringField(formData, "schema_key")
   const createPath = schemaKey
@@ -438,59 +522,12 @@ export async function updateCmsEntityAction(formData: FormData) {
     })
   }
 
-  const schema = getEntityEditorSchema(entity.schema_key)
-  if (!schema) {
-    redirectWithParams(editPath, {
-      error: "This entity schema is not registered for editing.",
-    })
-  }
-
-  const fields = getEditableEntityFields(entity.schema_key)
-  const data = jsonObject(entity.data)
-  const update: EntityUpdate = {}
-
-  for (const field of fields) {
-    const parsed = parseFieldValue(formData, field)
-
-    if (!parsed.ok) {
-      redirectWithParams(editPath, {
-        error: parsed.error,
-      })
-    }
-
-    if (field.source === "data") {
-      updateDataValue(data, field, parsed)
-      continue
-    }
-
-    if (field.key === "published") {
-      update.published = Boolean(parsed.value)
-    }
-
-    if (field.key === "slug") {
-      update.slug = parsed.value === null ? null : String(parsed.value)
-    }
-
-    if (field.key === "title") {
-      update.title = String(parsed.value)
-    }
-
-    if (field.key === "subtitle") {
-      update.subtitle = parsed.value === null ? null : String(parsed.value)
-    }
-
-    if (field.key === "summary") {
-      update.summary = parsed.value === null ? null : String(parsed.value)
-    }
-
-    if (field.key === "thumbnail_url") {
-      update.thumbnail_url = parsed.value === null ? null : String(parsed.value)
-    }
-
-    if (field.key === "sort_at") {
-      update.sort_at = new Date(String(parsed.value)).toISOString()
-    }
-  }
+  const update = await buildEntityUpdate({
+    formData,
+    entity,
+    editPath,
+    redirectOnError: true,
+  })
 
   const uploadedThumbnailUrl = await uploadThumbnailIfPresent({
     supabase,
@@ -502,8 +539,6 @@ export async function updateCmsEntityAction(formData: FormData) {
   if (uploadedThumbnailUrl) {
     update.thumbnail_url = uploadedThumbnailUrl
   }
-
-  update.data = data
 
   const { error: updateError } = await supabase
     .from("entities")
@@ -521,4 +556,55 @@ export async function updateCmsEntityAction(formData: FormData) {
   redirectWithParams(redirectTo, {
     saved: "entity",
   })
+}
+
+export async function updateCmsEntityInlineAction(
+  formData: FormData,
+): Promise<ActionResult> {
+  const entityId = stringField(formData, "entity_id")
+
+  try {
+    if (!entityId) {
+      throw new Error("Missing entity id.")
+    }
+
+    const editPath = `/ponix/entities/${entityId}/edit`
+    await requireCmsAdmin(editPath)
+
+    const supabase = await createClient()
+    const { data: entity, error: loadError } = await supabase
+      .from("entities")
+      .select("*")
+      .eq("id", entityId)
+      .maybeSingle()
+
+    if (loadError || !entity) {
+      throw new Error("Entity not found.")
+    }
+
+    const update = await buildEntityUpdate({
+      formData,
+      entity,
+      editPath,
+      redirectOnError: false,
+    })
+
+    const { error: updateError } = await supabase
+      .from("entities")
+      .update(update)
+      .eq("id", entityId)
+
+    if (updateError) {
+      throw new Error("Entity save failed.")
+    }
+
+    revalidateEntitySurfaces(entityId)
+
+    return { ok: true }
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : "Entity save failed.",
+    }
+  }
 }

--- a/app/ponix/pages/[id]/compose/composer-relation-list.tsx
+++ b/app/ponix/pages/[id]/compose/composer-relation-list.tsx
@@ -21,6 +21,12 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion"
+import {
   Drawer,
   DrawerClose,
   DrawerContent,
@@ -468,6 +474,8 @@ function SectionEntityRelationEditor({
 function EntityEditDrawer({ relation }: { relation: Relation }) {
   const entity = relation.entity
   const editableFields = entity ? getEditableEntityFields(entity.schemaKey) : []
+  const columnFields = editableFields.filter((field) => field.source !== "data")
+  const dataFields = editableFields.filter((field) => field.source === "data")
   const [saveState, setSaveState] = useState<SaveState>({ status: "idle" })
   const [isPending, startTransition] = useTransition()
 
@@ -538,14 +546,28 @@ function EntityEditDrawer({ relation }: { relation: Relation }) {
               data-composer-inline-entity-form={relation.entityId}
             >
               <input type="hidden" name="entity_id" value={relation.entityId} />
-              <div className="grid flex-1 gap-4 overflow-auto px-5 py-5 md:grid-cols-2">
-                {editableFields.map((field) => (
-                  <InlineEntityField
-                    key={`${field.source}:${field.key}`}
-                    field={field}
+              <div className="flex-1 overflow-auto px-5 py-5">
+                <Accordion
+                  type="multiple"
+                  defaultValue={["identity", "data"]}
+                  className="space-y-3"
+                  data-composer-entity-field-groups
+                >
+                  <EntityFieldGroup
+                    value="identity"
+                    title="기본 정보"
+                    description="목록과 카드에 바로 노출되는 대표 정보입니다."
+                    fields={columnFields}
                     entity={entity}
                   />
-                ))}
+                  <EntityFieldGroup
+                    value="data"
+                    title="콘텐츠 데이터"
+                    description="렌더러가 사용하는 세부 데이터입니다."
+                    fields={dataFields}
+                    entity={entity}
+                  />
+                </Accordion>
               </div>
               <div
                 className={cn(
@@ -582,6 +604,55 @@ function EntityEditDrawer({ relation }: { relation: Relation }) {
         </div>
       </DrawerContent>
     </DrawerNested>
+  )
+}
+
+function EntityFieldGroup({
+  value,
+  title,
+  description,
+  fields,
+  entity,
+}: {
+  value: string
+  title: string
+  description: string
+  fields: CmsEditableEntityField[]
+  entity: NonNullable<Relation["entity"]>
+}) {
+  if (!fields.length) return null
+
+  return (
+    <AccordionItem
+      value={value}
+      className="overflow-hidden rounded-xl border bg-background/70 px-4"
+      data-composer-entity-field-group={value}
+    >
+      <AccordionTrigger className="hover:no-underline">
+        <span className="flex min-w-0 flex-col gap-1">
+          <span className="flex items-center gap-2">
+            <span>{title}</span>
+            <Badge variant="secondary" className="rounded-full">
+              {fields.length}
+            </Badge>
+          </span>
+          <span className="text-xs font-normal text-muted-foreground">
+            {description}
+          </span>
+        </span>
+      </AccordionTrigger>
+      <AccordionContent>
+        <div className="grid gap-4 md:grid-cols-2">
+          {fields.map((field) => (
+            <InlineEntityField
+              key={`${field.source}:${field.key}`}
+              field={field}
+              entity={entity}
+            />
+          ))}
+        </div>
+      </AccordionContent>
+    </AccordionItem>
   )
 }
 

--- a/app/ponix/pages/[id]/compose/composer-relation-list.tsx
+++ b/app/ponix/pages/[id]/compose/composer-relation-list.tsx
@@ -11,12 +11,11 @@ import {
   PencilLine,
 } from "lucide-react"
 
-import { CmsSubmitButton } from "@/app/ponix/_components/cms-save-controls"
 import { updateCmsEntityInlineAction } from "@/app/ponix/entities/actions"
 import {
   deleteSectionEntityRelationAction,
   reorderSectionEntityRelationsAction,
-  updateSectionEntityRelationAction,
+  updateSectionEntityRelationInlineAction,
 } from "@/app/ponix/relations/actions"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -126,7 +125,8 @@ export function ComposerRelationList({
         data-composer-order-status={saveState.status}
       >
         <span>{orderStatusText(saveState, isPending)}</span>
-        {saveState.status === "saving" || isPending ? (
+        {saveState.status === "saving" ||
+        (isPending && saveState.status === "idle") ? (
           <Loader2 className="size-3.5 animate-spin" />
         ) : saveState.status === "saved" ? (
           <Check className="size-3.5 text-emerald-600" />
@@ -198,6 +198,23 @@ function SectionEntityRelationEditor({
 }) {
   const typeListId = `relation-types-${relation.id}`
   const slotListId = `relation-slots-${relation.id}`
+  const [saveState, setSaveState] = useState<SaveState>({ status: "idle" })
+  const [isPending, startTransition] = useTransition()
+
+  function saveRelation(formData: FormData) {
+    setSaveState({ status: "saving" })
+    startTransition(() => {
+      void updateSectionEntityRelationInlineAction(formData).then((result) => {
+        if (!result.ok) {
+          setSaveState({ status: "error", message: result.error })
+          return
+        }
+
+        setSaveState({ status: "saved" })
+        window.dispatchEvent(new CustomEvent("ponix:reload-canvas"))
+      })
+    })
+  }
 
   return (
     <div
@@ -344,9 +361,14 @@ function SectionEntityRelationEditor({
 
             <div className="flex-1 overflow-auto px-5 py-5">
               <form
-                action={updateSectionEntityRelationAction}
-                className="grid gap-4"
+                action={saveRelation}
+                className="grid gap-5"
                 data-composer-track-dirty
+                onChange={() => {
+                  if (saveState.status !== "idle") {
+                    setSaveState({ status: "idle" })
+                  }
+                }}
               >
                 <input type="hidden" name="redirect_to" value={redirectTo} />
                 <input type="hidden" name="relation_id" value={relation.id} />
@@ -403,12 +425,17 @@ function SectionEntityRelationEditor({
                   typeListId={typeListId}
                   slotListId={slotListId}
                 />
-                <CmsSubmitButton
-                  className="w-full rounded-full"
-                  pendingLabel="반영 중..."
-                >
-                  연결 정보 저장
-                </CmsSubmitButton>
+                <SaveFeedbackBar
+                  state={saveState}
+                  pending={isPending}
+                  idleText="섹션 안에서의 노출 방식과 순서를 조정합니다."
+                  savingText="연결 정보를 저장하는 중입니다."
+                  savedText="연결 정보가 저장되었습니다. 미리보기를 갱신했습니다."
+                  buttonLabel="연결 정보 저장"
+                  pendingButtonLabel="반영 중..."
+                  statusAttr="data-composer-relation-save-status"
+                  messageAttr="data-composer-relation-save-message"
+                />
               </form>
             </div>
           </div>
@@ -522,31 +549,21 @@ function EntityEditDrawer({ relation }: { relation: Relation }) {
               </div>
               <div
                 className={cn(
-                  "flex flex-col gap-3 border-t bg-background px-5 py-4 sm:flex-row sm:items-center sm:justify-between",
+                  "border-t bg-background px-5 py-4",
                   saveState.status === "error" && "bg-destructive/5",
                 )}
-                data-composer-inline-entity-status={saveState.status}
               >
-                <p
-                  className={cn(
-                    "text-xs text-muted-foreground",
-                    saveState.status === "error" && "text-destructive",
-                  )}
-                >
-                  {inlineStatusText(saveState, isPending)}
-                </p>
-                <Button
-                  type="submit"
-                  disabled={isPending || saveState.status === "saving"}
-                  className="rounded-full"
-                >
-                  {saveState.status === "saving" || isPending ? (
-                    <Loader2 className="size-4 animate-spin" />
-                  ) : (
-                    <Check className="size-4" />
-                  )}
-                  데이터 저장
-                </Button>
+                <SaveFeedbackBar
+                  state={saveState}
+                  pending={isPending}
+                  idleText="저장해도 composer 화면을 떠나지 않습니다."
+                  savingText="데이터를 저장하는 중입니다."
+                  savedText="데이터가 저장되었습니다. 미리보기를 갱신했습니다."
+                  buttonLabel="데이터 저장"
+                  pendingButtonLabel="저장 중..."
+                  statusAttr="data-composer-inline-entity-status"
+                  messageAttr="data-composer-inline-entity-message"
+                />
               </div>
             </form>
           ) : (
@@ -565,6 +582,73 @@ function EntityEditDrawer({ relation }: { relation: Relation }) {
         </div>
       </DrawerContent>
     </DrawerNested>
+  )
+}
+
+function SaveFeedbackBar({
+  state,
+  pending,
+  idleText,
+  savingText,
+  savedText,
+  buttonLabel,
+  pendingButtonLabel,
+  statusAttr,
+  messageAttr,
+}: {
+  state: SaveState
+  pending: boolean
+  idleText: string
+  savingText: string
+  savedText: string
+  buttonLabel: string
+  pendingButtonLabel: string
+  statusAttr: string
+  messageAttr: string
+}) {
+  const saving = state.status === "saving" || (pending && state.status === "idle")
+  const message =
+    state.status === "error"
+      ? state.message
+      : saving
+        ? savingText
+        : state.status === "saved"
+          ? savedText
+          : idleText
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-3 rounded-xl border bg-card/70 p-3 sm:flex-row sm:items-center sm:justify-between",
+        state.status === "saved" && "border-emerald-300 bg-emerald-50",
+        state.status === "error" && "border-destructive/40 bg-destructive/10",
+      )}
+      {...{ [statusAttr]: state.status }}
+    >
+      <p
+        className={cn(
+          "text-xs leading-relaxed text-muted-foreground",
+          state.status === "saved" && "text-emerald-800",
+          state.status === "error" && "text-destructive",
+        )}
+        aria-live="polite"
+        {...{ [messageAttr]: "" }}
+      >
+        {message}
+      </p>
+      <Button
+        type="submit"
+        disabled={saving}
+        className="rounded-full sm:min-w-36"
+      >
+        {saving ? (
+          <Loader2 className="size-4 animate-spin" />
+        ) : state.status === "saved" ? (
+          <Check className="size-4" />
+        ) : null}
+        {saving ? pendingButtonLabel : buttonLabel}
+      </Button>
+    </div>
   )
 }
 
@@ -778,10 +862,6 @@ function inlineFieldDefaultText(
 }
 
 function orderStatusText(saveState: SaveState, isPending: boolean) {
-  if (saveState.status === "saving" || isPending) {
-    return "순서를 저장하는 중입니다."
-  }
-
   if (saveState.status === "saved") {
     return "순서가 저장되었습니다."
   }
@@ -790,21 +870,9 @@ function orderStatusText(saveState: SaveState, isPending: boolean) {
     return saveState.message
   }
 
-  return "핸들을 끌어서 노출 순서를 바꿉니다."
-}
-
-function inlineStatusText(saveState: SaveState, isPending: boolean) {
   if (saveState.status === "saving" || isPending) {
-    return "데이터를 저장하는 중입니다."
+    return "순서를 저장하는 중입니다."
   }
 
-  if (saveState.status === "saved") {
-    return "데이터가 저장되었습니다. 화면 반영을 위해 미리보기를 갱신했습니다."
-  }
-
-  if (saveState.status === "error") {
-    return saveState.message
-  }
-
-  return "저장해도 composer 화면을 떠나지 않습니다."
+  return "핸들을 끌어서 노출 순서를 바꿉니다."
 }

--- a/app/ponix/pages/[id]/compose/composer-relation-list.tsx
+++ b/app/ponix/pages/[id]/compose/composer-relation-list.tsx
@@ -1,0 +1,810 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import Link from "next/link"
+import {
+  AlertCircle,
+  Check,
+  ExternalLink,
+  GripVertical,
+  Loader2,
+  PencilLine,
+} from "lucide-react"
+
+import { CmsSubmitButton } from "@/app/ponix/_components/cms-save-controls"
+import { updateCmsEntityInlineAction } from "@/app/ponix/entities/actions"
+import {
+  deleteSectionEntityRelationAction,
+  reorderSectionEntityRelationsAction,
+  updateSectionEntityRelationAction,
+} from "@/app/ponix/relations/actions"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerNested,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@/components/ui/drawer"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import type { CmsSectionRelationContext } from "@/lib/cms/content"
+import {
+  cmsEntityFieldInputName,
+  getEditableEntityFields,
+  type CmsEditableEntityField,
+} from "@/lib/cms/entity-editor"
+import { cn } from "@/lib/utils"
+
+type Relation = CmsSectionRelationContext["sectionEntities"][number]
+
+type SaveState =
+  | {
+      status: "idle"
+    }
+  | {
+      status: "saving"
+    }
+  | {
+      status: "saved"
+    }
+  | {
+      status: "error"
+      message: string
+    }
+
+export function ComposerRelationList({
+  sectionId,
+  relations,
+  redirectTo,
+  typeOptions,
+  slotOptions,
+}: {
+  sectionId: string
+  relations: Relation[]
+  redirectTo: string
+  typeOptions: string[]
+  slotOptions: string[]
+}) {
+  const [orderedRelations, setOrderedRelations] = useState(relations)
+  const [draggingId, setDraggingId] = useState<string | null>(null)
+  const [dropTargetId, setDropTargetId] = useState<string | null>(null)
+  const [saveState, setSaveState] = useState<SaveState>({ status: "idle" })
+  const [isPending, startTransition] = useTransition()
+
+  function moveRelation(sourceId: string, targetId: string) {
+    if (sourceId === targetId) return
+
+    const previous = orderedRelations
+    const next = reorderById(previous, sourceId, targetId)
+    if (next === previous) return
+
+    setOrderedRelations(next)
+    setSaveState({ status: "saving" })
+
+    startTransition(() => {
+      void reorderSectionEntityRelationsAction({
+        sectionId,
+        relationIds: next.map((relation) => relation.id),
+      }).then((result) => {
+        if (!result.ok) {
+          setOrderedRelations(previous)
+          setSaveState({ status: "error", message: result.error })
+          return
+        }
+
+        setSaveState({ status: "saved" })
+        window.dispatchEvent(new CustomEvent("ponix:reload-canvas"))
+      })
+    })
+  }
+
+  if (!orderedRelations.length) {
+    return (
+      <p className="rounded-md border bg-muted/30 p-4 text-sm text-muted-foreground">
+        아직 연결된 데이터가 없습니다.
+      </p>
+    )
+  }
+
+  return (
+    <div className="space-y-3" data-composer-relation-list>
+      <div
+        className={cn(
+          "flex items-center justify-between rounded-xl border px-3 py-2 text-xs",
+          saveState.status === "error"
+            ? "border-destructive/40 bg-destructive/10 text-destructive"
+            : "bg-muted/30 text-muted-foreground",
+        )}
+        data-composer-order-status={saveState.status}
+      >
+        <span>{orderStatusText(saveState, isPending)}</span>
+        {saveState.status === "saving" || isPending ? (
+          <Loader2 className="size-3.5 animate-spin" />
+        ) : saveState.status === "saved" ? (
+          <Check className="size-3.5 text-emerald-600" />
+        ) : saveState.status === "error" ? (
+          <AlertCircle className="size-3.5" />
+        ) : (
+          <GripVertical className="size-3.5" />
+        )}
+      </div>
+
+      <div className="space-y-2">
+        {orderedRelations.map((relation) => (
+          <SectionEntityRelationEditor
+            key={relation.id}
+            relation={relation}
+            redirectTo={redirectTo}
+            typeOptions={typeOptions}
+            slotOptions={slotOptions}
+            dragging={draggingId === relation.id}
+            dropTarget={dropTargetId === relation.id}
+            onDragStart={() => setDraggingId(relation.id)}
+            onDragEnd={() => {
+              setDraggingId(null)
+              setDropTargetId(null)
+            }}
+            onDragOver={(event) => {
+              event.preventDefault()
+              if (draggingId && draggingId !== relation.id) {
+                setDropTargetId(relation.id)
+              }
+            }}
+            onDrop={(event) => {
+              event.preventDefault()
+              if (draggingId) {
+                moveRelation(draggingId, relation.id)
+              }
+              setDraggingId(null)
+              setDropTargetId(null)
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function SectionEntityRelationEditor({
+  relation,
+  redirectTo,
+  typeOptions,
+  slotOptions,
+  dragging,
+  dropTarget,
+  onDragStart,
+  onDragEnd,
+  onDragOver,
+  onDrop,
+}: {
+  relation: Relation
+  redirectTo: string
+  typeOptions: string[]
+  slotOptions: string[]
+  dragging: boolean
+  dropTarget: boolean
+  onDragStart: () => void
+  onDragEnd: () => void
+  onDragOver: React.DragEventHandler<HTMLDivElement>
+  onDrop: React.DragEventHandler<HTMLDivElement>
+}) {
+  const typeListId = `relation-types-${relation.id}`
+  const slotListId = `relation-slots-${relation.id}`
+
+  return (
+    <div
+      data-composer-relation-item={relation.id}
+      data-composer-entity-id={relation.entityId}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+    >
+      <Drawer direction="right">
+        <div
+          className={cn(
+            "group flex items-stretch gap-2 rounded-xl border bg-background/70 p-2 shadow-xs transition",
+            "hover:border-accent/60 hover:bg-muted/30",
+            dragging && "scale-[0.99] opacity-60",
+            dropTarget && "border-accent bg-accent/10",
+          )}
+        >
+          <button
+            type="button"
+            draggable
+            aria-label="순서 끌어서 변경"
+            className="grid size-9 shrink-0 cursor-grab place-items-center self-center rounded-full border bg-muted/40 text-muted-foreground transition hover:border-accent hover:text-foreground active:cursor-grabbing"
+            data-composer-drag-handle={relation.id}
+            onDragStart={(event) => {
+              event.dataTransfer.effectAllowed = "move"
+              event.dataTransfer.setData("text/plain", relation.id)
+              onDragStart()
+            }}
+            onDragEnd={onDragEnd}
+          >
+            <GripVertical className="size-4" />
+          </button>
+          <DrawerTrigger asChild>
+            <button
+              type="button"
+              className="min-w-0 flex-1 rounded-lg px-2 py-2 text-left outline-none transition focus-visible:ring-2 focus-visible:ring-ring"
+              data-composer-relation-trigger={relation.id}
+            >
+              <div className="grid min-w-0 gap-2">
+                <div className="flex min-w-0 items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="line-clamp-1 text-sm font-medium">
+                      {relation.entity?.title ?? relation.entityId}
+                    </p>
+                    <p className="font-mono text-xs text-muted-foreground">
+                      {relation.entity?.schemaKey ?? "schema"}
+                    </p>
+                  </div>
+                  <Badge variant="outline" className="rounded-full">
+                    {relation.entity?.published ? "published" : "draft"}
+                  </Badge>
+                </div>
+                <div className="flex flex-wrap gap-1.5">
+                  <Badge
+                    variant="secondary"
+                    className="rounded-full font-mono text-[10px]"
+                  >
+                    {relation.slot}
+                  </Badge>
+                  <Badge
+                    variant="outline"
+                    className="rounded-full font-mono text-[10px]"
+                  >
+                    {relation.relationType}
+                  </Badge>
+                  <Badge
+                    variant="outline"
+                    className="rounded-full font-mono text-[10px]"
+                  >
+                    #{relation.sortOrder}
+                  </Badge>
+                </div>
+              </div>
+            </button>
+          </DrawerTrigger>
+        </div>
+
+        <DrawerContent
+          className="w-[min(94vw,42rem)] gap-0 p-0 sm:max-w-none"
+          data-composer-relation-drawer={relation.id}
+        >
+          <DrawerHeader className="border-b px-5 py-5">
+            <div className="flex items-start justify-between gap-5 pr-8">
+              <div className="min-w-0">
+                <p className="caps mb-2 text-muted-foreground">
+                  Section relation
+                </p>
+                <DrawerTitle className="line-clamp-2 font-serif text-3xl italic">
+                  {relation.entity?.title ?? relation.entityId}
+                </DrawerTitle>
+                <DrawerDescription className="mt-2 line-clamp-2">
+                  이 섹션에서 이 데이터가 어떻게 노출되는지 정리합니다.
+                </DrawerDescription>
+              </div>
+              <Badge variant="secondary" className="mt-1 shrink-0 rounded-full">
+                {relation.entity?.schemaLabel ??
+                  relation.entity?.schemaKey ??
+                  "schema"}
+              </Badge>
+            </div>
+          </DrawerHeader>
+
+          <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+            <div
+              className="border-b bg-muted/20 px-5 py-4"
+              data-composer-entity-quick-view={relation.entityId}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="text-xs font-medium text-muted-foreground">
+                    데이터
+                  </p>
+                  <p className="mt-1 line-clamp-1 text-sm font-medium">
+                    {relation.entity?.title ?? relation.entityId}
+                  </p>
+                  {(relation.entity?.subtitle || relation.entity?.summary) && (
+                    <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted-foreground">
+                      {relation.entity?.subtitle ?? relation.entity?.summary}
+                    </p>
+                  )}
+                </div>
+                <Badge
+                  variant="secondary"
+                  className="rounded-full font-mono text-[10px]"
+                >
+                  {relation.entity?.entityType ?? "entity"}
+                </Badge>
+              </div>
+              <div className="mt-3 flex flex-wrap gap-2">
+                <EntityEditDrawer relation={relation} />
+                <Button
+                  asChild
+                  variant="outline"
+                  size="sm"
+                  className="h-8 rounded-full"
+                >
+                  <Link href={`/ponix/entities/${relation.entityId}`}>
+                    상세 화면
+                    <ExternalLink className="size-3.5" />
+                  </Link>
+                </Button>
+              </div>
+            </div>
+
+            <div className="flex-1 overflow-auto px-5 py-5">
+              <form
+                action={updateSectionEntityRelationAction}
+                className="grid gap-4"
+                data-composer-track-dirty
+              >
+                <input type="hidden" name="redirect_to" value={redirectTo} />
+                <input type="hidden" name="relation_id" value={relation.id} />
+                <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_7rem]">
+                  <div className="space-y-1.5">
+                    <Label
+                      htmlFor={`relation-type-${relation.id}`}
+                      className="text-xs"
+                    >
+                      Type
+                    </Label>
+                    <Input
+                      id={`relation-type-${relation.id}`}
+                      name="relation_type"
+                      defaultValue={relation.relationType}
+                      list={typeListId}
+                      className="h-10 bg-card"
+                    />
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label
+                      htmlFor={`relation-slot-${relation.id}`}
+                      className="text-xs"
+                    >
+                      Slot
+                    </Label>
+                    <Input
+                      id={`relation-slot-${relation.id}`}
+                      name="slot"
+                      defaultValue={relation.slot}
+                      list={slotListId}
+                      className="h-10 bg-card"
+                    />
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label
+                      htmlFor={`relation-order-${relation.id}`}
+                      className="text-xs"
+                    >
+                      Order
+                    </Label>
+                    <Input
+                      id={`relation-order-${relation.id}`}
+                      name="sort_order"
+                      type="number"
+                      defaultValue={relation.sortOrder}
+                      className="h-10 bg-card"
+                    />
+                  </div>
+                </div>
+                <RelationDatalists
+                  typeOptions={typeOptions}
+                  slotOptions={slotOptions}
+                  typeListId={typeListId}
+                  slotListId={slotListId}
+                />
+                <CmsSubmitButton
+                  className="w-full rounded-full"
+                  pendingLabel="반영 중..."
+                >
+                  연결 정보 저장
+                </CmsSubmitButton>
+              </form>
+            </div>
+          </div>
+
+          <DrawerFooter className="border-t bg-background px-5 py-4">
+            <form action={deleteSectionEntityRelationAction}>
+              <input type="hidden" name="redirect_to" value={redirectTo} />
+              <input type="hidden" name="relation_id" value={relation.id} />
+              <Button
+                type="submit"
+                size="sm"
+                variant="ghost"
+                className="h-9 w-full text-destructive hover:text-destructive"
+              >
+                이 섹션에서 제거
+              </Button>
+            </form>
+            <DrawerClose asChild>
+              <Button variant="outline" className="rounded-full">
+                닫기
+              </Button>
+            </DrawerClose>
+          </DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+    </div>
+  )
+}
+
+function EntityEditDrawer({ relation }: { relation: Relation }) {
+  const entity = relation.entity
+  const editableFields = entity ? getEditableEntityFields(entity.schemaKey) : []
+  const [saveState, setSaveState] = useState<SaveState>({ status: "idle" })
+  const [isPending, startTransition] = useTransition()
+
+  function saveEntity(formData: FormData) {
+    setSaveState({ status: "saving" })
+    startTransition(() => {
+      void updateCmsEntityInlineAction(formData).then((result) => {
+        if (!result.ok) {
+          setSaveState({ status: "error", message: result.error })
+          return
+        }
+
+        setSaveState({ status: "saved" })
+        window.dispatchEvent(new CustomEvent("ponix:reload-canvas"))
+      })
+    })
+  }
+
+  return (
+    <DrawerNested direction="right">
+      <DrawerTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex h-8 items-center justify-center gap-2 rounded-full border bg-background px-3 text-sm font-medium shadow-xs transition hover:bg-accent hover:text-accent-foreground"
+          data-composer-entity-drawer-trigger={relation.entityId}
+        >
+          <PencilLine className="size-3.5" />
+          데이터 수정
+        </button>
+      </DrawerTrigger>
+      <DrawerContent
+        className="w-[min(94vw,58rem)] gap-0 p-0 sm:max-w-none"
+        data-composer-entity-edit-drawer={relation.entityId}
+      >
+        <DrawerHeader className="border-b px-5 py-5">
+          <div className="flex items-start justify-between gap-8 pr-8">
+            <div className="min-w-0">
+              <p className="caps mb-2 text-muted-foreground">Entity editor</p>
+              <DrawerTitle className="line-clamp-2 font-serif text-3xl italic">
+                {entity?.title ?? relation.entityId}
+              </DrawerTitle>
+              <DrawerDescription className="mt-2 line-clamp-2">
+                {entity?.subtitle ?? entity?.summary ?? "연결된 데이터 항목"}
+              </DrawerDescription>
+            </div>
+            <Badge variant="secondary" className="mt-1 shrink-0 rounded-full">
+              {entity?.schemaLabel ?? entity?.schemaKey ?? "schema"}
+            </Badge>
+          </div>
+        </DrawerHeader>
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          <div className="flex flex-wrap items-center justify-between gap-3 border-b bg-muted/20 px-5 py-3 text-xs text-muted-foreground">
+            <span>
+              현재 composer를 떠나지 않고 연결된 데이터의 주요 필드를 바로
+              수정합니다.
+            </span>
+            <Button asChild variant="outline" size="sm" className="rounded-full">
+              <Link href={`/ponix/entities/${relation.entityId}/edit`}>
+                전체 화면 편집
+                <ExternalLink className="size-3.5" />
+              </Link>
+            </Button>
+          </div>
+          {entity && editableFields.length ? (
+            <form
+              action={saveEntity}
+              className="flex min-h-0 flex-1 flex-col"
+              data-composer-inline-entity-form={relation.entityId}
+            >
+              <input type="hidden" name="entity_id" value={relation.entityId} />
+              <div className="grid flex-1 gap-4 overflow-auto px-5 py-5 md:grid-cols-2">
+                {editableFields.map((field) => (
+                  <InlineEntityField
+                    key={`${field.source}:${field.key}`}
+                    field={field}
+                    entity={entity}
+                  />
+                ))}
+              </div>
+              <div
+                className={cn(
+                  "flex flex-col gap-3 border-t bg-background px-5 py-4 sm:flex-row sm:items-center sm:justify-between",
+                  saveState.status === "error" && "bg-destructive/5",
+                )}
+                data-composer-inline-entity-status={saveState.status}
+              >
+                <p
+                  className={cn(
+                    "text-xs text-muted-foreground",
+                    saveState.status === "error" && "text-destructive",
+                  )}
+                >
+                  {inlineStatusText(saveState, isPending)}
+                </p>
+                <Button
+                  type="submit"
+                  disabled={isPending || saveState.status === "saving"}
+                  className="rounded-full"
+                >
+                  {saveState.status === "saving" || isPending ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <Check className="size-4" />
+                  )}
+                  데이터 저장
+                </Button>
+              </div>
+            </form>
+          ) : (
+            <div className="grid flex-1 place-items-center px-5 py-12 text-center">
+              <div className="max-w-sm">
+                <p className="font-medium">
+                  이 데이터는 인라인 편집을 지원하지 않습니다.
+                </p>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  등록되지 않은 스키마이거나 편집 가능한 필드가 없습니다. 전체
+                  화면 편집으로 확인하세요.
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+      </DrawerContent>
+    </DrawerNested>
+  )
+}
+
+function InlineEntityField({
+  field,
+  entity,
+}: {
+  field: CmsEditableEntityField
+  entity: NonNullable<Relation["entity"]>
+}) {
+  const id = `composer-entity-${entity.id}-${field.source}-${field.key}`
+  const name = cmsEntityFieldInputName(field)
+  const value = inlineEntityFieldValue(entity, field)
+  const wide =
+    field.type === "textarea" ||
+    field.type === "json" ||
+    field.type === "string-list"
+
+  return (
+    <div className={wide ? "space-y-2 md:col-span-2" : "space-y-2"}>
+      <div className="flex items-center gap-2">
+        <Label htmlFor={id}>{field.label}</Label>
+        {field.required && (
+          <Badge variant="outline" className="rounded-full">
+            Required
+          </Badge>
+        )}
+      </div>
+      {renderInlineFieldInput({ field, id, name, value })}
+      <p className="font-mono text-[11px] text-muted-foreground">
+        {field.source}.{field.key}
+      </p>
+      {field.description && (
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          {field.description}
+        </p>
+      )}
+    </div>
+  )
+}
+
+function renderInlineFieldInput({
+  field,
+  id,
+  name,
+  value,
+}: {
+  field: CmsEditableEntityField
+  id: string
+  name: string
+  value: unknown
+}) {
+  if (field.type === "boolean") {
+    return (
+      <div className="flex h-11 items-center gap-3 rounded-md border bg-background/70 px-3">
+        <input type="hidden" name={name} value="false" />
+        <Checkbox
+          id={id}
+          name={name}
+          value="true"
+          defaultChecked={Boolean(value)}
+        />
+        <Label htmlFor={id} className="text-sm font-normal">
+          Enabled
+        </Label>
+      </div>
+    )
+  }
+
+  if (
+    field.type === "textarea" ||
+    field.type === "string-list" ||
+    field.type === "json"
+  ) {
+    return (
+      <Textarea
+        id={id}
+        name={name}
+        defaultValue={inlineFieldDefaultText(field, value)}
+        rows={field.type === "json" ? 8 : 4}
+        className="bg-background/70"
+      />
+    )
+  }
+
+  if (field.type === "select") {
+    return (
+      <select
+        id={id}
+        name={name}
+        defaultValue={inlineFieldDefaultText(field, value)}
+        className="border-input h-11 w-full rounded-md border bg-background/70 px-3 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+      >
+        {!field.required && <option value="">Empty</option>}
+        {(field.options ?? []).map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    )
+  }
+
+  return (
+    <Input
+      id={id}
+      name={name}
+      type={inlineInputType(field)}
+      defaultValue={inlineFieldDefaultText(field, value)}
+      className="h-11 bg-background/70"
+    />
+  )
+}
+
+function RelationDatalists({
+  typeOptions,
+  slotOptions,
+  typeListId = "composer-relation-types",
+  slotListId = "composer-slots",
+}: {
+  typeOptions: string[]
+  slotOptions: string[]
+  typeListId?: string
+  slotListId?: string
+}) {
+  return (
+    <>
+      <datalist id={typeListId}>
+        {typeOptions.map((option) => (
+          <option key={option} value={option} />
+        ))}
+      </datalist>
+      <datalist id={slotListId}>
+        {slotOptions.map((option) => (
+          <option key={option} value={option} />
+        ))}
+      </datalist>
+    </>
+  )
+}
+
+function reorderById(relations: Relation[], sourceId: string, targetId: string) {
+  const sourceIndex = relations.findIndex((relation) => relation.id === sourceId)
+  const targetIndex = relations.findIndex((relation) => relation.id === targetId)
+
+  if (sourceIndex < 0 || targetIndex < 0) {
+    return relations
+  }
+
+  const next = [...relations]
+  const [moved] = next.splice(sourceIndex, 1)
+  next.splice(targetIndex, 0, moved)
+  return next
+}
+
+function inlineEntityFieldValue(
+  entity: NonNullable<Relation["entity"]>,
+  field: CmsEditableEntityField,
+) {
+  if (field.source === "data") {
+    return jsonRecord(entity.data)[field.key]
+  }
+
+  if (field.key === "slug") return entity.slug
+  if (field.key === "title") return entity.title
+  if (field.key === "subtitle") return entity.subtitle
+  if (field.key === "summary") return entity.summary
+  if (field.key === "thumbnail_url") return entity.thumbnailUrl
+  if (field.key === "sort_at") return entity.sortAt
+  if (field.key === "published") return entity.published
+
+  return null
+}
+
+function jsonRecord(value: unknown) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {} as Record<string, unknown>
+  }
+
+  return value as Record<string, unknown>
+}
+
+function inlineInputType(field: CmsEditableEntityField) {
+  if (field.type === "number") return "number"
+  if (field.type === "date") return "date"
+  if (field.type === "datetime") return "datetime-local"
+  return "text"
+}
+
+function inlineFieldDefaultText(
+  field: CmsEditableEntityField,
+  value: unknown,
+) {
+  if (value === null || value === undefined) {
+    return ""
+  }
+
+  if (field.type === "string-list") {
+    return Array.isArray(value) ? value.join("\n") : String(value)
+  }
+
+  if (field.type === "json") {
+    return JSON.stringify(value, null, 2)
+  }
+
+  if (field.type === "datetime" && typeof value === "string") {
+    return value.slice(0, 16)
+  }
+
+  return String(value)
+}
+
+function orderStatusText(saveState: SaveState, isPending: boolean) {
+  if (saveState.status === "saving" || isPending) {
+    return "순서를 저장하는 중입니다."
+  }
+
+  if (saveState.status === "saved") {
+    return "순서가 저장되었습니다."
+  }
+
+  if (saveState.status === "error") {
+    return saveState.message
+  }
+
+  return "핸들을 끌어서 노출 순서를 바꿉니다."
+}
+
+function inlineStatusText(saveState: SaveState, isPending: boolean) {
+  if (saveState.status === "saving" || isPending) {
+    return "데이터를 저장하는 중입니다."
+  }
+
+  if (saveState.status === "saved") {
+    return "데이터가 저장되었습니다. 화면 반영을 위해 미리보기를 갱신했습니다."
+  }
+
+  if (saveState.status === "error") {
+    return saveState.message
+  }
+
+  return "저장해도 composer 화면을 떠나지 않습니다."
+}

--- a/app/ponix/pages/[id]/compose/composer-workspace.tsx
+++ b/app/ponix/pages/[id]/compose/composer-workspace.tsx
@@ -169,6 +169,20 @@ export function PonixComposerWorkspace({
     return () => window.removeEventListener("message", handleMessage)
   })
 
+  useEffect(() => {
+    function handleReloadCanvas() {
+      const frame = iframeRef.current
+      if (!frame) return
+
+      frame.src = canvasHref(pageId, selectedKey)
+    }
+
+    window.addEventListener("ponix:reload-canvas", handleReloadCanvas)
+    return () => {
+      window.removeEventListener("ponix:reload-canvas", handleReloadCanvas)
+    }
+  }, [pageId, selectedKey])
+
   function selectSection(sectionKey: string) {
     if (!sections.some((section) => section.key === sectionKey)) return
     if (

--- a/app/ponix/pages/[id]/compose/composer-workspace.tsx
+++ b/app/ponix/pages/[id]/compose/composer-workspace.tsx
@@ -74,7 +74,6 @@ export function PonixComposerWorkspace({
     const delays = [0, 150, 500, 1000]
     const timers = delays.map((delay) =>
       window.setTimeout(() => {
-        highlightEntityInFrame(iframeRef.current, selectedEntityId)
         iframeRef.current?.contentWindow?.postMessage(
           { type: "ponix:set-selected-entity", entityId: selectedEntityId },
           window.location.origin,
@@ -194,7 +193,6 @@ export function PonixComposerWorkspace({
 
     dirtyRef.current = false
     delete panelsRef.current?.dataset.composerDirty
-    highlightEntityInFrame(iframeRef.current, null)
     iframeRef.current?.contentWindow?.postMessage(
       { type: "ponix:set-selected-entity", entityId: null },
       window.location.origin,
@@ -215,7 +213,6 @@ export function PonixComposerWorkspace({
       )
     }
 
-    highlightEntityInFrame(iframeRef.current, selectedEntityId)
     target.postMessage(
       { type: "ponix:set-selected-entity", entityId: selectedEntityId },
       window.location.origin,
@@ -380,41 +377,6 @@ function canvasHref(pageId: string, sectionKey: string | null) {
 
 function composeHref(pageId: string, sectionKey: string) {
   return `/ponix/pages/${pageId}/compose?section=${encodeURIComponent(sectionKey)}`
-}
-
-function highlightEntityInFrame(
-  frame: HTMLIFrameElement | null,
-  entityId: string | null,
-) {
-  const frameWindow = frame?.contentWindow
-  const frameDocument = frame?.contentDocument
-  if (!frameWindow || !frameDocument) return
-
-  const nodes =
-    frameDocument.querySelectorAll<HTMLElement>("[data-ponix-entity]")
-  let firstMatch: HTMLElement | null = null
-
-  nodes.forEach((node) => {
-    const selected = Boolean(entityId) && node.dataset.ponixEntity === entityId
-    if (selected && !firstMatch) {
-      firstMatch = node
-    }
-    node.dataset.ponixEntityState = selected ? "selected" : "idle"
-  })
-
-  const target = firstMatch as HTMLElement | null
-  if (!target) return
-
-  const rect = target.getBoundingClientRect()
-  const top =
-    frameWindow.scrollY +
-    rect.top -
-    Math.max(24, (frameWindow.innerHeight - rect.height) / 2)
-
-  frameWindow.scrollTo({
-    top: Math.max(0, top),
-    behavior: "smooth",
-  })
 }
 
 function isSectionMessage(

--- a/app/ponix/pages/[id]/compose/composer-workspace.tsx
+++ b/app/ponix/pages/[id]/compose/composer-workspace.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useMemo, useRef, useState, type ReactNode } from "react"
+import { useEffect, useRef, useState, type ReactNode } from "react"
 import Link from "next/link"
 import { ArrowUpRight } from "lucide-react"
 
@@ -40,63 +40,13 @@ export function PonixComposerWorkspace({
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const panelsRef = useRef<HTMLDivElement>(null)
   const dirtyRef = useRef(false)
-  const [selectedKey, setSelectedKey] = useState(initialSelectedKey)
-  const [selectedEntityId, setSelectedEntityId] = useState<string | null>(null)
-  const selectedSection = useMemo(
-    () => sections.find((section) => section.key === selectedKey) ?? null,
-    [sections, selectedKey],
-  )
+  const selectedKeyRef = useRef(initialSelectedKey)
+  const selectedEntityIdRef = useRef<string | null>(null)
 
   useEffect(() => {
-    const root = panelsRef.current
-    if (!root) return
-
-    root
-      .querySelectorAll<HTMLElement>("[data-composer-panel]")
-      .forEach((panel) => {
-        const selected = panel.dataset.composerPanel === selectedKey
-        panel.hidden = !selected
-        panel.dataset.state = selected ? "selected" : "idle"
-      })
-  }, [selectedKey])
-
-  useEffect(() => {
-    const frame = iframeRef.current
-    if (!frame?.contentWindow || !selectedKey) return
-
-    frame.contentWindow.postMessage(
-      { type: "ponix:set-selected-section", sectionKey: selectedKey },
-      window.location.origin,
-    )
-  }, [selectedKey])
-
-  useEffect(() => {
-    const delays = [0, 150, 500, 1000]
-    const timers = delays.map((delay) =>
-      window.setTimeout(() => {
-        iframeRef.current?.contentWindow?.postMessage(
-          { type: "ponix:set-selected-entity", entityId: selectedEntityId },
-          window.location.origin,
-        )
-      }, delay),
-    )
-
-    return () => {
-      timers.forEach((timer) => window.clearTimeout(timer))
-    }
-  }, [selectedEntityId])
-
-  useEffect(() => {
-    const root = panelsRef.current
-    if (!root) return
-
-    root
-      .querySelectorAll<HTMLElement>("[data-composer-entity-id]")
-      .forEach((row) => {
-        const selected = row.dataset.composerEntityId === selectedEntityId
-        row.dataset.composerEntityState = selected ? "selected" : "idle"
-      })
-  }, [selectedEntityId])
+    updateSelectedPanel(panelsRef.current, selectedKeyRef.current)
+    updateSelectedRows(panelsRef.current, selectedEntityIdRef.current)
+  }, [])
 
   useEffect(() => {
     const root = panelsRef.current
@@ -129,7 +79,9 @@ export function PonixComposerWorkspace({
       const entityId = row?.dataset.composerEntityId
       if (!entityId) return
 
-      setSelectedEntityId(entityId)
+      selectedEntityIdRef.current = entityId
+      updateSelectedRows(panelRoot, entityId)
+      postSelectedEntity(iframeRef.current, entityId)
     }
 
     function handleBeforeUnload(event: BeforeUnloadEvent) {
@@ -173,48 +125,58 @@ export function PonixComposerWorkspace({
       const frame = iframeRef.current
       if (!frame) return
 
-      frame.src = canvasHref(pageId, selectedKey)
+      frame.src = canvasHref(pageId, selectedKeyRef.current)
     }
 
     window.addEventListener("ponix:reload-canvas", handleReloadCanvas)
     return () => {
       window.removeEventListener("ponix:reload-canvas", handleReloadCanvas)
     }
-  }, [pageId, selectedKey])
+  }, [pageId])
 
   function selectSection(sectionKey: string) {
-    if (!sections.some((section) => section.key === sectionKey)) return
+    if (!sections.some((section) => section.key === sectionKey)) return false
     if (
       dirtyRef.current &&
       !window.confirm("저장하지 않은 변경사항이 있습니다. 섹션을 이동할까요?")
     ) {
-      return
+      return false
     }
 
     dirtyRef.current = false
     delete panelsRef.current?.dataset.composerDirty
-    iframeRef.current?.contentWindow?.postMessage(
-      { type: "ponix:set-selected-entity", entityId: null },
-      window.location.origin,
-    )
-    setSelectedKey(sectionKey)
-    setSelectedEntityId(null)
+    selectedKeyRef.current = sectionKey
+    selectedEntityIdRef.current = null
+    updateSelectedPanel(panelsRef.current, sectionKey)
+    updateSelectedRows(panelsRef.current, null)
+    postSelectedEntity(iframeRef.current, null)
+    postSelectedSection(iframeRef.current, sectionKey)
+    scrollCanvasSection(iframeRef.current, sectionKey)
     window.history.replaceState(null, "", composeHref(pageId, sectionKey))
+    window.dispatchEvent(
+      new CustomEvent("ponix:composer-section-changed", {
+        detail: { sectionKey },
+      }),
+    )
+    return true
   }
 
   function syncCanvasFrame() {
     const target = iframeRef.current?.contentWindow
     if (!target) return
 
-    if (selectedKey) {
+    if (selectedKeyRef.current) {
       target.postMessage(
-        { type: "ponix:set-selected-section", sectionKey: selectedKey },
+        {
+          type: "ponix:set-selected-section",
+          sectionKey: selectedKeyRef.current,
+        },
         window.location.origin,
       )
     }
 
     target.postMessage(
-      { type: "ponix:set-selected-entity", entityId: selectedEntityId },
+      { type: "ponix:set-selected-entity", entityId: selectedEntityIdRef.current },
       window.location.origin,
     )
   }
@@ -252,7 +214,7 @@ export function PonixComposerWorkspace({
             <SectionRail
               pageId={pageId}
               sections={sections}
-              selectedKey={selectedSection?.key ?? null}
+              initialSelectedKey={initialSelectedKey}
               onSelect={selectSection}
             />
           </CardHeader>
@@ -325,14 +287,34 @@ function ComposerHeader({
 function SectionRail({
   pageId,
   sections,
-  selectedKey,
+  initialSelectedKey,
   onSelect,
 }: {
   pageId: string
   sections: ComposerSection[]
-  selectedKey: string | null
-  onSelect: (sectionKey: string) => void
+  initialSelectedKey: string | null
+  onSelect: (sectionKey: string) => boolean
 }) {
+  const [selectedKey, setSelectedKey] = useState(initialSelectedKey)
+
+  useEffect(() => {
+    function handleSectionChange(event: Event) {
+      if (!(event instanceof CustomEvent)) return
+      const sectionKey = event.detail?.sectionKey
+      if (typeof sectionKey === "string") {
+        setSelectedKey(sectionKey)
+      }
+    }
+
+    window.addEventListener("ponix:composer-section-changed", handleSectionChange)
+    return () => {
+      window.removeEventListener(
+        "ponix:composer-section-changed",
+        handleSectionChange,
+      )
+    }
+  }, [])
+
   if (!sections.length) {
     return null
   }
@@ -351,7 +333,14 @@ function SectionRail({
               size="sm"
               className="rounded-full"
               aria-current={selected ? "true" : undefined}
-              onClick={() => onSelect(section.key)}
+              onClick={(event) => {
+                event.preventDefault()
+                const beforeY = window.scrollY
+                if (!onSelect(section.key)) return
+                if (window.scrollY !== beforeY) {
+                  window.scrollTo({ top: beforeY })
+                }
+              }}
               data-composer-section-button={section.key}
               data-href={composeHref(pageId, section.key)}
             >
@@ -377,6 +366,83 @@ function canvasHref(pageId: string, sectionKey: string | null) {
 
 function composeHref(pageId: string, sectionKey: string) {
   return `/ponix/pages/${pageId}/compose?section=${encodeURIComponent(sectionKey)}`
+}
+
+function updateSelectedPanel(
+  root: HTMLElement | null,
+  selectedKey: string | null,
+) {
+  if (!root) return
+
+  root.querySelectorAll<HTMLElement>("[data-composer-panel]").forEach((panel) => {
+    const selected = panel.dataset.composerPanel === selectedKey
+    panel.hidden = !selected
+    panel.dataset.state = selected ? "selected" : "idle"
+  })
+}
+
+function updateSelectedRows(root: HTMLElement | null, entityId: string | null) {
+  if (!root) return
+
+  root
+    .querySelectorAll<HTMLElement>("[data-composer-entity-id]")
+    .forEach((row) => {
+      const selected = row.dataset.composerEntityId === entityId
+      row.dataset.composerEntityState = selected ? "selected" : "idle"
+    })
+}
+
+function postSelectedSection(
+  frame: HTMLIFrameElement | null,
+  sectionKey: string,
+) {
+  frame?.contentWindow?.postMessage(
+    { type: "ponix:set-selected-section", sectionKey },
+    window.location.origin,
+  )
+}
+
+function scrollCanvasSection(
+  frame: HTMLIFrameElement | null,
+  sectionKey: string,
+) {
+  for (const delay of [0, 120, 360]) {
+    window.setTimeout(() => {
+      const frameWindow = frame?.contentWindow
+      const frameDocument = frame?.contentDocument
+      if (!frameWindow || !frameDocument) return
+
+      const section = frameDocument.querySelector<HTMLElement>(
+        `[data-ponix-section="${CSS.escape(sectionKey)}"]`,
+      )
+      if (!section) return
+
+      const rect = section.getBoundingClientRect()
+      const top =
+        frameWindow.scrollY +
+        rect.top -
+        Math.max(24, (frameWindow.innerHeight - rect.height) / 2)
+
+      frameWindow.scrollTo({
+        top: Math.max(0, top),
+        behavior: "auto",
+      })
+    }, delay)
+  }
+}
+
+function postSelectedEntity(
+  frame: HTMLIFrameElement | null,
+  entityId: string | null,
+) {
+  for (const delay of [0, 150, 500, 1000]) {
+    window.setTimeout(() => {
+      frame?.contentWindow?.postMessage(
+        { type: "ponix:set-selected-entity", entityId },
+        window.location.origin,
+      )
+    }, delay)
+  }
 }
 
 function isSectionMessage(

--- a/app/ponix/pages/[id]/compose/page.tsx
+++ b/app/ponix/pages/[id]/compose/page.tsx
@@ -1,18 +1,15 @@
 import type { Metadata } from "next"
 import Link from "next/link"
 import { notFound } from "next/navigation"
-import { ArrowDown, ArrowUp, Database, Layers3, PencilLine } from "lucide-react"
+import { Database, Layers3, PencilLine } from "lucide-react"
 
 import { CmsEntityPicker } from "@/app/ponix/_components/cms-entity-picker"
 import { renderFieldInput } from "@/app/ponix/_components/cms-section-form"
 import { CmsSubmitButton } from "@/app/ponix/_components/cms-save-controls"
+import { ComposerRelationList } from "@/app/ponix/pages/[id]/compose/composer-relation-list"
 import { ComposerSaveFeedback } from "@/app/ponix/pages/[id]/compose/composer-save-feedback"
 import { PonixComposerWorkspace } from "@/app/ponix/pages/[id]/compose/composer-workspace"
-import {
-  addSectionEntityRelationAction,
-  deleteSectionEntityRelationAction,
-  updateSectionEntityRelationAction,
-} from "@/app/ponix/relations/actions"
+import { addSectionEntityRelationAction } from "@/app/ponix/relations/actions"
 import { updateCmsSectionAction } from "@/app/ponix/sections/actions"
 import {
   Accordion,
@@ -423,29 +420,13 @@ function SectionEntityWorkspace({
             </Badge>
           </div>
 
-          {relations.sectionEntities.length ? (
-            <Accordion type="single" collapsible className="space-y-2">
-              {relations.sectionEntities.map((relation, index) => (
-                <SectionEntityRelationEditor
-                  key={relation.id}
-                  relation={relation}
-                  previousSortOrder={
-                    relations.sectionEntities[index - 1]?.sortOrder ?? null
-                  }
-                  nextSortOrder={
-                    relations.sectionEntities[index + 1]?.sortOrder ?? null
-                  }
-                  redirectTo={redirectTo}
-                  typeOptions={relationTypeOptions}
-                  slotOptions={slotOptions}
-                />
-              ))}
-            </Accordion>
-          ) : (
-            <p className="rounded-md border bg-muted/30 p-4 text-sm text-muted-foreground">
-              아직 연결된 데이터가 없습니다.
-            </p>
-          )}
+          <ComposerRelationList
+            sectionId={section.id}
+            relations={relations.sectionEntities}
+            redirectTo={redirectTo}
+            typeOptions={relationTypeOptions}
+            slotOptions={slotOptions}
+          />
         </div>
 
       </CardContent>
@@ -484,269 +465,6 @@ function SectionAdvancedSettingsCard({ section }: { section: GraphSection }) {
         </AccordionItem>
       </Accordion>
     </Card>
-  )
-}
-
-function SectionEntityRelationEditor({
-  relation,
-  previousSortOrder,
-  nextSortOrder,
-  redirectTo,
-  typeOptions,
-  slotOptions,
-}: {
-  relation: CmsSectionRelationContext["sectionEntities"][number]
-  previousSortOrder: number | null
-  nextSortOrder: number | null
-  redirectTo: string
-  typeOptions: string[]
-  slotOptions: string[]
-}) {
-  const typeListId = `relation-types-${relation.id}`
-  const slotListId = `relation-slots-${relation.id}`
-  const moveUpSortOrder =
-    previousSortOrder === null ? null : previousSortOrder - 1
-  const moveDownSortOrder =
-    nextSortOrder === null ? null : nextSortOrder + 1
-
-  return (
-    <AccordionItem
-      value={relation.id}
-      className="rounded-xl border bg-background/70 px-3 shadow-xs"
-      data-composer-relation-item={relation.id}
-      data-composer-entity-id={relation.entityId}
-    >
-      <AccordionTrigger
-        className="gap-3 py-3 hover:no-underline"
-        data-composer-relation-trigger={relation.id}
-      >
-        <div className="grid min-w-0 flex-1 gap-2 text-left">
-          <div className="flex min-w-0 items-start justify-between gap-3">
-            <div className="min-w-0">
-              <p className="line-clamp-1 text-sm font-medium">
-                {relation.entity?.title ?? relation.entityId}
-              </p>
-              <p className="font-mono text-xs text-muted-foreground">
-                {relation.entity?.schemaKey ?? "schema"}
-              </p>
-            </div>
-            <Badge variant="outline" className="rounded-full">
-              {relation.entity?.published ? "published" : "draft"}
-            </Badge>
-          </div>
-          <div className="flex flex-wrap gap-1.5">
-            <Badge
-              variant="secondary"
-              className="rounded-full font-mono text-[10px]"
-            >
-              {relation.slot}
-            </Badge>
-            <Badge
-              variant="outline"
-              className="rounded-full font-mono text-[10px]"
-            >
-              {relation.relationType}
-            </Badge>
-            <Badge
-              variant="outline"
-              className="rounded-full font-mono text-[10px]"
-            >
-              #{relation.sortOrder}
-            </Badge>
-          </div>
-        </div>
-      </AccordionTrigger>
-
-      <AccordionContent
-        className="space-y-3 pb-3"
-        data-composer-relation-editor={relation.id}
-      >
-        <div
-          className="rounded-xl border bg-muted/30 p-3"
-          data-composer-entity-quick-view={relation.entityId}
-        >
-          <div className="flex items-start justify-between gap-3">
-            <div className="min-w-0">
-              <p className="text-xs font-medium text-muted-foreground">
-                데이터
-              </p>
-              <p className="mt-1 line-clamp-1 text-sm font-medium">
-                {relation.entity?.title ?? relation.entityId}
-              </p>
-              {(relation.entity?.subtitle || relation.entity?.summary) && (
-                <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted-foreground">
-                  {relation.entity?.subtitle ?? relation.entity?.summary}
-                </p>
-              )}
-            </div>
-            <Badge
-              variant="secondary"
-              className="rounded-full font-mono text-[10px]"
-            >
-              {relation.entity?.entityType ?? "entity"}
-            </Badge>
-          </div>
-          <div className="mt-3 flex flex-wrap gap-2">
-            <Button
-              asChild
-              variant="outline"
-              size="sm"
-              className="h-8 rounded-full"
-            >
-              <Link href={`/ponix/entities/${relation.entityId}`}>
-                상세 보기
-              </Link>
-            </Button>
-            <Button
-              asChild
-              variant="outline"
-              size="sm"
-              className="h-8 rounded-full"
-            >
-              <Link href={`/ponix/entities/${relation.entityId}/edit`}>
-                데이터 수정
-              </Link>
-            </Button>
-          </div>
-        </div>
-
-        <form
-          action={updateSectionEntityRelationAction}
-          className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(0,0.9fr)_5.5rem]"
-          data-composer-track-dirty
-        >
-          <input type="hidden" name="redirect_to" value={redirectTo} />
-          <input type="hidden" name="relation_id" value={relation.id} />
-          <div className="space-y-1.5">
-            <Label htmlFor={`relation-type-${relation.id}`} className="text-xs">
-              Type
-            </Label>
-            <Input
-              id={`relation-type-${relation.id}`}
-              name="relation_type"
-              defaultValue={relation.relationType}
-              list={typeListId}
-              className="h-9 bg-card"
-            />
-          </div>
-          <div className="space-y-1.5">
-            <Label htmlFor={`relation-slot-${relation.id}`} className="text-xs">
-              Slot
-            </Label>
-            <Input
-              id={`relation-slot-${relation.id}`}
-              name="slot"
-              defaultValue={relation.slot}
-              list={slotListId}
-              className="h-9 bg-card"
-            />
-          </div>
-          <div className="space-y-1.5">
-            <Label
-              htmlFor={`relation-order-${relation.id}`}
-              className="text-xs"
-            >
-              Order
-            </Label>
-            <Input
-              id={`relation-order-${relation.id}`}
-              name="sort_order"
-              type="number"
-              defaultValue={relation.sortOrder}
-              className="h-9 bg-card"
-            />
-          </div>
-          <div className="flex gap-2 sm:col-span-3">
-            <CmsSubmitButton
-              className="h-9 flex-1 rounded-full"
-              pendingLabel="반영 중..."
-            >
-              연결 정보 저장
-            </CmsSubmitButton>
-            <Button asChild variant="outline" className="h-9 rounded-full">
-              <Link href={`/ponix/entities/${relation.entityId}/edit`}>
-                데이터 수정
-              </Link>
-            </Button>
-          </div>
-          <RelationDatalists
-            typeOptions={typeOptions}
-            slotOptions={slotOptions}
-            typeListId={typeListId}
-            slotListId={slotListId}
-          />
-        </form>
-
-        <div className="grid gap-2 sm:grid-cols-2" data-composer-order-controls>
-          <RelationMoveForm
-            relationId={relation.id}
-            redirectTo={redirectTo}
-            sortOrder={moveUpSortOrder}
-            label="위로"
-            icon="up"
-          />
-          <RelationMoveForm
-            relationId={relation.id}
-            redirectTo={redirectTo}
-            sortOrder={moveDownSortOrder}
-            label="아래로"
-            icon="down"
-          />
-        </div>
-
-        <form action={deleteSectionEntityRelationAction}>
-          <input type="hidden" name="redirect_to" value={redirectTo} />
-          <input type="hidden" name="relation_id" value={relation.id} />
-          <Button
-            type="submit"
-            size="sm"
-            variant="ghost"
-            className="h-8 px-2 text-destructive hover:text-destructive"
-          >
-            이 섹션에서 제거
-          </Button>
-        </form>
-      </AccordionContent>
-    </AccordionItem>
-  )
-}
-
-function RelationMoveForm({
-  relationId,
-  redirectTo,
-  sortOrder,
-  label,
-  icon,
-}: {
-  relationId: string
-  redirectTo: string
-  sortOrder: number | null
-  label: string
-  icon: "up" | "down"
-}) {
-  const Icon = icon === "up" ? ArrowUp : ArrowDown
-
-  return (
-    <form action={updateSectionEntityRelationAction}>
-      <input type="hidden" name="redirect_to" value={redirectTo} />
-      <input type="hidden" name="relation_id" value={relationId} />
-      <input
-        type="hidden"
-        name="sort_order"
-        value={sortOrder === null ? "" : String(sortOrder)}
-        data-composer-move-sort-order={label}
-      />
-      <Button
-        type="submit"
-        size="sm"
-        variant="outline"
-        disabled={sortOrder === null}
-        className="h-8 w-full rounded-full"
-      >
-        <Icon className="size-3.5" />
-        {label}
-      </Button>
-    </form>
   )
 }
 

--- a/app/ponix/relations/actions.ts
+++ b/app/ponix/relations/actions.ts
@@ -21,6 +21,15 @@ type EntityRelationInsert =
 type EntityRelationUpdate =
   Database["public"]["Tables"]["entity_relations"]["Update"]
 
+type ActionResult =
+  | {
+      ok: true
+    }
+  | {
+      ok: false
+      error: string
+    }
+
 const uuidPattern =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
@@ -325,6 +334,70 @@ export async function updateSectionEntityRelationAction(formData: FormData) {
     relationSuccess(redirectTo, "Section relation saved.")
   } catch (error) {
     relationError(redirectTo, error)
+  }
+}
+
+export async function reorderSectionEntityRelationsAction({
+  sectionId,
+  relationIds,
+}: {
+  sectionId: string
+  relationIds: string[]
+}): Promise<ActionResult> {
+  try {
+    await requireCmsAdmin("/ponix/relations")
+
+    if (!uuidPattern.test(sectionId)) {
+      throw new Error("Section is required.")
+    }
+
+    const orderedIds = relationIds.filter((id) => uuidPattern.test(id))
+    if (orderedIds.length !== relationIds.length || orderedIds.length === 0) {
+      throw new Error("Relation order is invalid.")
+    }
+
+    const supabase = await createClient()
+    const { data: relations, error: loadError } = await supabase
+      .from("section_entities")
+      .select("id, section_id, entity_id")
+      .eq("section_id", sectionId)
+      .in("id", orderedIds)
+
+    if (loadError) {
+      throw new Error(loadError.message)
+    }
+
+    const loadedIds = new Set((relations ?? []).map((relation) => relation.id))
+    if (loadedIds.size !== orderedIds.length) {
+      throw new Error("Some relations do not belong to this section.")
+    }
+
+    const updates = orderedIds.map((relationId, index) =>
+      supabase
+        .from("section_entities")
+        .update({ sort_order: (index + 1) * 10 } satisfies SectionEntityUpdate)
+        .eq("id", relationId)
+        .eq("section_id", sectionId),
+    )
+    const results = await Promise.all(updates)
+    const updateError = results.find((result) => result.error)?.error
+
+    if (updateError) {
+      throw new Error(updateError.message)
+    }
+
+    revalidateRelationSurfaces([
+      `/ponix/sections/${sectionId}`,
+      ...(relations ?? []).map((relation) => `/ponix/entities/${relation.entity_id}`),
+    ])
+
+    return { ok: true }
+  } catch (error) {
+    return {
+      ok: false,
+      error:
+        error instanceof Error ? error.message : "Relation reorder failed.",
+    }
   }
 }
 

--- a/app/ponix/relations/actions.ts
+++ b/app/ponix/relations/actions.ts
@@ -337,6 +337,65 @@ export async function updateSectionEntityRelationAction(formData: FormData) {
   }
 }
 
+export async function updateSectionEntityRelationInlineAction(
+  formData: FormData,
+): Promise<ActionResult> {
+  try {
+    await requireCmsAdmin("/ponix/relations")
+    const supabase = await createClient()
+    const relationId = parseUuid(formData, "relation_id", "Relation")
+    const update: SectionEntityUpdate = {
+      sort_order: parseSortOrder(formData),
+    }
+
+    if (hasField(formData, "relation_type")) {
+      update.relation_type = parseText(
+        formData,
+        "relation_type",
+        "Relation type",
+      )
+    }
+
+    if (hasField(formData, "slot")) {
+      update.slot = stringField(formData, "slot") || "default"
+    }
+
+    if (hasField(formData, "props")) {
+      update.props = parseProps(formData)
+    }
+
+    const { data: relation, error: loadError } = await supabase
+      .from("section_entities")
+      .select("section_id, entity_id")
+      .eq("id", relationId)
+      .maybeSingle()
+
+    if (loadError || !relation) {
+      throw new Error(loadError?.message ?? "Relation not found.")
+    }
+
+    const { error } = await supabase
+      .from("section_entities")
+      .update(update)
+      .eq("id", relationId)
+
+    if (error) throw new Error(error.message)
+
+    revalidateRelationSurfaces([
+      `/ponix/sections/${relation.section_id}`,
+      `/ponix/entities/${relation.entity_id}`,
+    ])
+
+    return { ok: true }
+  } catch (error) {
+    return {
+      ok: false,
+      error:
+        error instanceof Error ? error.message : "Section relation save failed.",
+    }
+  }
+}
+
 export async function reorderSectionEntityRelationsAction({
   sectionId,
   relationIds,

--- a/components/ui/drawer.tsx
+++ b/components/ui/drawer.tsx
@@ -11,6 +11,12 @@ function Drawer({
   return <DrawerPrimitive.Root data-slot="drawer" {...props} />
 }
 
+function DrawerNested({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.NestedRoot>) {
+  return <DrawerPrimitive.NestedRoot data-slot="drawer-nested" {...props} />
+}
+
 function DrawerTrigger({
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
@@ -123,6 +129,7 @@ function DrawerDescription({
 
 export {
   Drawer,
+  DrawerNested,
   DrawerPortal,
   DrawerOverlay,
   DrawerTrigger,


### PR DESCRIPTION
Closes #67

## Summary
- Replace temporary up/down relation ordering controls with drag handles and an optimistic client-side relation list.
- Add a non-redirect server action for section entity reorder saves, so the parent composer route does not navigate on order changes.
- Reload only the live canvas iframe after successful reorder instead of refreshing the whole composer page.
- Change entity edit entry from full-page navigation to a shadcn Sheet overlay with an embedded editor frame and full-screen fallback link.

## QA
- pnpm exec tsc --noEmit
- pnpm run lint
- git diff --check
- pnpm run build
- CMUX browser QA: drag handles present, old up/down controls removed.
- CMUX browser QA: data edit opens a Sheet without changing the parent composer URL.
- CMUX browser QA: embedded editor frame opens with usable height.

## Notes
- Drag/drop persistence was not submitted against production data during QA. The server action path is covered by typecheck/build; full mutation smoke should be done on a disposable section or with an explicit reversible order test.
- The Sheet currently embeds the existing edit route. A later refinement should extract the entity editor form into a native embedded Sheet component.