### PR TITLE
Clarify CMS relation bridge contract

### DIFF
--- a/app/ponix/_components/cms-relations.tsx
+++ b/app/ponix/_components/cms-relations.tsx
@@ -585,7 +585,10 @@ function BridgeHealthNotice({ health }: { health: CmsBridgeHealth }) {
     return (
       <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
         <Badge variant="outline" className="rounded-full">
-          Entity graph synced
+          읽기: entity_relations
+        </Badge>
+        <Badge variant="outline" className="rounded-full">
+          저장: source row
         </Badge>
         <span>
           {health.mirrored}
@@ -640,6 +643,7 @@ function PageSectionRelationsTable({
             </TableCell>
             <TableCell className="font-mono text-xs">
               {relation.sortOrder}
+              <BridgeSourceHint relation={relation} />
             </TableCell>
             <TableCell>
               <SectionLink
@@ -720,6 +724,7 @@ function SectionEntityRelationsTable({
             <TableCell className="font-mono text-xs">{relation.slot}</TableCell>
             <TableCell className="font-mono text-xs">
               {relation.sortOrder}
+              <BridgeSourceHint relation={relation} />
             </TableCell>
             <TableCell>
               <EntityLink entity={relation.entity} fallbackId={relation.entityId} />
@@ -825,7 +830,7 @@ function PageSectionRelationActions({
         className="flex items-center gap-2"
       >
         <input type="hidden" name="redirect_to" value={redirectTo} />
-        <input type="hidden" name="relation_id" value={relation.id} />
+        <input type="hidden" name="relation_id" value={relation.sourceId} />
         <Input
           aria-label="Sort order"
           name="sort_order"
@@ -839,7 +844,7 @@ function PageSectionRelationActions({
       </form>
       <form action={deletePageSectionRelationAction}>
         <input type="hidden" name="redirect_to" value={redirectTo} />
-        <input type="hidden" name="relation_id" value={relation.id} />
+        <input type="hidden" name="relation_id" value={relation.sourceId} />
         <Button
           type="submit"
           size="sm"
@@ -867,7 +872,7 @@ function SectionEntityRelationActions({
         className="flex items-center gap-2"
       >
         <input type="hidden" name="redirect_to" value={redirectTo} />
-        <input type="hidden" name="relation_id" value={relation.id} />
+        <input type="hidden" name="relation_id" value={relation.sourceId} />
         <Input
           aria-label="Sort order"
           name="sort_order"
@@ -881,7 +886,7 @@ function SectionEntityRelationActions({
       </form>
       <form action={deleteSectionEntityRelationAction}>
         <input type="hidden" name="redirect_to" value={redirectTo} />
-        <input type="hidden" name="relation_id" value={relation.id} />
+        <input type="hidden" name="relation_id" value={relation.sourceId} />
         <Button
           type="submit"
           size="sm"
@@ -891,6 +896,19 @@ function SectionEntityRelationActions({
           Remove from section
         </Button>
       </form>
+    </div>
+  )
+}
+
+function BridgeSourceHint({
+  relation,
+}: {
+  relation: CmsPageSectionRelation | CmsSectionEntityRelation
+}) {
+  return (
+    <div className="mt-1 space-y-0.5 text-[10px] leading-tight text-muted-foreground">
+      <div>source: {shortId(relation.sourceId)}</div>
+      <div>graph: {shortId(relation.graphRelationId)}</div>
     </div>
   )
 }
@@ -932,6 +950,10 @@ function EntityRelationActions({
       </form>
     </div>
   )
+}
+
+function shortId(id: string) {
+  return id.slice(0, 8)
 }
 
 function PageLink({

--- a/app/ponix/pages/[id]/compose/composer-relation-list.tsx
+++ b/app/ponix/pages/[id]/compose/composer-relation-list.tsx
@@ -97,7 +97,7 @@ export function ComposerRelationList({
     startTransition(() => {
       void reorderSectionEntityRelationsAction({
         sectionId,
-        relationIds: next.map((relation) => relation.id),
+        relationIds: next.map((relation) => relation.sourceId),
       }).then((result) => {
         if (!result.ok) {
           setOrderedRelations(previous)
@@ -225,6 +225,8 @@ function SectionEntityRelationEditor({
   return (
     <div
       data-composer-relation-item={relation.id}
+      data-composer-relation-source-id={relation.sourceId}
+      data-composer-relation-graph-id={relation.graphRelationId}
       data-composer-entity-id={relation.entityId}
       onDragOver={onDragOver}
       onDrop={onDrop}
@@ -377,7 +379,11 @@ function SectionEntityRelationEditor({
                 }}
               >
                 <input type="hidden" name="redirect_to" value={redirectTo} />
-                <input type="hidden" name="relation_id" value={relation.id} />
+                <input
+                  type="hidden"
+                  name="relation_id"
+                  value={relation.sourceId}
+                />
                 <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_7rem]">
                   <div className="space-y-1.5">
                     <Label
@@ -449,7 +455,11 @@ function SectionEntityRelationEditor({
           <DrawerFooter className="border-t bg-background px-5 py-4">
             <form action={deleteSectionEntityRelationAction}>
               <input type="hidden" name="redirect_to" value={redirectTo} />
-              <input type="hidden" name="relation_id" value={relation.id} />
+              <input
+                type="hidden"
+                name="relation_id"
+                value={relation.sourceId}
+              />
               <Button
                 type="submit"
                 size="sm"

--- a/app/ponix/pages/[id]/compose/page.tsx
+++ b/app/ponix/pages/[id]/compose/page.tsx
@@ -504,7 +504,10 @@ function ComposerBridgeHealth({
     return (
       <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
         <Badge variant="outline" className="rounded-full">
-          Entity graph synced
+          읽기: entity_relations
+        </Badge>
+        <Badge variant="outline" className="rounded-full">
+          저장: section_entities
         </Badge>
         <span>
           {health.mirrored}

--- a/docs/content-graph.md
+++ b/docs/content-graph.md
@@ -46,6 +46,17 @@ is a compatibility read model, not the only source of truth. Do not remove
 `pages`, `sections`, `page_sections`, or `section_entities` until all renderers,
 forms, audits, migrations, and generated types have moved to the entity graph.
 
+Current PONIX contract:
+
+- CMS relation lists read page/section placement through `entity_relations`
+  bridge rows.
+- Those bridge rows expose both the `entity_relations.id` and the legacy
+  `source_id`.
+- Routine CMS writes still target `page_sections` and `section_entities`; bridge
+  triggers mirror those writes back into `entity_relations`.
+- Code that mutates page or section composition must pass the legacy
+  `source_id`, not the graph row id.
+
 ## Tables
 
 | Table | Purpose |

--- a/lib/cms/content.ts
+++ b/lib/cms/content.ts
@@ -116,6 +116,9 @@ export type CmsLinkedEntity = SchemaSummary & {
 
 export type CmsPageSectionRelation = {
   id: string
+  graphRelationId: string
+  sourceTable: "page_sections"
+  sourceId: string
   pageId: string
   sectionId: string
   sortOrder: number
@@ -127,6 +130,9 @@ export type CmsPageSectionRelation = {
 
 export type CmsSectionEntityRelation = {
   id: string
+  graphRelationId: string
+  sourceTable: "section_entities"
+  sourceId: string
   sectionId: string
   entityId: string
   relationType: string
@@ -916,6 +922,9 @@ async function loadPageSectionRelationsFromEntityGraph({
 
       return {
         id: relation.source_id,
+        graphRelationId: relation.id,
+        sourceTable: "page_sections",
+        sourceId: relation.source_id,
         pageId: mappedPageId,
         sectionId: mappedSectionId,
         sortOrder: relation.sort_order,
@@ -1003,6 +1012,9 @@ async function loadSectionEntityRelationsFromEntityGraph({
 
       return {
         id: relation.source_id,
+        graphRelationId: relation.id,
+        sourceTable: "section_entities",
+        sourceId: relation.source_id,
         sectionId: mappedSectionId,
         entityId: relation.to_entity_id,
         relationType: relation.relation_type,


### PR DESCRIPTION
Closes #69

## Summary
- expose graph relation ids separately from legacy source row ids in CMS relation contexts
- pass sourceId to page/section composition mutations while reading through entity_relations
- show the read/write bridge contract in PONIX relation/composer UI
- document the current bridge contract in docs/content-graph.md

## QA
- pnpm exec tsc --noEmit
- pnpm run lint
- git diff --check
- pnpm run build
- CMUX /ponix/relations bridge UI smoke
- CMUX composer source/graph attribute smoke
- reversible composer relation save with Supabase select confirming source and graph sort_order restored to 10