### PR TITLE
Make composition writes graph-primary

### DIFF
--- a/app/ponix/relations/actions.ts
+++ b/app/ponix/relations/actions.ts
@@ -8,19 +8,33 @@ import { PUBLIC_CONTENT_CACHE_TAG } from "@/lib/data/public-cache"
 import { createClient } from "@/lib/supabase/server"
 import type { Database, Json } from "@/lib/supabase/types"
 
-type PageSectionInsert =
-  Database["public"]["Tables"]["page_sections"]["Insert"]
-type PageSectionUpdate =
-  Database["public"]["Tables"]["page_sections"]["Update"]
-type SectionEntityInsert =
-  Database["public"]["Tables"]["section_entities"]["Insert"]
-type SectionEntityUpdate =
-  Database["public"]["Tables"]["section_entities"]["Update"]
 type EntityRelationInsert =
   Database["public"]["Tables"]["entity_relations"]["Insert"]
 type EntityRelationUpdate =
   Database["public"]["Tables"]["entity_relations"]["Update"]
 type ServerSupabaseClient = Awaited<ReturnType<typeof createClient>>
+
+type SourceEntityLink = {
+  source_table: string | null
+  source_id: string | null
+}
+
+type PageSectionGraphRelation = {
+  id: string
+  from_entity_id: string
+  to_entity_id: string
+  source_id: string | null
+  fromEntity?: SourceEntityLink | null
+  toEntity?: SourceEntityLink | null
+}
+
+type SectionEntityGraphRelation = {
+  id: string
+  from_entity_id: string
+  to_entity_id: string
+  source_id: string | null
+  fromEntity?: SourceEntityLink | null
+}
 
 type ActionResult =
   | {
@@ -137,88 +151,166 @@ function revalidateRelationSurfaces(paths: string[]) {
   }
 }
 
