### PR TITLE
Polish CMS relation bridge editing affordances

### DIFF
--- a/app/ponix/_components/cms-relations.tsx
+++ b/app/ponix/_components/cms-relations.tsx
@@ -585,14 +585,14 @@ function BridgeHealthNotice({ health }: { health: CmsBridgeHealth }) {
     return (
       <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
         <Badge variant="outline" className="rounded-full">
-          읽기: entity_relations
+          읽기: 그래프 미러
         </Badge>
         <Badge variant="outline" className="rounded-full">
-          저장: source row
+          저장: 원본 관계 행
         </Badge>
         <span>
           {health.mirrored}
-          {health.expected !== null ? ` / ${health.expected}` : ""} mirror rows
+          {health.expected !== null ? ` / ${health.expected}` : ""}개 동기화
         </span>
       </div>
     )
@@ -601,9 +601,9 @@ function BridgeHealthNotice({ health }: { health: CmsBridgeHealth }) {
   return (
     <Alert variant="destructive" className="mt-3 rounded-md">
       <AlertDescription>
-        Entity graph mirror is out of sync: {health.mirrored}
-        {health.expected !== null ? ` / ${health.expected}` : ""} rows available.
-        Use the legacy relation actions only after the bridge catches up.
+        그래프 미러 동기화가 아직 맞지 않습니다: {health.mirrored}
+        {health.expected !== null ? ` / ${health.expected}` : ""}개 행이
+        확인되었습니다. 동기화가 끝난 뒤 관계를 수정하세요.
       </AlertDescription>
     </Alert>
   )
@@ -907,8 +907,8 @@ function BridgeSourceHint({
 }) {
   return (
     <div className="mt-1 space-y-0.5 text-[10px] leading-tight text-muted-foreground">
-      <div>source: {shortId(relation.sourceId)}</div>
-      <div>graph: {shortId(relation.graphRelationId)}</div>
+      <div>저장 행: {shortId(relation.sourceId)}</div>
+      <div>그래프 행: {shortId(relation.graphRelationId)}</div>
     </div>
   )
 }

--- a/app/ponix/pages/[id]/compose/composer-relation-list.tsx
+++ b/app/ponix/pages/[id]/compose/composer-relation-list.tsx
@@ -79,16 +79,18 @@ export function ComposerRelationList({
   slotOptions: string[]
 }) {
   const [orderedRelations, setOrderedRelations] = useState(relations)
-  const [draggingId, setDraggingId] = useState<string | null>(null)
-  const [dropTargetId, setDropTargetId] = useState<string | null>(null)
+  const [draggingSourceId, setDraggingSourceId] = useState<string | null>(null)
+  const [dropTargetSourceId, setDropTargetSourceId] = useState<string | null>(
+    null,
+  )
   const [saveState, setSaveState] = useState<SaveState>({ status: "idle" })
   const [isPending, startTransition] = useTransition()
 
-  function moveRelation(sourceId: string, targetId: string) {
-    if (sourceId === targetId) return
+  function moveRelation(sourceRowId: string, targetSourceRowId: string) {
+    if (sourceRowId === targetSourceRowId) return
 
     const previous = orderedRelations
-    const next = reorderById(previous, sourceId, targetId)
+    const next = reorderBySourceId(previous, sourceRowId, targetSourceRowId)
     if (next === previous) return
 
     setOrderedRelations(next)
@@ -151,26 +153,29 @@ export function ComposerRelationList({
             redirectTo={redirectTo}
             typeOptions={typeOptions}
             slotOptions={slotOptions}
-            dragging={draggingId === relation.id}
-            dropTarget={dropTargetId === relation.id}
-            onDragStart={() => setDraggingId(relation.id)}
+            dragging={draggingSourceId === relation.sourceId}
+            dropTarget={dropTargetSourceId === relation.sourceId}
+            onDragStart={() => setDraggingSourceId(relation.sourceId)}
             onDragEnd={() => {
-              setDraggingId(null)
-              setDropTargetId(null)
+              setDraggingSourceId(null)
+              setDropTargetSourceId(null)
             }}
             onDragOver={(event) => {
               event.preventDefault()
-              if (draggingId && draggingId !== relation.id) {
-                setDropTargetId(relation.id)
+              if (
+                draggingSourceId &&
+                draggingSourceId !== relation.sourceId
+              ) {
+                setDropTargetSourceId(relation.sourceId)
               }
             }}
             onDrop={(event) => {
               event.preventDefault()
-              if (draggingId) {
-                moveRelation(draggingId, relation.id)
+              if (draggingSourceId) {
+                moveRelation(draggingSourceId, relation.sourceId)
               }
-              setDraggingId(null)
-              setDropTargetId(null)
+              setDraggingSourceId(null)
+              setDropTargetSourceId(null)
             }}
           />
         ))}
@@ -245,10 +250,10 @@ function SectionEntityRelationEditor({
             draggable
             aria-label="순서 끌어서 변경"
             className="grid size-9 shrink-0 cursor-grab place-items-center self-center rounded-full border bg-muted/40 text-muted-foreground transition hover:border-accent hover:text-foreground active:cursor-grabbing"
-            data-composer-drag-handle={relation.id}
+            data-composer-drag-handle={relation.sourceId}
             onDragStart={(event) => {
               event.dataTransfer.effectAllowed = "move"
-              event.dataTransfer.setData("text/plain", relation.id)
+              event.dataTransfer.setData("text/plain", relation.sourceId)
               onDragStart()
             }}
             onDragEnd={onDragEnd}
@@ -871,9 +876,17 @@ function RelationDatalists({
   )
 }
 
-function reorderById(relations: Relation[], sourceId: string, targetId: string) {
-  const sourceIndex = relations.findIndex((relation) => relation.id === sourceId)
-  const targetIndex = relations.findIndex((relation) => relation.id === targetId)
+function reorderBySourceId(
+  relations: Relation[],
+  sourceRowId: string,
+  targetSourceRowId: string,
+) {
+  const sourceIndex = relations.findIndex(
+    (relation) => relation.sourceId === sourceRowId,
+  )
+  const targetIndex = relations.findIndex(
+    (relation) => relation.sourceId === targetSourceRowId,
+  )
 
   if (sourceIndex < 0 || targetIndex < 0) {
     return relations

--- a/app/ponix/pages/[id]/compose/page.tsx
+++ b/app/ponix/pages/[id]/compose/page.tsx
@@ -504,14 +504,14 @@ function ComposerBridgeHealth({
     return (
       <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
         <Badge variant="outline" className="rounded-full">
-          읽기: entity_relations
+          읽기: 그래프 미러
         </Badge>
         <Badge variant="outline" className="rounded-full">
-          저장: section_entities
+          저장: 섹션 원본 행
         </Badge>
         <span>
           {health.mirrored}
-          {health.expected !== null ? ` / ${health.expected}` : ""} mirror rows
+          {health.expected !== null ? ` / ${health.expected}` : ""}개 동기화
         </span>
       </div>
     )


### PR DESCRIPTION
Closes #72

## Summary
- rename composer drag/reorder state around source row identity
- make drag handles submit source row ids instead of ambiguous relation ids
- replace raw source/graph bridge labels with admin-readable Korean labels

## QA
- pnpm exec tsc --noEmit
- pnpm run lint
- git diff --check
- pnpm run build
- CMUX /ponix/relations label smoke
- CMUX composer source drag-handle smoke