### PR TITLE
Make CMS relation mutations use graph relation ids

### DIFF
--- a/app/ponix/_components/cms-relations.tsx
+++ b/app/ponix/_components/cms-relations.tsx
@@ -830,7 +830,11 @@ function PageSectionRelationActions({
         className="flex items-center gap-2"
       >
         <input type="hidden" name="redirect_to" value={redirectTo} />
-        <input type="hidden" name="relation_id" value={relation.sourceId} />
+        <input
+          type="hidden"
+          name="relation_id"
+          value={relation.graphRelationId}
+        />
         <Input
           aria-label="Sort order"
           name="sort_order"
@@ -844,7 +848,11 @@ function PageSectionRelationActions({
       </form>
       <form action={deletePageSectionRelationAction}>
         <input type="hidden" name="redirect_to" value={redirectTo} />
-        <input type="hidden" name="relation_id" value={relation.sourceId} />
+        <input
+          type="hidden"
+          name="relation_id"
+          value={relation.graphRelationId}
+        />
         <Button
           type="submit"
           size="sm"
@@ -872,7 +880,11 @@ function SectionEntityRelationActions({
         className="flex items-center gap-2"
       >
         <input type="hidden" name="redirect_to" value={redirectTo} />
-        <input type="hidden" name="relation_id" value={relation.sourceId} />
+        <input
+          type="hidden"
+          name="relation_id"
+          value={relation.graphRelationId}
+        />
         <Input
           aria-label="Sort order"
           name="sort_order"
@@ -886,7 +898,11 @@ function SectionEntityRelationActions({
       </form>
       <form action={deleteSectionEntityRelationAction}>
         <input type="hidden" name="redirect_to" value={redirectTo} />
-        <input type="hidden" name="relation_id" value={relation.sourceId} />
+        <input
+          type="hidden"
+          name="relation_id"
+          value={relation.graphRelationId}
+        />
         <Button
           type="submit"
           size="sm"

--- a/app/ponix/pages/[id]/compose/composer-relation-list.tsx
+++ b/app/ponix/pages/[id]/compose/composer-relation-list.tsx
@@ -79,18 +79,20 @@ export function ComposerRelationList({
   slotOptions: string[]
 }) {
   const [orderedRelations, setOrderedRelations] = useState(relations)
-  const [draggingSourceId, setDraggingSourceId] = useState<string | null>(null)
-  const [dropTargetSourceId, setDropTargetSourceId] = useState<string | null>(
-    null,
-  )
+  const [draggingGraphId, setDraggingGraphId] = useState<string | null>(null)
+  const [dropTargetGraphId, setDropTargetGraphId] = useState<string | null>(null)
   const [saveState, setSaveState] = useState<SaveState>({ status: "idle" })
   const [isPending, startTransition] = useTransition()
 
-  function moveRelation(sourceRowId: string, targetSourceRowId: string) {
-    if (sourceRowId === targetSourceRowId) return
+  function moveRelation(graphRelationId: string, targetGraphRelationId: string) {
+    if (graphRelationId === targetGraphRelationId) return
 
     const previous = orderedRelations
-    const next = reorderBySourceId(previous, sourceRowId, targetSourceRowId)
+    const next = reorderByGraphRelationId(
+      previous,
+      graphRelationId,
+      targetGraphRelationId,
+    )
     if (next === previous) return
 
     setOrderedRelations(next)
@@ -99,7 +101,7 @@ export function ComposerRelationList({
     startTransition(() => {
       void reorderSectionEntityRelationsAction({
         sectionId,
-        relationIds: next.map((relation) => relation.sourceId),
+        graphRelationIds: next.map((relation) => relation.graphRelationId),
       }).then((result) => {
         if (!result.ok) {
           setOrderedRelations(previous)
@@ -153,29 +155,29 @@ export function ComposerRelationList({
             redirectTo={redirectTo}
             typeOptions={typeOptions}
             slotOptions={slotOptions}
-            dragging={draggingSourceId === relation.sourceId}
-            dropTarget={dropTargetSourceId === relation.sourceId}
-            onDragStart={() => setDraggingSourceId(relation.sourceId)}
+            dragging={draggingGraphId === relation.graphRelationId}
+            dropTarget={dropTargetGraphId === relation.graphRelationId}
+            onDragStart={() => setDraggingGraphId(relation.graphRelationId)}
             onDragEnd={() => {
-              setDraggingSourceId(null)
-              setDropTargetSourceId(null)
+              setDraggingGraphId(null)
+              setDropTargetGraphId(null)
             }}
             onDragOver={(event) => {
               event.preventDefault()
               if (
-                draggingSourceId &&
-                draggingSourceId !== relation.sourceId
+                draggingGraphId &&
+                draggingGraphId !== relation.graphRelationId
               ) {
-                setDropTargetSourceId(relation.sourceId)
+                setDropTargetGraphId(relation.graphRelationId)
               }
             }}
             onDrop={(event) => {
               event.preventDefault()
-              if (draggingSourceId) {
-                moveRelation(draggingSourceId, relation.sourceId)
+              if (draggingGraphId) {
+                moveRelation(draggingGraphId, relation.graphRelationId)
               }
-              setDraggingSourceId(null)
-              setDropTargetSourceId(null)
+              setDraggingGraphId(null)
+              setDropTargetGraphId(null)
             }}
           />
         ))}
@@ -250,10 +252,10 @@ function SectionEntityRelationEditor({
             draggable
             aria-label="순서 끌어서 변경"
             className="grid size-9 shrink-0 cursor-grab place-items-center self-center rounded-full border bg-muted/40 text-muted-foreground transition hover:border-accent hover:text-foreground active:cursor-grabbing"
-            data-composer-drag-handle={relation.sourceId}
+            data-composer-drag-handle={relation.graphRelationId}
             onDragStart={(event) => {
               event.dataTransfer.effectAllowed = "move"
-              event.dataTransfer.setData("text/plain", relation.sourceId)
+              event.dataTransfer.setData("text/plain", relation.graphRelationId)
               onDragStart()
             }}
             onDragEnd={onDragEnd}
@@ -387,7 +389,7 @@ function SectionEntityRelationEditor({
                 <input
                   type="hidden"
                   name="relation_id"
-                  value={relation.sourceId}
+                  value={relation.graphRelationId}
                 />
                 <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_7rem]">
                   <div className="space-y-1.5">
@@ -463,7 +465,7 @@ function SectionEntityRelationEditor({
               <input
                 type="hidden"
                 name="relation_id"
-                value={relation.sourceId}
+                value={relation.graphRelationId}
               />
               <Button
                 type="submit"
@@ -876,16 +878,16 @@ function RelationDatalists({
   )
 }
 
-function reorderBySourceId(
+function reorderByGraphRelationId(
   relations: Relation[],
-  sourceRowId: string,
-  targetSourceRowId: string,
+  graphRelationId: string,
+  targetGraphRelationId: string,
 ) {
   const sourceIndex = relations.findIndex(
-    (relation) => relation.sourceId === sourceRowId,
+    (relation) => relation.graphRelationId === graphRelationId,
   )
   const targetIndex = relations.findIndex(
-    (relation) => relation.sourceId === targetSourceRowId,
+    (relation) => relation.graphRelationId === targetGraphRelationId,
   )
 
   if (sourceIndex < 0 || targetIndex < 0) {

--- a/app/ponix/relations/actions.ts
+++ b/app/ponix/relations/actions.ts
@@ -1,7 +1,7 @@
 "use server"
 
 import { revalidatePath, updateTag } from "next/cache"
-import { redirect } from "next/navigation"
+import { redirect, unstable_rethrow } from "next/navigation"
 
 import { requireCmsAdmin } from "@/lib/cms/auth"
 import { PUBLIC_CONTENT_CACHE_TAG } from "@/lib/data/public-cache"
@@ -20,6 +20,7 @@ type EntityRelationInsert =
   Database["public"]["Tables"]["entity_relations"]["Insert"]
 type EntityRelationUpdate =
   Database["public"]["Tables"]["entity_relations"]["Update"]
+type ServerSupabaseClient = Awaited<ReturnType<typeof createClient>>
 
 type ActionResult =
   | {
@@ -101,6 +102,8 @@ function parseProps(formData: FormData): Json {
 }
 
 function relationError(path: string, error: unknown): never {
+  unstable_rethrow(error)
+
   redirectWithParams(path, {
     relation_error:
       error instanceof Error ? error.message : "Relation mutation failed.",
@@ -132,6 +135,66 @@ function revalidateRelationSurfaces(paths: string[]) {
   ]) {
     revalidatePath(path)
   }
+}
+
+async function loadPageSectionSourceRelation(
+  supabase: ServerSupabaseClient,
+  graphRelationId: string,
+) {
+  const { data: bridge, error: bridgeError } = await supabase
+    .from("entity_relations")
+    .select("source_id")
+    .eq("id", graphRelationId)
+    .eq("source_table", "page_sections")
+    .maybeSingle()
+
+  if (bridgeError || !bridge?.source_id) {
+    throw new Error(
+      bridgeError?.message ?? "Page section graph relation not found.",
+    )
+  }
+
+  const { data: relation, error: relationError } = await supabase
+    .from("page_sections")
+    .select("id, page_id, section_id")
+    .eq("id", bridge.source_id)
+    .maybeSingle()
+
+  if (relationError || !relation) {
+    throw new Error(
+      relationError?.message ?? "Page section source row not found.",
+    )
+  }
+
+  return relation
+}
+
+async function loadSectionEntitySourceRelation(
+  supabase: ServerSupabaseClient,
+  graphRelationId: string,
+) {
+  const { data: bridge, error: bridgeError } = await supabase
+    .from("entity_relations")
+    .select("source_id")
+    .eq("id", graphRelationId)
+    .eq("source_table", "section_entities")
+    .maybeSingle()
+
+  if (bridgeError || !bridge?.source_id) {
+    throw new Error(bridgeError?.message ?? "Section graph relation not found.")
+  }
+
+  const { data: relation, error: relationError } = await supabase
+    .from("section_entities")
+    .select("id, section_id, entity_id")
+    .eq("id", bridge.source_id)
+    .maybeSingle()
+
+  if (relationError || !relation) {
+    throw new Error(relationError?.message ?? "Section source row not found.")
+  }
+
+  return relation
 }
 
 export async function addPageSectionRelationAction(formData: FormData) {
@@ -169,24 +232,19 @@ export async function updatePageSectionRelationAction(formData: FormData) {
   try {
     await requireCmsAdmin(redirectTo)
     const supabase = await createClient()
-    const relationId = parseUuid(formData, "relation_id", "Relation")
+    const graphRelationId = parseUuid(formData, "relation_id", "Relation")
     const update: PageSectionUpdate = {
       sort_order: parseSortOrder(formData),
     }
-    const { data: relation, error: loadError } = await supabase
-      .from("page_sections")
-      .select("page_id, section_id")
-      .eq("id", relationId)
-      .maybeSingle()
-
-    if (loadError || !relation) {
-      throw new Error(loadError?.message ?? "Relation not found.")
-    }
+    const relation = await loadPageSectionSourceRelation(
+      supabase,
+      graphRelationId,
+    )
 
     const { error } = await supabase
       .from("page_sections")
       .update(update)
-      .eq("id", relationId)
+      .eq("id", relation.id)
 
     if (error) throw new Error(error.message)
 
@@ -206,21 +264,16 @@ export async function deletePageSectionRelationAction(formData: FormData) {
   try {
     await requireCmsAdmin(redirectTo)
     const supabase = await createClient()
-    const relationId = parseUuid(formData, "relation_id", "Relation")
-    const { data: relation, error: loadError } = await supabase
-      .from("page_sections")
-      .select("page_id, section_id")
-      .eq("id", relationId)
-      .maybeSingle()
-
-    if (loadError || !relation) {
-      throw new Error(loadError?.message ?? "Relation not found.")
-    }
+    const graphRelationId = parseUuid(formData, "relation_id", "Relation")
+    const relation = await loadPageSectionSourceRelation(
+      supabase,
+      graphRelationId,
+    )
 
     const { error } = await supabase
       .from("page_sections")
       .delete()
-      .eq("id", relationId)
+      .eq("id", relation.id)
 
     if (error) throw new Error(error.message)
 
@@ -289,7 +342,7 @@ export async function updateSectionEntityRelationAction(formData: FormData) {
   try {
     await requireCmsAdmin(redirectTo)
     const supabase = await createClient()
-    const relationId = parseUuid(formData, "relation_id", "Relation")
+    const graphRelationId = parseUuid(formData, "relation_id", "Relation")
     const update: SectionEntityUpdate = {
       sort_order: parseSortOrder(formData),
     }
@@ -310,20 +363,15 @@ export async function updateSectionEntityRelationAction(formData: FormData) {
       update.props = parseProps(formData)
     }
 
-    const { data: relation, error: loadError } = await supabase
-      .from("section_entities")
-      .select("section_id, entity_id")
-      .eq("id", relationId)
-      .maybeSingle()
-
-    if (loadError || !relation) {
-      throw new Error(loadError?.message ?? "Relation not found.")
-    }
+    const relation = await loadSectionEntitySourceRelation(
+      supabase,
+      graphRelationId,
+    )
 
     const { error } = await supabase
       .from("section_entities")
       .update(update)
-      .eq("id", relationId)
+      .eq("id", relation.id)
 
     if (error) throw new Error(error.message)
 
@@ -343,7 +391,7 @@ export async function updateSectionEntityRelationInlineAction(
   try {
     await requireCmsAdmin("/ponix/relations")
     const supabase = await createClient()
-    const relationId = parseUuid(formData, "relation_id", "Relation")
+    const graphRelationId = parseUuid(formData, "relation_id", "Relation")
     const update: SectionEntityUpdate = {
       sort_order: parseSortOrder(formData),
     }
@@ -364,20 +412,15 @@ export async function updateSectionEntityRelationInlineAction(
       update.props = parseProps(formData)
     }
 
-    const { data: relation, error: loadError } = await supabase
-      .from("section_entities")
-      .select("section_id, entity_id")
-      .eq("id", relationId)
-      .maybeSingle()
-
-    if (loadError || !relation) {
-      throw new Error(loadError?.message ?? "Relation not found.")
-    }
+    const relation = await loadSectionEntitySourceRelation(
+      supabase,
+      graphRelationId,
+    )
 
     const { error } = await supabase
       .from("section_entities")
       .update(update)
-      .eq("id", relationId)
+      .eq("id", relation.id)
 
     if (error) throw new Error(error.message)
 
@@ -398,10 +441,10 @@ export async function updateSectionEntityRelationInlineAction(
 
 export async function reorderSectionEntityRelationsAction({
   sectionId,
-  relationIds,
+  graphRelationIds,
 }: {
   sectionId: string
-  relationIds: string[]
+  graphRelationIds: string[]
 }): Promise<ActionResult> {
   try {
     await requireCmsAdmin("/ponix/relations")
@@ -410,16 +453,32 @@ export async function reorderSectionEntityRelationsAction({
       throw new Error("Section is required.")
     }
 
-    const orderedIds = relationIds.filter((id) => uuidPattern.test(id))
-    if (orderedIds.length !== relationIds.length || orderedIds.length === 0) {
+    const orderedIds = graphRelationIds.filter((id) => uuidPattern.test(id))
+    if (
+      orderedIds.length !== graphRelationIds.length ||
+      new Set(orderedIds).size !== orderedIds.length ||
+      orderedIds.length === 0
+    ) {
       throw new Error("Relation order is invalid.")
     }
 
     const supabase = await createClient()
+    const { data: sectionShadow, error: shadowError } = await supabase
+      .from("entities")
+      .select("id")
+      .eq("source_table", "sections")
+      .eq("source_id", sectionId)
+      .maybeSingle()
+
+    if (shadowError || !sectionShadow) {
+      throw new Error(shadowError?.message ?? "Section graph entity not found.")
+    }
+
     const { data: relations, error: loadError } = await supabase
-      .from("section_entities")
-      .select("id, section_id, entity_id")
-      .eq("section_id", sectionId)
+      .from("entity_relations")
+      .select("id, source_id, to_entity_id")
+      .eq("source_table", "section_entities")
+      .eq("from_entity_id", sectionShadow.id)
       .in("id", orderedIds)
 
     if (loadError) {
@@ -431,7 +490,18 @@ export async function reorderSectionEntityRelationsAction({
       throw new Error("Some relations do not belong to this section.")
     }
 
-    const updates = orderedIds.map((relationId, index) =>
+    const sourceIdByGraphId = new Map(
+      (relations ?? []).map((relation) => [relation.id, relation.source_id]),
+    )
+    const orderedSourceIds = orderedIds
+      .map((graphRelationId) => sourceIdByGraphId.get(graphRelationId))
+      .filter((id): id is string => Boolean(id))
+
+    if (orderedSourceIds.length !== orderedIds.length) {
+      throw new Error("Some graph relations are missing source rows.")
+    }
+
+    const updates = orderedSourceIds.map((relationId, index) =>
       supabase
         .from("section_entities")
         .update({ sort_order: (index + 1) * 10 } satisfies SectionEntityUpdate)
@@ -447,7 +517,7 @@ export async function reorderSectionEntityRelationsAction({
 
     revalidateRelationSurfaces([
       `/ponix/sections/${sectionId}`,
-      ...(relations ?? []).map((relation) => `/ponix/entities/${relation.entity_id}`),
+      ...(relations ?? []).map((relation) => `/ponix/entities/${relation.to_entity_id}`),
     ])
 
     return { ok: true }
@@ -466,21 +536,16 @@ export async function deleteSectionEntityRelationAction(formData: FormData) {
   try {
     await requireCmsAdmin(redirectTo)
     const supabase = await createClient()
-    const relationId = parseUuid(formData, "relation_id", "Relation")
-    const { data: relation, error: loadError } = await supabase
-      .from("section_entities")
-      .select("section_id, entity_id")
-      .eq("id", relationId)
-      .maybeSingle()
-
-    if (loadError || !relation) {
-      throw new Error(loadError?.message ?? "Relation not found.")
-    }
+    const graphRelationId = parseUuid(formData, "relation_id", "Relation")
+    const relation = await loadSectionEntitySourceRelation(
+      supabase,
+      graphRelationId,
+    )
 
     const { error } = await supabase
       .from("section_entities")
       .delete()
-      .eq("id", relationId)
+      .eq("id", relation.id)
 
     if (error) throw new Error(error.message)
 

--- a/docs/content-graph.md
+++ b/docs/content-graph.md
@@ -55,10 +55,11 @@ Current PONIX contract:
   bridge rows.
 - Those bridge rows expose both the `entity_relations.id` and the legacy
   `source_id`.
-- Routine CMS writes still target `page_sections` and `section_entities`; bridge
-  triggers mirror those writes back into `entity_relations`.
-- Code that mutates page or section composition must pass the legacy
-  `source_id`, not the graph row id.
+- Routine CMS writes resolve `entity_relations.id` back to `source_id`, then
+  target `page_sections` and `section_entities`; bridge triggers mirror those
+  writes back into `entity_relations`.
+- Code that mutates page or section composition must pass the graph relation id,
+  not the legacy `source_id`.
 
 ## Tables
 


### PR DESCRIPTION
## Summary
- Submit graph relation ids from PONIX relation forms and composer DnD instead of legacy source ids.
- Resolve graph bridge rows server-side before mutating page_sections / section_entities during the transition.
- Preserve redirect success handling with Next unstable_rethrow and document the current graph-write contract.

## Verification
- pnpm exec tsc --noEmit
- pnpm run lint
- git diff --check
- pnpm run qa:content-graph
- pnpm run build
- Reversible PONIX UI write: home-stage-highlights sort_order 30 -> 31 -> 30, verified source and graph rows via Supabase MCP.
- Public route smoke: /, /history, /performances, /photos, /videos all 200.
- Authenticated canvas route smoke: home/history/performances/photos/videos all 200.

Closes #76