-async function loadPageSectionSourceRelation(
+function sourceIdFromLink(
+  link: SourceEntityLink | null | undefined,
+  sourceTable: "pages" | "sections",
+) {
+  return link?.source_table === sourceTable ? link.source_id : null
+}
+
+async function loadShadowEntityId({
+  supabase,
+  sourceTable,
+  sourceId,
+  label,
+}: {
+  supabase: ServerSupabaseClient
+  sourceTable: "pages" | "sections"
+  sourceId: string
+  label: string
+}) {
+  const { data, error } = await supabase
+    .from("entities")
+    .select("id")
+    .eq("source_table", sourceTable)
+    .eq("source_id", sourceId)
+    .maybeSingle()
+
+  if (error || !data?.id) {
+    throw new Error(error?.message ?? `${label} graph entity not found.`)
+  }
+
+  return data.id
+}
+
+async function loadPageSectionGraphRelation(
   supabase: ServerSupabaseClient,
   graphRelationId: string,
 ) {
-  const { data: bridge, error: bridgeError } = await supabase
+  const { data, error } = await supabase
     .from("entity_relations")
-    .select("source_id")
+    .select(
+      `
+        id,
+        from_entity_id,
+        to_entity_id,
+        source_id,
+        fromEntity:entities!entity_relations_from_entity_id_fkey(source_table, source_id),
+        toEntity:entities!entity_relations_to_entity_id_fkey(source_table, source_id)
+      `,
+    )
     .eq("id", graphRelationId)
     .eq("source_table", "page_sections")
     .maybeSingle()
 
-  if (bridgeError || !bridge?.source_id) {
-    throw new Error(
-      bridgeError?.message ?? "Page section graph relation not found.",
-    )
+  const relation = data as unknown as PageSectionGraphRelation | null
+  const pageId = sourceIdFromLink(relation?.fromEntity, "pages")
+  const sectionId = sourceIdFromLink(relation?.toEntity, "sections")
+
+  if (error || !relation || !pageId || !sectionId) {
+    throw new Error(error?.message ?? "Page section graph relation not found.")
   }
 
-  const { data: relation, error: relationError } = await supabase
-    .from("page_sections")
-    .select("id, page_id, section_id")
-    .eq("id", bridge.source_id)
-    .maybeSingle()
-
-  if (relationError || !relation) {
-    throw new Error(
-      relationError?.message ?? "Page section source row not found.",
-    )
+  return {
+    ...relation,
+    pageId,
+    sectionId,
   }
-
-  return relation
 }
 
-async function loadSectionEntitySourceRelation(
+async function loadSectionEntityGraphRelation(
   supabase: ServerSupabaseClient,
   graphRelationId: string,
 ) {
-  const { data: bridge, error: bridgeError } = await supabase
+  const { data, error } = await supabase
     .from("entity_relations")
-    .select("source_id")
+    .select(
+      `
+        id,
+        from_entity_id,
+        to_entity_id,
+        source_id,
+        fromEntity:entities!entity_relations_from_entity_id_fkey(source_table, source_id)
+      `,
+    )
     .eq("id", graphRelationId)
     .eq("source_table", "section_entities")
     .maybeSingle()
 
-  if (bridgeError || !bridge?.source_id) {
-    throw new Error(bridgeError?.message ?? "Section graph relation not found.")
+  const relation = data as unknown as SectionEntityGraphRelation | null
+  const sectionId = sourceIdFromLink(relation?.fromEntity, "sections")
+
+  if (error || !relation || !sectionId) {
+    throw new Error(error?.message ?? "Section graph relation not found.")
   }
 
-  const { data: relation, error: relationError } = await supabase
-    .from("section_entities")
-    .select("id, section_id, entity_id")
-    .eq("id", bridge.source_id)
-    .maybeSingle()
-
-  if (relationError || !relation) {
-    throw new Error(relationError?.message ?? "Section source row not found.")
+  return {
+    ...relation,
+    sectionId,
+    entityId: relation.to_entity_id,
   }
-
-  return relation
 }
 
 export async function addPageSectionRelationAction(formData: FormData) {
   const redirectTo = safeRedirectPath(formData)
 
   try {
-    await requireCmsAdmin(redirectTo)
+    const admin = await requireCmsAdmin(redirectTo)
     const supabase = await createClient()
-    const payload: PageSectionInsert = {
-      page_id: parseUuid(formData, "page_id", "Page"),
-      section_id: parseUuid(formData, "section_id", "Section"),
+    const pageId = parseUuid(formData, "page_id", "Page")
+    const sectionId = parseUuid(formData, "section_id", "Section")
+    const [pageEntityId, sectionEntityId] = await Promise.all([
+      loadShadowEntityId({
+        supabase,
+        sourceTable: "pages",
+        sourceId: pageId,
+        label: "Page",
+      }),
+      loadShadowEntityId({
+        supabase,
+        sourceTable: "sections",
+        sourceId: sectionId,
+        label: "Section",
+      }),
+    ])
+    const payload: EntityRelationInsert = {
+      from_entity_id: pageEntityId,
+      to_entity_id: sectionEntityId,
+      schema_key: "relation/page-section/v1",
+      relation_type: "contains_section",
+      slot: "sections",
       sort_order: parseSortOrder(formData),
+      props: {},
+      source_table: "page_sections",
+      created_by_member_id: admin.id,
     }
-    const { error } = await supabase
-      .from("page_sections")
-      .upsert(payload, {
-        onConflict: "page_id,section_id",
-      })
+    const { data: existing, error: existingError } = await supabase
+      .from("entity_relations")
+      .select("id")
+      .eq("source_table", "page_sections")
+      .eq("from_entity_id", pageEntityId)
+      .eq("to_entity_id", sectionEntityId)
+      .eq("relation_type", "contains_section")
+      .eq("slot", "sections")
+      .maybeSingle()
+
+    if (existingError) throw new Error(existingError.message)
+
+    const { error } = existing
+      ? await supabase
+          .from("entity_relations")
+          .update({
+            sort_order: payload.sort_order,
+            props: payload.props,
+          } satisfies EntityRelationUpdate)
+          .eq("id", existing.id)
+      : await supabase.from("entity_relations").insert(payload)
 
     if (error) throw new Error(error.message)
 
     revalidateRelationSurfaces([
-      `/ponix/pages/${payload.page_id}`,
-      `/ponix/sections/${payload.section_id}`,
+      `/ponix/pages/${pageId}`,
+      `/ponix/sections/${sectionId}`,
     ])
     relationSuccess(redirectTo, "Page section saved.")
   } catch (error) {
@@ -233,24 +325,24 @@ export async function updatePageSectionRelationAction(formData: FormData) {
     await requireCmsAdmin(redirectTo)
     const supabase = await createClient()
     const graphRelationId = parseUuid(formData, "relation_id", "Relation")
-    const update: PageSectionUpdate = {
+    const update: EntityRelationUpdate = {
       sort_order: parseSortOrder(formData),
     }
-    const relation = await loadPageSectionSourceRelation(
+    const relation = await loadPageSectionGraphRelation(
       supabase,
       graphRelationId,
     )
 
     const { error } = await supabase
-      .from("page_sections")
+      .from("entity_relations")
       .update(update)
       .eq("id", relation.id)
 
     if (error) throw new Error(error.message)
 
     revalidateRelationSurfaces([
-      `/ponix/pages/${relation.page_id}`,
-      `/ponix/sections/${relation.section_id}`,
+      `/ponix/pages/${relation.pageId}`,
+      `/ponix/sections/${relation.sectionId}`,
     ])
     relationSuccess(redirectTo, "Page section order saved.")
   } catch (error) {
@@ -265,21 +357,21 @@ export async function deletePageSectionRelationAction(formData: FormData) {
     await requireCmsAdmin(redirectTo)
     const supabase = await createClient()
     const graphRelationId = parseUuid(formData, "relation_id", "Relation")
-    const relation = await loadPageSectionSourceRelation(
+    const relation = await loadPageSectionGraphRelation(
       supabase,
       graphRelationId,
     )
 
     const { error } = await supabase
-      .from("page_sections")
+      .from("entity_relations")
       .delete()
       .eq("id", relation.id)
 
     if (error) throw new Error(error.message)
 
     revalidateRelationSurfaces([
-      `/ponix/pages/${relation.page_id}`,
-      `/ponix/sections/${relation.section_id}`,
+      `/ponix/pages/${relation.pageId}`,
+      `/ponix/sections/${relation.sectionId}`,
     ])
     relationSuccess(redirectTo, "Page section removed.")
   } catch (error) {
@@ -291,21 +383,37 @@ export async function addSectionEntityRelationAction(formData: FormData) {
   const redirectTo = safeRedirectPath(formData)
 
   try {
-    await requireCmsAdmin(redirectTo)
+    const admin = await requireCmsAdmin(redirectTo)
     const supabase = await createClient()
-    const payload: SectionEntityInsert = {
-      section_id: parseUuid(formData, "section_id", "Section"),
-      entity_id: parseUuid(formData, "entity_id", "Entity"),
-      relation_type: parseText(formData, "relation_type", "Relation type"),
-      slot: stringField(formData, "slot") || "default",
+    const sectionId = parseUuid(formData, "section_id", "Section")
+    const entityId = parseUuid(formData, "entity_id", "Entity")
+    const relationType = parseText(formData, "relation_type", "Relation type")
+    const slot = stringField(formData, "slot") || "default"
+    const sectionEntityId = await loadShadowEntityId({
+      supabase,
+      sourceTable: "sections",
+      sourceId: sectionId,
+      label: "Section",
+    })
+    const payload: EntityRelationInsert = {
+      from_entity_id: sectionEntityId,
+      to_entity_id: entityId,
+      schema_key: "relation/section-entity/v1",
+      relation_type: relationType,
+      slot,
       sort_order: parseSortOrder(formData),
       props: parseProps(formData),
+      source_table: "section_entities",
+      created_by_member_id: admin.id,
     }
     const { data: existing, error: existingError } = await supabase
-      .from("section_entities")
+      .from("entity_relations")
       .select("id")
-      .eq("section_id", payload.section_id)
-      .eq("entity_id", payload.entity_id)
+      .eq("source_table", "section_entities")
+      .eq("from_entity_id", payload.from_entity_id)
+      .eq("to_entity_id", payload.to_entity_id)
+      .eq("relation_type", relationType)
+      .eq("slot", slot)
       .order("sort_order", { ascending: true })
       .limit(1)
       .maybeSingle()
@@ -314,21 +422,21 @@ export async function addSectionEntityRelationAction(formData: FormData) {
 
     const { error } = existing
       ? await supabase
-          .from("section_entities")
+          .from("entity_relations")
           .update({
             relation_type: payload.relation_type,
             slot: payload.slot,
             sort_order: payload.sort_order,
             props: payload.props,
-          } satisfies SectionEntityUpdate)
+          } satisfies EntityRelationUpdate)
           .eq("id", existing.id)
-      : await supabase.from("section_entities").insert(payload)
+      : await supabase.from("entity_relations").insert(payload)
 
     if (error) throw new Error(error.message)
 
     revalidateRelationSurfaces([
-      `/ponix/sections/${payload.section_id}`,
-      `/ponix/entities/${payload.entity_id}`,
+      `/ponix/sections/${sectionId}`,
+      `/ponix/entities/${entityId}`,
     ])
     relationSuccess(redirectTo, "Section relation saved.")
   } catch (error) {
@@ -343,7 +451,7 @@ export async function updateSectionEntityRelationAction(formData: FormData) {
     await requireCmsAdmin(redirectTo)
     const supabase = await createClient()
     const graphRelationId = parseUuid(formData, "relation_id", "Relation")
-    const update: SectionEntityUpdate = {
+    const update: EntityRelationUpdate = {
       sort_order: parseSortOrder(formData),
     }
 
@@ -363,21 +471,21 @@ export async function updateSectionEntityRelationAction(formData: FormData) {
       update.props = parseProps(formData)
     }
 
-    const relation = await loadSectionEntitySourceRelation(
+    const relation = await loadSectionEntityGraphRelation(
       supabase,
       graphRelationId,
     )
 
     const { error } = await supabase
-      .from("section_entities")
+      .from("entity_relations")
       .update(update)
       .eq("id", relation.id)
 
     if (error) throw new Error(error.message)
 
     revalidateRelationSurfaces([
-      `/ponix/sections/${relation.section_id}`,
-      `/ponix/entities/${relation.entity_id}`,
+      `/ponix/sections/${relation.sectionId}`,
+      `/ponix/entities/${relation.entityId}`,
     ])
     relationSuccess(redirectTo, "Section relation saved.")
   } catch (error) {
@@ -392,7 +500,7 @@ export async function updateSectionEntityRelationInlineAction(
     await requireCmsAdmin("/ponix/relations")
     const supabase = await createClient()
     const graphRelationId = parseUuid(formData, "relation_id", "Relation")
-    const update: SectionEntityUpdate = {
+    const update: EntityRelationUpdate = {
       sort_order: parseSortOrder(formData),
     }
 
@@ -412,21 +520,21 @@ export async function updateSectionEntityRelationInlineAction(
       update.props = parseProps(formData)
     }
 
-    const relation = await loadSectionEntitySourceRelation(
+    const relation = await loadSectionEntityGraphRelation(
       supabase,
       graphRelationId,
     )
 
     const { error } = await supabase
-      .from("section_entities")
+      .from("entity_relations")
       .update(update)
       .eq("id", relation.id)
 
     if (error) throw new Error(error.message)
 
     revalidateRelationSurfaces([
-      `/ponix/sections/${relation.section_id}`,
-      `/ponix/entities/${relation.entity_id}`,
+      `/ponix/sections/${relation.sectionId}`,
+      `/ponix/entities/${relation.entityId}`,
     ])
 
     return { ok: true }
@@ -476,7 +584,7 @@ export async function reorderSectionEntityRelationsAction({
 
     const { data: relations, error: loadError } = await supabase
       .from("entity_relations")
-      .select("id, source_id, to_entity_id")
+      .select("id, to_entity_id")
       .eq("source_table", "section_entities")
       .eq("from_entity_id", sectionShadow.id)
       .in("id", orderedIds)
@@ -490,23 +598,13 @@ export async function reorderSectionEntityRelationsAction({
       throw new Error("Some relations do not belong to this section.")
     }
 
-    const sourceIdByGraphId = new Map(
-      (relations ?? []).map((relation) => [relation.id, relation.source_id]),
-    )
-    const orderedSourceIds = orderedIds
-      .map((graphRelationId) => sourceIdByGraphId.get(graphRelationId))
-      .filter((id): id is string => Boolean(id))
-
-    if (orderedSourceIds.length !== orderedIds.length) {
-      throw new Error("Some graph relations are missing source rows.")
-    }
-
-    const updates = orderedSourceIds.map((relationId, index) =>
+    const updates = orderedIds.map((relationId, index) =>
       supabase
-        .from("section_entities")
-        .update({ sort_order: (index + 1) * 10 } satisfies SectionEntityUpdate)
+        .from("entity_relations")
+        .update({ sort_order: (index + 1) * 10 } satisfies EntityRelationUpdate)
         .eq("id", relationId)
-        .eq("section_id", sectionId),
+        .eq("source_table", "section_entities")
+        .eq("from_entity_id", sectionShadow.id),
     )
     const results = await Promise.all(updates)
     const updateError = results.find((result) => result.error)?.error
@@ -537,21 +635,21 @@ export async function deleteSectionEntityRelationAction(formData: FormData) {
     await requireCmsAdmin(redirectTo)
     const supabase = await createClient()
     const graphRelationId = parseUuid(formData, "relation_id", "Relation")
-    const relation = await loadSectionEntitySourceRelation(
+    const relation = await loadSectionEntityGraphRelation(
       supabase,
       graphRelationId,
     )
 
     const { error } = await supabase
-      .from("section_entities")
+      .from("entity_relations")
       .delete()
       .eq("id", relation.id)
 
     if (error) throw new Error(error.message)
 
     revalidateRelationSurfaces([
-      `/ponix/sections/${relation.section_id}`,
-      `/ponix/entities/${relation.entity_id}`,
+      `/ponix/sections/${relation.sectionId}`,
+      `/ponix/entities/${relation.entityId}`,
     ])
     relationSuccess(redirectTo, "Section relation removed.")
   } catch (error) {

--- a/docs/content-graph.md
+++ b/docs/content-graph.md
@@ -41,10 +41,10 @@ The bridge uses `source_table` and `source_id` columns on `entities` and
 Sync triggers keep the shadow graph updated while the app still writes through
 the current CMS screens.
 
-Until the public loaders and PONIX editors are explicitly migrated, the bridge
-is a compatibility read model, not the only source of truth. Do not remove
-`pages`, `sections`, `page_sections`, or `section_entities` until all renderers,
-forms, audits, migrations, and generated types have moved to the entity graph.
+The bridge is now the primary runtime composition path. The legacy composition
+tables remain compatibility mirrors. Do not remove `pages`, `sections`,
+`page_sections`, or `section_entities` until all forms, audits, migrations, and
+generated types have moved to the entity graph.
 
 Current PONIX contract:
 
@@ -55,9 +55,9 @@ Current PONIX contract:
   bridge rows.
 - Those bridge rows expose both the `entity_relations.id` and the legacy
   `source_id`.
-- Routine CMS writes resolve `entity_relations.id` back to `source_id`, then
-  target `page_sections` and `section_entities`; bridge triggers mirror those
-  writes back into `entity_relations`.
+- Routine CMS composition writes target `entity_relations`; graph-to-legacy
+  triggers mirror those writes back into `page_sections` and
+  `section_entities`.
 - Code that mutates page or section composition must pass the graph relation id,
   not the legacy `source_id`.
 

--- a/supabase/migrations/20260508000043_graph_primary_composition_writes.sql
+++ b/supabase/migrations/20260508000043_graph_primary_composition_writes.sql
@@ -1,0 +1,410 @@
+-- Bremen — make composition relation writes graph-primary.
+--
+-- Runtime reads already use entity_relations. This migration keeps the legacy
+-- page_sections / section_entities tables as compatibility mirrors, but allows
+-- direct writes to the graph bridge rows without creating trigger recursion.
+
+create or replace function private.sync_page_section_relation_bridge()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, private
+as $$
+declare
+  page_entity_id uuid;
+  section_entity_id uuid;
+begin
+  if pg_trigger_depth() > 1 then
+    if tg_op = 'DELETE' then
+      return old;
+    end if;
+
+    return new;
+  end if;
+
+  if tg_op = 'DELETE' then
+    delete from public.entity_relations
+    where source_table = 'page_sections'
+      and source_id = old.id;
+    return old;
+  end if;
+
+  select id into page_entity_id
+  from public.entities
+  where source_table = 'pages'
+    and source_id = new.page_id;
+
+  select id into section_entity_id
+  from public.entities
+  where source_table = 'sections'
+    and source_id = new.section_id;
+
+  if page_entity_id is null or section_entity_id is null then
+    raise exception 'Cannot mirror page_sections %, missing page or section shadow entity', new.id;
+  end if;
+
+  update public.entity_relations relation_ref
+  set from_entity_id = page_entity_id,
+      to_entity_id = section_entity_id,
+      schema_key = 'relation/page-section/v1',
+      relation_type = 'contains_section',
+      slot = 'sections',
+      sort_order = new.sort_order,
+      props = new.props,
+      updated_at = now()
+  where relation_ref.source_table = 'page_sections'
+    and relation_ref.source_id = new.id;
+
+  if found then
+    return new;
+  end if;
+
+  insert into public.entity_relations (
+    from_entity_id,
+    to_entity_id,
+    schema_key,
+    relation_type,
+    slot,
+    sort_order,
+    props,
+    source_table,
+    source_id,
+    created_at,
+    updated_at
+  )
+  values (
+    page_entity_id,
+    section_entity_id,
+    'relation/page-section/v1',
+    'contains_section',
+    'sections',
+    new.sort_order,
+    new.props,
+    'page_sections',
+    new.id,
+    new.created_at,
+    new.updated_at
+  );
+
+  return new;
+end;
+$$;
+
+revoke all on function private.sync_page_section_relation_bridge() from public;
+
+create or replace function private.sync_section_entity_relation_bridge()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, private
+as $$
+declare
+  section_entity_id uuid;
+begin
+  if pg_trigger_depth() > 1 then
+    if tg_op = 'DELETE' then
+      return old;
+    end if;
+
+    return new;
+  end if;
+
+  if tg_op = 'DELETE' then
+    delete from public.entity_relations
+    where source_table = 'section_entities'
+      and source_id = old.id;
+    return old;
+  end if;
+
+  select id into section_entity_id
+  from public.entities
+  where source_table = 'sections'
+    and source_id = new.section_id;
+
+  if section_entity_id is null then
+    raise exception 'Cannot mirror section_entities %, missing section shadow entity', new.id;
+  end if;
+
+  update public.entity_relations relation_ref
+  set from_entity_id = section_entity_id,
+      to_entity_id = new.entity_id,
+      schema_key = 'relation/section-entity/v1',
+      relation_type = new.relation_type,
+      slot = new.slot,
+      sort_order = new.sort_order,
+      props = new.props,
+      updated_at = now()
+  where relation_ref.source_table = 'section_entities'
+    and relation_ref.source_id = new.id;
+
+  if found then
+    return new;
+  end if;
+
+  insert into public.entity_relations (
+    from_entity_id,
+    to_entity_id,
+    schema_key,
+    relation_type,
+    slot,
+    sort_order,
+    props,
+    source_table,
+    source_id,
+    created_at,
+    updated_at
+  )
+  values (
+    section_entity_id,
+    new.entity_id,
+    'relation/section-entity/v1',
+    new.relation_type,
+    new.slot,
+    new.sort_order,
+    new.props,
+    'section_entities',
+    new.id,
+    new.created_at,
+    new.updated_at
+  );
+
+  return new;
+end;
+$$;
+
+revoke all on function private.sync_section_entity_relation_bridge() from public;
+
+create or replace function private.sync_entity_relation_source_bridge()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, private
+as $$
+declare
+  mapped_page_id uuid;
+  mapped_section_id uuid;
+  mapped_source_id uuid;
+begin
+  if pg_trigger_depth() > 1 then
+    if tg_op = 'DELETE' then
+      return old;
+    end if;
+
+    return new;
+  end if;
+
+  if tg_op = 'DELETE' then
+    if old.source_table = 'page_sections' and old.source_id is not null then
+      delete from public.page_sections
+      where id = old.source_id;
+    elsif old.source_table = 'section_entities' and old.source_id is not null then
+      delete from public.section_entities
+      where id = old.source_id;
+    end if;
+
+    return old;
+  end if;
+
+  if tg_op = 'UPDATE'
+    and old.source_table in ('page_sections', 'section_entities')
+    and old.source_id is not null
+    and (
+      new.source_table is distinct from old.source_table
+      or new.source_id is distinct from old.source_id
+    )
+  then
+    if old.source_table = 'page_sections' then
+      delete from public.page_sections
+      where id = old.source_id;
+    else
+      delete from public.section_entities
+      where id = old.source_id;
+    end if;
+  end if;
+
+  if new.source_table is null then
+    return new;
+  end if;
+
+  if new.source_table = 'page_sections' then
+    if new.schema_key <> 'relation/page-section/v1' then
+      raise exception 'Page-section graph relations must use schema_key relation/page-section/v1';
+    end if;
+
+    if new.relation_type <> 'contains_section' or new.slot <> 'sections' then
+      raise exception 'Page-section graph relations must use contains_section / sections';
+    end if;
+
+    select source_id into mapped_page_id
+    from public.entities
+    where id = new.from_entity_id
+      and source_table = 'pages';
+
+    select source_id into mapped_section_id
+    from public.entities
+    where id = new.to_entity_id
+      and source_table = 'sections';
+
+    if mapped_page_id is null or mapped_section_id is null then
+      raise exception 'Cannot mirror graph relation %, missing page or section source', new.id;
+    end if;
+
+    if new.source_id is null then
+      insert into public.page_sections (
+        page_id,
+        section_id,
+        sort_order,
+        props
+      )
+      values (
+        mapped_page_id,
+        mapped_section_id,
+        new.sort_order,
+        coalesce(new.props, '{}'::jsonb)
+      )
+      on conflict (page_id, section_id) do update
+      set sort_order = excluded.sort_order,
+          props = excluded.props
+      returning id into mapped_source_id;
+    else
+      update public.page_sections
+      set page_id = mapped_page_id,
+          section_id = mapped_section_id,
+          sort_order = new.sort_order,
+          props = coalesce(new.props, '{}'::jsonb)
+      where id = new.source_id
+      returning id into mapped_source_id;
+
+      if mapped_source_id is null then
+        insert into public.page_sections (
+          id,
+          page_id,
+          section_id,
+          sort_order,
+          props
+        )
+        values (
+          new.source_id,
+          mapped_page_id,
+          mapped_section_id,
+          new.sort_order,
+          coalesce(new.props, '{}'::jsonb)
+        )
+        on conflict (page_id, section_id) do update
+        set sort_order = excluded.sort_order,
+            props = excluded.props
+        returning id into mapped_source_id;
+      end if;
+    end if;
+
+    new.source_id := mapped_source_id;
+    return new;
+  end if;
+
+  if new.source_table = 'section_entities' then
+    if new.schema_key <> 'relation/section-entity/v1' then
+      raise exception 'Section-entity graph relations must use schema_key relation/section-entity/v1';
+    end if;
+
+    select source_id into mapped_section_id
+    from public.entities
+    where id = new.from_entity_id
+      and source_table = 'sections';
+
+    if mapped_section_id is null then
+      raise exception 'Cannot mirror graph relation %, missing section source', new.id;
+    end if;
+
+    if new.source_id is null then
+      insert into public.section_entities (
+        section_id,
+        entity_id,
+        relation_type,
+        slot,
+        sort_order,
+        props
+      )
+      values (
+        mapped_section_id,
+        new.to_entity_id,
+        new.relation_type,
+        new.slot,
+        new.sort_order,
+        coalesce(new.props, '{}'::jsonb)
+      )
+      on conflict (section_id, entity_id, relation_type, slot) do update
+      set sort_order = excluded.sort_order,
+          props = excluded.props
+      returning id into mapped_source_id;
+    else
+      update public.section_entities
+      set section_id = mapped_section_id,
+          entity_id = new.to_entity_id,
+          relation_type = new.relation_type,
+          slot = new.slot,
+          sort_order = new.sort_order,
+          props = coalesce(new.props, '{}'::jsonb)
+      where id = new.source_id
+      returning id into mapped_source_id;
+
+      if mapped_source_id is null then
+        insert into public.section_entities (
+          id,
+          section_id,
+          entity_id,
+          relation_type,
+          slot,
+          sort_order,
+          props
+        )
+        values (
+          new.source_id,
+          mapped_section_id,
+          new.to_entity_id,
+          new.relation_type,
+          new.slot,
+          new.sort_order,
+          coalesce(new.props, '{}'::jsonb)
+        )
+        on conflict (section_id, entity_id, relation_type, slot) do update
+        set sort_order = excluded.sort_order,
+            props = excluded.props
+        returning id into mapped_source_id;
+      end if;
+    end if;
+
+    new.source_id := mapped_source_id;
+    return new;
+  end if;
+
+  return new;
+end;
+$$;
+
+revoke all on function private.sync_entity_relation_source_bridge() from public;
+
+drop trigger if exists entity_relations_source_bridge on public.entity_relations;
+drop trigger if exists entity_relations_source_bridge_insert on public.entity_relations;
+drop trigger if exists entity_relations_source_bridge_update on public.entity_relations;
+drop trigger if exists entity_relations_source_bridge_delete on public.entity_relations;
+
+create trigger entity_relations_source_bridge_insert
+  before insert on public.entity_relations
+  for each row
+  when (new.source_table in ('page_sections', 'section_entities'))
+  execute function private.sync_entity_relation_source_bridge();
+
+create trigger entity_relations_source_bridge_update
+  before update on public.entity_relations
+  for each row
+  when (
+    new.source_table in ('page_sections', 'section_entities')
+    or old.source_table in ('page_sections', 'section_entities')
+  )
+  execute function private.sync_entity_relation_source_bridge();
+
+create trigger entity_relations_source_bridge_delete
+  before delete on public.entity_relations
+  for each row
+  when (old.source_table in ('page_sections', 'section_entities'))
+  execute function private.sync_entity_relation_source_bridge();


### PR DESCRIPTION
## Summary
- Move CMS page-section and section-entity composition writes to entity_relations.
- Add graph-to-legacy bridge triggers so existing public loaders and compatibility tables stay in sync.
- Document graph-primary composition writes and legacy mirror behavior.

## Verification
- Supabase migration graph_primary_composition_writes applied and listed remotely.
- Reversible PONIX UI write verified: home-stage-highlights sort_order 30 -> 31 -> 30, graph and legacy rows stayed synced.
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm run qa:content-graph
- Public route smoke: /, /history, /performances, /photos, /videos all 200
- PONIX canvas route smoke for home/history/performances/photos/videos all 200 in dev logs
- pnpm run build

## Notes
- Supabase advisors still report existing Auth leaked-password-protection and performance lints; no migration-specific blocker found.
- No generated Supabase type update is needed because this does not add or change public table/view/function signatures.

Closes #80