### PR TITLE
Use DB registry metadata in PONIX editors

### DIFF
--- a/app/ponix/_components/cms-detail.tsx
+++ b/app/ponix/_components/cms-detail.tsx
@@ -22,10 +22,10 @@ import {
 import type { CmsAuditEventList } from "@/lib/cms/audit"
 import type { CmsContentDetail } from "@/lib/cms/content"
 import {
-  getCmsSchema,
   type CmsFieldDefinition,
   type CmsFieldSource,
 } from "@/lib/cms/schema-registry"
+import { loadCmsSchema } from "@/lib/cms/schema-registry.server"
 
 import { CmsAuditTrailCard } from "./cms-audit-card"
 import { formatCmsDate, PublishBadge, SchemaBadge } from "./cms-list"
@@ -37,7 +37,7 @@ const sourceLabels: Record<CmsFieldSource, string> = {
   relation_props: "Relation props",
 }
 
-export function CmsDetailPage({
+export async function CmsDetailPage({
   detail,
   backHref,
   backLabel,
@@ -52,7 +52,7 @@ export function CmsDetailPage({
   audit?: CmsAuditEventList
   children?: ReactNode
 }) {
-  const schema = getCmsSchema(detail.schemaKey)
+  const schema = await loadCmsSchema(detail.schemaKey)
   const fieldCount = schema?.fields.length ?? 0
 
   return (

--- a/app/ponix/_components/cms-entity-create-form.tsx
+++ b/app/ponix/_components/cms-entity-create-form.tsx
@@ -18,7 +18,7 @@ import type { CmsSchemaDefinition } from "@/lib/cms/schema-registry"
 import {
   cmsEntityFieldInputName,
   entityTypeFromSchemaKey,
-  getEditableEntityFields,
+  editableEntityFieldsForSchema,
   type CmsEditableEntityField,
 } from "@/lib/cms/entity-editor"
 
@@ -29,7 +29,7 @@ export function CmsEntityCreatePage({
   schema: CmsSchemaDefinition
   error?: string
 }) {
-  const editableFields = getEditableEntityFields(schema.schemaKey)
+  const editableFields = editableEntityFieldsForSchema(schema)
   const columnFields = editableFields.filter((field) => field.source === "column")
   const dataFields = editableFields.filter((field) => field.source === "data")
   const formId = `cms-entity-create-${schema.schemaKey.replace(/[^a-z0-9]+/gi, "-")}`

--- a/app/ponix/_components/cms-entity-form.tsx
+++ b/app/ponix/_components/cms-entity-form.tsx
@@ -23,17 +23,17 @@ import { Textarea } from "@/components/ui/textarea"
 import type { CmsContentDetail } from "@/lib/cms/content"
 import {
   cmsEntityFieldInputName,
-  getEditableEntityFields,
-  getEntityEditorSchema,
   getEntityFieldValue,
+  editableEntityFieldsForSchema,
   type CmsEditableEntityField,
 } from "@/lib/cms/entity-editor"
+import { loadEntityEditorSchema } from "@/lib/cms/entity-editor.server"
 
 import { CmsEntityLivePreview } from "./cms-live-preview"
 
 type CmsEntityDetail = Extract<CmsContentDetail, { kind: "entity" }>
 
-export function CmsEntityEditorPage({
+export async function CmsEntityEditorPage({
   detail,
   error,
   saved,
@@ -42,8 +42,8 @@ export function CmsEntityEditorPage({
   error?: string
   saved?: boolean
 }) {
-  const schema = getEntityEditorSchema(detail.schemaKey)
-  const editableFields = getEditableEntityFields(detail.schemaKey)
+  const schema = await loadEntityEditorSchema(detail.schemaKey)
+  const editableFields = schema ? editableEntityFieldsForSchema(schema) : []
   const columnFields = editableFields.filter((field) => field.source === "column")
   const dataFields = editableFields.filter((field) => field.source === "data")
   const formId = `cms-entity-form-${detail.row.id}`

--- a/app/ponix/_components/cms-page-form.tsx
+++ b/app/ponix/_components/cms-page-form.tsx
@@ -22,15 +22,15 @@ import { Textarea } from "@/components/ui/textarea"
 import type { CmsContentDetail } from "@/lib/cms/content"
 import {
   cmsPageFieldInputName,
-  getEditablePageFields,
-  getPageEditorSchema,
   getPageFieldValue,
+  editablePageFieldsForSchema,
   type CmsEditablePageField,
 } from "@/lib/cms/page-editor"
+import { loadPageEditorSchema } from "@/lib/cms/page-editor.server"
 
 type CmsPageDetail = Extract<CmsContentDetail, { kind: "page" }>
 
-export function CmsPageEditorPage({
+export async function CmsPageEditorPage({
   detail,
   error,
   saved,
@@ -39,8 +39,8 @@ export function CmsPageEditorPage({
   error?: string
   saved?: boolean
 }) {
-  const schema = getPageEditorSchema()
-  const editableFields = getEditablePageFields()
+  const schema = await loadPageEditorSchema()
+  const editableFields = schema ? editablePageFieldsForSchema(schema) : []
   const columnFields = editableFields.filter((field) => field.source === "column")
   const propsFields = editableFields.filter((field) => field.source === "props")
 

--- a/app/ponix/_components/cms-section-create-form.tsx
+++ b/app/ponix/_components/cms-section-create-form.tsx
@@ -16,8 +16,8 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import {
   cmsFieldInputName,
-  getEditableSectionFields,
   sectionTypeFromSchemaKey,
+  editableSectionFieldsForSchema,
   type CmsEditableSectionField,
 } from "@/lib/cms/section-editor"
 import type { CmsSchemaDefinition } from "@/lib/cms/schema-registry"
@@ -29,7 +29,7 @@ export function CmsSectionCreatePage({
   schema: CmsSchemaDefinition
   error?: string
 }) {
-  const editableFields = getEditableSectionFields(schema.schemaKey)
+  const editableFields = editableSectionFieldsForSchema(schema)
   const columnFields = editableFields.filter((field) => field.source === "column")
   const propsFields = editableFields.filter((field) => field.source === "props")
   const formId = `cms-section-create-${schema.schemaKey.replace(/[^a-z0-9]+/gi, "-")}`

--- a/app/ponix/_components/cms-section-form.tsx
+++ b/app/ponix/_components/cms-section-form.tsx
@@ -22,17 +22,17 @@ import { Textarea } from "@/components/ui/textarea"
 import type { CmsContentDetail, CmsSectionRelationContext } from "@/lib/cms/content"
 import {
   cmsFieldInputName,
-  getEditableSectionFields,
-  getSectionEditorSchema,
   getSectionFieldValue,
+  editableSectionFieldsForSchema,
   type CmsEditableSectionField,
 } from "@/lib/cms/section-editor"
+import { loadSectionEditorSchema } from "@/lib/cms/section-editor.server"
 
 import { CmsSectionLivePreview } from "./cms-live-preview"
 
 type CmsSectionDetail = Extract<CmsContentDetail, { kind: "section" }>
 
-export function CmsSectionEditorPage({
+export async function CmsSectionEditorPage({
   detail,
   relations,
   error,
@@ -43,8 +43,8 @@ export function CmsSectionEditorPage({
   error?: string
   saved?: boolean
 }) {
-  const schema = getSectionEditorSchema(detail.schemaKey)
-  const editableFields = getEditableSectionFields(detail.schemaKey)
+  const schema = await loadSectionEditorSchema(detail.schemaKey)
+  const editableFields = schema ? editableSectionFieldsForSchema(schema) : []
   const columnFields = editableFields.filter((field) => field.source === "column")
   const propsFields = editableFields.filter((field) => field.source === "props")
   const formId = `cms-section-form-${detail.row.id}`

--- a/app/ponix/entities/actions.ts
+++ b/app/ponix/entities/actions.ts
@@ -7,13 +7,15 @@ import { requireCmsAdmin } from "@/lib/cms/auth"
 import {
   cmsEntityFieldInputName,
   entityTypeFromSchemaKey,
-  getEditableEntityFields,
-  getEntityCreationSchema,
-  getEntityEditorSchema,
+  editableEntityFieldsForSchema,
   jsonObject,
   type CmsEditableEntityField,
   type CmsJsonObject,
 } from "@/lib/cms/entity-editor"
+import {
+  loadEntityCreationSchema,
+  loadEntityEditorSchema,
+} from "@/lib/cms/entity-editor.server"
 import { PUBLIC_CONTENT_CACHE_TAG } from "@/lib/data/public-cache"
 import { createClient } from "@/lib/supabase/server"
 import type { Database, Json } from "@/lib/supabase/types"
@@ -324,7 +326,7 @@ async function buildEntityUpdate({
   editPath: string
   redirectOnError: boolean
 }) {
-  const schema = getEntityEditorSchema(entity.schema_key)
+  const schema = await loadEntityEditorSchema(entity.schema_key)
   if (!schema) {
     const error = "This entity schema is not registered for editing."
     if (redirectOnError) {
@@ -333,7 +335,7 @@ async function buildEntityUpdate({
     throw new Error(error)
   }
 
-  const fields = getEditableEntityFields(entity.schema_key)
+  const fields = editableEntityFieldsForSchema(schema)
   const data = jsonObject(entity.data)
   const update: EntityUpdate = {}
 
@@ -395,14 +397,14 @@ export async function createCmsEntityAction(formData: FormData) {
     : "/ponix/entities/new"
   const admin = await requireCmsAdmin(createPath)
 
-  const schema = getEntityCreationSchema(schemaKey)
+  const schema = await loadEntityCreationSchema(schemaKey)
   if (!schema) {
     redirectWithParams("/ponix/entities/new", {
       error: "Choose a schema that can be created from CMS.",
     })
   }
 
-  const fields = getEditableEntityFields(schema.schemaKey)
+  const fields = editableEntityFieldsForSchema(schema)
   const data: CmsJsonObject = {}
   const insert: EntityInsert = {
     data,

--- a/app/ponix/entities/new/page.tsx
+++ b/app/ponix/entities/new/page.tsx
@@ -13,11 +13,12 @@ import {
   CardTitle,
 } from "@/components/ui/card"
 import { requireCmsAdmin } from "@/lib/cms/auth"
+import { entityTypeFromSchemaKey } from "@/lib/cms/entity-editor"
 import {
-  entityTypeFromSchemaKey,
-  getEntityCreationSchema,
-  getEntityCreationSchemas,
-} from "@/lib/cms/entity-editor"
+  loadEntityCreationSchema,
+  loadEntityCreationSchemas,
+} from "@/lib/cms/entity-editor.server"
+import type { CmsSchemaDefinition } from "@/lib/cms/schema-registry"
 
 export const metadata: Metadata = {
   title: "New PONIX Entity | 브레멘 Bremen",
@@ -45,15 +46,18 @@ export default async function PonixNewEntityPage({
   await requireCmsAdmin("/ponix/entities/new")
 
   if (schemaKey) {
-    const schema = getEntityCreationSchema(schemaKey)
+    const schema = await loadEntityCreationSchema(schemaKey)
 
     if (schema) {
       return <CmsEntityCreatePage schema={schema} error={error} />
     }
   }
 
+  const schemas = await loadEntityCreationSchemas()
+
   return (
     <SchemaPickerPage
+      schemas={schemas}
       error={
         schemaKey
           ? `Schema ${schemaKey} cannot be created from CMS.`
@@ -63,9 +67,13 @@ export default async function PonixNewEntityPage({
   )
 }
 
-function SchemaPickerPage({ error }: { error?: string }) {
-  const schemas = getEntityCreationSchemas()
-
+function SchemaPickerPage({
+  schemas,
+  error,
+}: {
+  schemas: CmsSchemaDefinition[]
+  error?: string
+}) {
   return (
     <main className="relative min-h-[calc(100vh-5rem)] overflow-hidden">
       <div className="pointer-events-none absolute inset-0 -z-10">

--- a/app/ponix/pages/[id]/compose/composer-relation-list.tsx
+++ b/app/ponix/pages/[id]/compose/composer-relation-list.tsx
@@ -43,7 +43,6 @@ import { Textarea } from "@/components/ui/textarea"
 import type { CmsSectionRelationContext } from "@/lib/cms/content"
 import {
   cmsEntityFieldInputName,
-  getEditableEntityFields,
   type CmsEditableEntityField,
 } from "@/lib/cms/entity-editor"
 import { cn } from "@/lib/utils"
@@ -71,12 +70,14 @@ export function ComposerRelationList({
   redirectTo,
   typeOptions,
   slotOptions,
+  entityFieldsBySchemaKey,
 }: {
   sectionId: string
   relations: Relation[]
   redirectTo: string
   typeOptions: string[]
   slotOptions: string[]
+  entityFieldsBySchemaKey: Record<string, CmsEditableEntityField[]>
 }) {
   const [orderedRelations, setOrderedRelations] = useState(relations)
   const [draggingGraphId, setDraggingGraphId] = useState<string | null>(null)
@@ -155,6 +156,7 @@ export function ComposerRelationList({
             redirectTo={redirectTo}
             typeOptions={typeOptions}
             slotOptions={slotOptions}
+            entityFieldsBySchemaKey={entityFieldsBySchemaKey}
             dragging={draggingGraphId === relation.graphRelationId}
             dropTarget={dropTargetGraphId === relation.graphRelationId}
             onDragStart={() => setDraggingGraphId(relation.graphRelationId)}
@@ -191,6 +193,7 @@ function SectionEntityRelationEditor({
   redirectTo,
   typeOptions,
   slotOptions,
+  entityFieldsBySchemaKey,
   dragging,
   dropTarget,
   onDragStart,
@@ -202,6 +205,7 @@ function SectionEntityRelationEditor({
   redirectTo: string
   typeOptions: string[]
   slotOptions: string[]
+  entityFieldsBySchemaKey: Record<string, CmsEditableEntityField[]>
   dragging: boolean
   dropTarget: boolean
   onDragStart: () => void
@@ -359,7 +363,10 @@ function SectionEntityRelationEditor({
                 </Badge>
               </div>
               <div className="mt-3 flex flex-wrap gap-2">
-                <EntityEditDrawer relation={relation} />
+                <EntityEditDrawer
+                  relation={relation}
+                  entityFieldsBySchemaKey={entityFieldsBySchemaKey}
+                />
                 <Button
                   asChild
                   variant="outline"
@@ -488,9 +495,17 @@ function SectionEntityRelationEditor({
   )
 }
 
-function EntityEditDrawer({ relation }: { relation: Relation }) {
+function EntityEditDrawer({
+  relation,
+  entityFieldsBySchemaKey,
+}: {
+  relation: Relation
+  entityFieldsBySchemaKey: Record<string, CmsEditableEntityField[]>
+}) {
   const entity = relation.entity
-  const editableFields = entity ? getEditableEntityFields(entity.schemaKey) : []
+  const editableFields = entity
+    ? (entityFieldsBySchemaKey[entity.schemaKey] ?? [])
+    : []
   const columnFields = editableFields.filter((field) => field.source !== "data")
   const dataFields = editableFields.filter((field) => field.source === "data")
   const [saveState, setSaveState] = useState<SaveState>({ status: "idle" })

--- a/app/ponix/pages/[id]/compose/page.tsx
+++ b/app/ponix/pages/[id]/compose/page.tsx
@@ -41,10 +41,13 @@ import {
 } from "@/lib/cms/content"
 import {
   cmsFieldInputName,
-  getEditableSectionFields,
   getSectionFieldValue,
+  type CmsEditableSectionField,
 } from "@/lib/cms/section-editor"
-import { getCmsSchema } from "@/lib/cms/schema-registry"
+import { loadEditableSectionFields } from "@/lib/cms/section-editor.server"
+import { loadCmsSchema } from "@/lib/cms/schema-registry.server"
+import { loadEditableEntityFields } from "@/lib/cms/entity-editor.server"
+import type { CmsEditableEntityField } from "@/lib/cms/entity-editor"
 import { loadDraftCompositionPage } from "@/lib/data/content-graph"
 import type { GraphSection } from "@/lib/data/content-graph"
 
@@ -84,16 +87,35 @@ export default async function PonixPageComposerPage({
     loadCmsRelationEditorOptions(),
     Promise.all(
       preview.graph.sections.map(async (section) => {
-        const [sectionDetail, sectionRelations] = await Promise.all([
-          loadCmsSectionDetail(section.id),
-          loadCmsSectionRelations(section.id),
-        ])
+        const [sectionDetail, sectionRelations, editableSectionFields, schema] =
+          await Promise.all([
+            loadCmsSectionDetail(section.id),
+            loadCmsSectionRelations(section.id),
+            loadEditableSectionFields(section.schemaKey),
+            loadCmsSchema(section.schemaKey),
+          ])
+        const entitySchemaKeys = uniqueStrings(
+          sectionRelations?.sectionEntities.map(
+            (relation) => relation.entity?.schemaKey,
+          ) ?? [],
+        )
+        const entityFieldEntries = await Promise.all(
+          entitySchemaKeys.map(async (schemaKey) => [
+            schemaKey,
+            await loadEditableEntityFields(schemaKey),
+          ] as const),
+        )
 
         return {
           section,
           sectionDetail:
             sectionDetail?.kind === "section" ? sectionDetail : null,
           sectionRelations,
+          editableSectionFields,
+          sectionSlotOptions: schema?.relationSlots?.length
+            ? schema.relationSlots
+            : ["default"],
+          entityFieldsBySchemaKey: Object.fromEntries(entityFieldEntries),
         }
       }),
     ),
@@ -116,7 +138,14 @@ export default async function PonixPageComposerPage({
         }))}
         initialSelectedKey={selectedKey}
       >
-        {sectionContexts.map(({ section, sectionDetail, sectionRelations }) => (
+        {sectionContexts.map(({
+          section,
+          sectionDetail,
+          sectionRelations,
+          editableSectionFields,
+          sectionSlotOptions,
+          entityFieldsBySchemaKey,
+        }) => (
           <div
             key={section.id}
             data-composer-panel={section.key}
@@ -130,6 +159,9 @@ export default async function PonixPageComposerPage({
               sectionDetail={sectionDetail}
               relations={sectionRelations}
               relationOptions={relationOptions}
+              editableSectionFields={editableSectionFields}
+              sectionSlotOptions={sectionSlotOptions}
+              entityFieldsBySchemaKey={entityFieldsBySchemaKey}
               redirectTo={composeHref(id, section.key)}
               saved={section.key === selectedKey && sectionSaved}
               relationMessage={
@@ -153,6 +185,9 @@ function SectionInspector({
   sectionDetail,
   relations,
   relationOptions,
+  editableSectionFields,
+  sectionSlotOptions,
+  entityFieldsBySchemaKey,
   redirectTo,
   saved,
   relationMessage,
@@ -164,6 +199,9 @@ function SectionInspector({
   sectionDetail: (Extract<CmsContentDetail, { kind: "section" }>) | null
   relations: CmsSectionRelationContext | null
   relationOptions: CmsRelationEditorOptions | null
+  editableSectionFields: CmsEditableSectionField[]
+  sectionSlotOptions: string[]
+  entityFieldsBySchemaKey: Record<string, CmsEditableEntityField[]>
   redirectTo: string
   saved: boolean
   relationMessage?: string
@@ -233,12 +271,18 @@ function SectionInspector({
           section={section}
           relations={relations}
           options={relationOptions}
+          slotOptions={sectionSlotOptions}
+          entityFieldsBySchemaKey={entityFieldsBySchemaKey}
           redirectTo={redirectTo}
         />
       )}
 
       {sectionDetail && (
-        <SectionQuickEditCard detail={sectionDetail} redirectTo={redirectTo} />
+        <SectionQuickEditCard
+          detail={sectionDetail}
+          fields={editableSectionFields}
+          redirectTo={redirectTo}
+        />
       )}
 
       {section && <SectionAdvancedSettingsCard section={section} />}
@@ -248,13 +292,13 @@ function SectionInspector({
 
 function SectionQuickEditCard({
   detail,
+  fields,
   redirectTo,
 }: {
   detail: Extract<CmsContentDetail, { kind: "section" }>
+  fields: CmsEditableSectionField[]
   redirectTo: string
 }) {
-  const fields = getEditableSectionFields(detail.schemaKey)
-
   return (
     <Card className="overflow-hidden rounded-2xl bg-card/95 shadow-sm">
       <Accordion type="single" collapsible>
@@ -318,17 +362,20 @@ function SectionEntityWorkspace({
   section,
   relations,
   options,
+  slotOptions,
+  entityFieldsBySchemaKey,
   redirectTo,
 }: {
   section: GraphSection
   relations: CmsSectionRelationContext
   options: CmsRelationEditorOptions
+  slotOptions: string[]
+  entityFieldsBySchemaKey: Record<string, CmsEditableEntityField[]>
   redirectTo: string
 }) {
   const nextSortOrder =
     Math.max(0, ...relations.sectionEntities.map((relation) => relation.sortOrder)) +
     10
-  const slotOptions = getCmsSchema(section.schemaKey)?.relationSlots ?? ["default"]
   const relationTypeOptions = uniqueStrings([
     "item",
     ...relations.sectionEntities.map((relation) => relation.relationType),
@@ -426,6 +473,7 @@ function SectionEntityWorkspace({
             redirectTo={redirectTo}
             typeOptions={relationTypeOptions}
             slotOptions={slotOptions}
+            entityFieldsBySchemaKey={entityFieldsBySchemaKey}
           />
         </div>
 
@@ -558,6 +606,10 @@ function searchValue(value: string | string[] | undefined) {
   return value ?? null
 }
 
-function uniqueStrings(values: string[]) {
-  return Array.from(new Set(values.map((value) => value.trim()).filter(Boolean)))
+function uniqueStrings(values: Array<string | null | undefined>) {
+  const strings = values
+    .map((value) => value?.trim())
+    .filter((value): value is string => Boolean(value))
+
+  return Array.from(new Set(strings))
 }

--- a/app/ponix/pages/actions.ts
+++ b/app/ponix/pages/actions.ts
@@ -6,12 +6,12 @@ import { redirect } from "next/navigation"
 import { requireCmsAdmin } from "@/lib/cms/auth"
 import {
   cmsPageFieldInputName,
-  getEditablePageFields,
-  getPageEditorSchema,
+  editablePageFieldsForSchema,
   jsonObject,
   type CmsEditablePageField,
   type CmsJsonObject,
 } from "@/lib/cms/page-editor"
+import { loadPageEditorSchema } from "@/lib/cms/page-editor.server"
 import { PUBLIC_CONTENT_CACHE_TAG } from "@/lib/data/public-cache"
 import { createClient } from "@/lib/supabase/server"
 import type { Database, Json } from "@/lib/supabase/types"
@@ -163,7 +163,7 @@ export async function updateCmsPageAction(formData: FormData) {
   const redirectTo = safeRedirectPath(formData, editPath)
   await requireCmsAdmin(editPath)
 
-  const schema = getPageEditorSchema()
+  const schema = await loadPageEditorSchema()
   if (!schema) {
     redirectWithParams(editPath, {
       error: "The page editor schema is not registered.",
@@ -183,7 +183,7 @@ export async function updateCmsPageAction(formData: FormData) {
     })
   }
 
-  const fields = getEditablePageFields()
+  const fields = editablePageFieldsForSchema(schema)
   const props = jsonObject(page.props)
   const update: PageUpdate = {}
 

--- a/app/ponix/sections/[id]/page.tsx
+++ b/app/ponix/sections/[id]/page.tsx
@@ -17,7 +17,7 @@ import {
   loadCmsSectionDetail,
   loadCmsSectionRelations,
 } from "@/lib/cms/content"
-import { getEditableSectionFields } from "@/lib/cms/section-editor"
+import { loadEditableSectionFields } from "@/lib/cms/section-editor.server"
 
 export const metadata: Metadata = {
   title: "PONIX Section Detail | 브레멘 Bremen",
@@ -52,7 +52,7 @@ export default async function PonixSectionRecordPage({
     notFound()
   }
 
-  const editableFields = getEditableSectionFields(detail.schemaKey)
+  const editableFields = await loadEditableSectionFields(detail.schemaKey)
 
   return (
     <CmsDetailPage

--- a/app/ponix/sections/actions.ts
+++ b/app/ponix/sections/actions.ts
@@ -6,14 +6,16 @@ import { redirect } from "next/navigation"
 import { requireCmsAdmin } from "@/lib/cms/auth"
 import {
   cmsFieldInputName,
-  getEditableSectionFields,
-  getSectionCreationSchema,
-  getSectionEditorSchema,
+  editableSectionFieldsForSchema,
   jsonObject,
   sectionTypeFromSchemaKey,
   type CmsEditableSectionField,
   type CmsJsonObject,
 } from "@/lib/cms/section-editor"
+import {
+  loadSectionCreationSchema,
+  loadSectionEditorSchema,
+} from "@/lib/cms/section-editor.server"
 import { PUBLIC_CONTENT_CACHE_TAG } from "@/lib/data/public-cache"
 import { createClient } from "@/lib/supabase/server"
 import type { Database, Json } from "@/lib/supabase/types"
@@ -260,7 +262,7 @@ export async function createCmsSectionAction(formData: FormData) {
     : "/ponix/sections/new"
   const admin = await requireCmsAdmin(createPath)
 
-  const schema = getSectionCreationSchema(schemaKey)
+  const schema = await loadSectionCreationSchema(schemaKey)
   if (!schema) {
     redirectWithParams("/ponix/sections/new", {
       error: "Choose a section schema that can be created from CMS.",
@@ -274,7 +276,7 @@ export async function createCmsSectionAction(formData: FormData) {
     })
   }
 
-  const fields = getEditableSectionFields(schema.schemaKey)
+  const fields = editableSectionFieldsForSchema(schema)
   const props: CmsJsonObject = {}
   const insert: SectionInsert = {
     key: parseSectionKey(formData, createPath),
@@ -364,14 +366,14 @@ export async function updateCmsSectionAction(formData: FormData) {
     })
   }
 
-  const schema = getSectionEditorSchema(section.schema_key)
+  const schema = await loadSectionEditorSchema(section.schema_key)
   if (!schema) {
     redirectWithParams(editPath, {
       error: "This section schema is not registered for editing.",
     })
   }
 
-  const fields = getEditableSectionFields(section.schema_key)
+  const fields = editableSectionFieldsForSchema(schema)
   const props = jsonObject(section.props)
   const update: SectionUpdate = {}
 

--- a/app/ponix/sections/new/page.tsx
+++ b/app/ponix/sections/new/page.tsx
@@ -14,10 +14,13 @@ import {
 } from "@/components/ui/card"
 import { requireCmsAdmin } from "@/lib/cms/auth"
 import {
-  getSectionCreationSchema,
-  getSectionCreationSchemas,
   sectionTypeFromSchemaKey,
 } from "@/lib/cms/section-editor"
+import {
+  loadSectionCreationSchema,
+  loadSectionCreationSchemas,
+} from "@/lib/cms/section-editor.server"
+import type { CmsSchemaDefinition } from "@/lib/cms/schema-registry"
 
 export const metadata: Metadata = {
   title: "New PONIX Section | 브레멘 Bremen",
@@ -45,15 +48,18 @@ export default async function PonixNewSectionPage({
   await requireCmsAdmin("/ponix/sections/new")
 
   if (schemaKey) {
-    const schema = getSectionCreationSchema(schemaKey)
+    const schema = await loadSectionCreationSchema(schemaKey)
 
     if (schema) {
       return <CmsSectionCreatePage schema={schema} error={error} />
     }
   }
 
+  const schemas = await loadSectionCreationSchemas()
+
   return (
     <SchemaPickerPage
+      schemas={schemas}
       error={
         schemaKey
           ? `Schema ${schemaKey} cannot be created from CMS.`
@@ -63,9 +69,13 @@ export default async function PonixNewSectionPage({
   )
 }
 
-function SchemaPickerPage({ error }: { error?: string }) {
-  const schemas = getSectionCreationSchemas()
-
+function SchemaPickerPage({
+  schemas,
+  error,
+}: {
+  schemas: CmsSchemaDefinition[]
+  error?: string
+}) {
   return (
     <main className="relative min-h-[calc(100vh-5rem)] overflow-hidden">
       <div className="pointer-events-none absolute inset-0 -z-10">

--- a/docs/cms-prework.md
+++ b/docs/cms-prework.md
@@ -37,7 +37,9 @@ The database already has JSONB fields:
 
 Those fields are flexible but not enough for a safe CMS. A CMS needs to know which JSON keys are editable, which fields are required, which options are allowed, and which fields are read-only.
 
-The first registry lives in code at `lib/cms/schema-registry.ts`. It can later move to database-backed metadata if needed.
+PONIX now reads editor metadata from DB-backed `entity_schemas` first, then falls
+back to the reviewed code registry at `lib/cms/schema-registry.ts` when metadata
+is missing or invalid.
 
 ## Next Issues
 

--- a/docs/content-graph.md
+++ b/docs/content-graph.md
@@ -102,12 +102,12 @@ CMS forms should not infer editable fields directly from arbitrary JSONB.
 
 There are now two layers:
 
-- `entity_schemas` is the DB-backed registry foundation. It stores stable
-  `schema_key`, `kind`, version, label, renderer hint, relation slots, and future
-  JSON field/validation definitions.
-- `lib/cms/schema-registry.ts` is still the active code-level field contract for
-  PONIX forms until the DB-backed registry is fully populated and wired into the
-  editor.
+- `entity_schemas` is the DB-backed registry used by PONIX server-rendered
+  editor/detail flows. It stores stable `schema_key`, `kind`, version, label,
+  renderer hint, relation slots, and JSON field metadata.
+- `lib/cms/schema-registry.ts` remains the reviewed code fallback and renderer
+  compatibility contract. Keep it in sync until DB-only schema editing has its
+  own review and QA path.
 
 Use the registry contract for:
 
@@ -117,14 +117,14 @@ Use the registry contract for:
 - `entity_relations.props`
 
 Each registry entry defines the schema key, field source, field type,
-required/read-only status, and select options. Future CMS editor screens should
-prefer `entity_schemas` as the metadata source, with the code registry as the
-reviewed renderer/field fallback.
+required/read-only status, and select options. CMS editor screens should prefer
+`entity_schemas` as the metadata source, with the code registry as the reviewed
+renderer/field fallback.
 
-Use `pnpm run qa:cms-schema-registry` to compare the code registry with active
-DB `entity_schemas`. The command is intentionally read-only and reports the
-current DB-primary readiness state. A schema with `dbFields = 0` still depends on
-`lib/cms/schema-registry.ts` for PONIX editor fields.
+Use `pnpm run qa:cms-schema-registry -- --strict` to compare the code registry
+with active DB `entity_schemas`. The command is intentionally read-only and
+should report `dbFieldMissing = 0` before DB-first editor behavior is considered
+safe.
 
 ## Entity Schema Direction
 

--- a/lib/cms/content.ts
+++ b/lib/cms/content.ts
@@ -1,7 +1,11 @@
 import { createClient } from "@/lib/supabase/server"
 import type { Database, Json } from "@/lib/supabase/types"
 
-import { getCmsSchema, getCmsSchemasByKind } from "./schema-registry"
+import type { CmsSchemaDefinition } from "./schema-registry"
+import {
+  loadCmsSchemaRegistryMap,
+  loadCmsSchemasByKind,
+} from "./schema-registry.server"
 
 const ENTITY_LIST_LIMIT = 200
 const RELATION_ENTITY_OPTION_LIMIT = 80
@@ -33,6 +37,7 @@ type SchemaSummary = {
   schemaLabel: string
   schemaRegistered: boolean
 }
+type SchemaRegistryMap = Map<string, CmsSchemaDefinition>
 
 export type CmsPageSummary = SchemaSummary & {
   id: string
@@ -238,8 +243,11 @@ export type CmsContentDetail =
       row: EntityRow
     } & SchemaSummary
 
-function schemaSummary(schemaKey: string): SchemaSummary {
-  const schema = getCmsSchema(schemaKey)
+function schemaSummary(
+  schemaKey: string,
+  registry: SchemaRegistryMap,
+): SchemaSummary {
+  const schema = registry.get(schemaKey)
 
   return {
     schemaKey,
@@ -248,8 +256,9 @@ function schemaSummary(schemaKey: string): SchemaSummary {
   }
 }
 
-function entitySchemaOptions(): CmsEntitySchemaOption[] {
-  return getCmsSchemasByKind("entity")
+async function entitySchemaOptions(): Promise<CmsEntitySchemaOption[]> {
+  const schemas = await loadCmsSchemasByKind("entity")
+  return schemas
     .map((schema) => ({
       key: schema.schemaKey,
       label: schema.label,
@@ -269,9 +278,11 @@ function mapEntitySummary(entity: Pick<
   | "published"
   | "sort_at"
   | "updated_at"
->): CmsEntitySummary {
+>,
+  registry: SchemaRegistryMap,
+): CmsEntitySummary {
   return {
-    ...schemaSummary(entity.schema_key),
+    ...schemaSummary(entity.schema_key, registry),
     id: entity.id,
     entityType: entity.entity_type,
     slug: entity.slug,
@@ -331,13 +342,14 @@ function linkedPage(page: RawPageLink | null): CmsLinkedPage | null {
 
 function linkedSection(
   section: RawSectionLink | null,
+  registry: SchemaRegistryMap,
 ): CmsLinkedSection | null {
   if (!section) {
     return null
   }
 
   return {
-    ...schemaSummary(section.schema_key),
+    ...schemaSummary(section.schema_key, registry),
     id: section.id,
     key: section.key,
     title: section.title,
@@ -346,13 +358,16 @@ function linkedSection(
   }
 }
 
-function linkedEntity(entity: RawEntityLink | null): CmsLinkedEntity | null {
+function linkedEntity(
+  entity: RawEntityLink | null,
+  registry: SchemaRegistryMap,
+): CmsLinkedEntity | null {
   if (!entity) {
     return null
   }
 
   return {
-    ...schemaSummary(entity.schema_key),
+    ...schemaSummary(entity.schema_key, registry),
     id: entity.id,
     entityType: entity.entity_type,
     slug: entity.slug,
@@ -407,7 +422,10 @@ type RawEntityRelation = {
   toEntity: RawEntityLink | null
 }
 
-function mapEntityRelation(relation: RawEntityRelation): CmsEntityRelation {
+function mapEntityRelation(
+  relation: RawEntityRelation,
+  registry: SchemaRegistryMap,
+): CmsEntityRelation {
   return {
     id: relation.id,
     fromEntityId: relation.from_entity_id,
@@ -417,8 +435,8 @@ function mapEntityRelation(relation: RawEntityRelation): CmsEntityRelation {
     sortOrder: relation.sort_order,
     props: relation.props,
     updatedAt: relation.updated_at,
-    fromEntity: linkedEntity(relation.fromEntity),
-    toEntity: linkedEntity(relation.toEntity),
+    fromEntity: linkedEntity(relation.fromEntity, registry),
+    toEntity: linkedEntity(relation.toEntity, registry),
   }
 }
 
@@ -466,17 +484,22 @@ function byEntityRelationOrder(left: CmsEntityRelation, right: CmsEntityRelation
 
 export async function loadCmsPages(): Promise<CmsPageSummary[]> {
   const supabase = await createClient()
-  const { data, error } = await supabase
+  const pagesQuery = supabase
     .from("pages")
     .select("id, slug, title, subtitle, published, updated_at")
     .order("slug", { ascending: true })
+  const [registry, result] = await Promise.all([
+    loadCmsSchemaRegistryMap(),
+    pagesQuery,
+  ])
+  const { data, error } = result
 
   if (error) {
     throw new Error(`Failed to load CMS pages: ${error.message}`)
   }
 
   return (data ?? []).map((page) => ({
-    ...schemaSummary("page/default/v1"),
+    ...schemaSummary("page/default/v1", registry),
     id: page.id,
     slug: page.slug,
     title: page.title,
@@ -490,11 +513,16 @@ export async function loadCmsPageDetail(
   id: string,
 ): Promise<CmsContentDetail | null> {
   const supabase = await createClient()
-  const { data, error } = await supabase
+  const pageQuery = supabase
     .from("pages")
     .select("*")
     .eq("id", id)
     .maybeSingle()
+  const [registry, result] = await Promise.all([
+    loadCmsSchemaRegistryMap(),
+    pageQuery,
+  ])
+  const { data, error } = result
 
   if (error) {
     throw new Error(`Failed to load CMS page detail: ${error.message}`)
@@ -505,7 +533,7 @@ export async function loadCmsPageDetail(
   }
 
   return {
-    ...schemaSummary("page/default/v1"),
+    ...schemaSummary("page/default/v1", registry),
     kind: "page",
     table: "pages",
     title: data.title,
@@ -518,17 +546,22 @@ export async function loadCmsPageDetail(
 
 export async function loadCmsSections(): Promise<CmsSectionSummary[]> {
   const supabase = await createClient()
-  const { data, error } = await supabase
+  const sectionsQuery = supabase
     .from("sections")
     .select("id, key, section_type, schema_key, title, subtitle, published, updated_at")
     .order("key", { ascending: true })
+  const [registry, result] = await Promise.all([
+    loadCmsSchemaRegistryMap(),
+    sectionsQuery,
+  ])
+  const { data, error } = result
 
   if (error) {
     throw new Error(`Failed to load CMS sections: ${error.message}`)
   }
 
   return (data ?? []).map((section) => ({
-    ...schemaSummary(section.schema_key),
+    ...schemaSummary(section.schema_key, registry),
     id: section.id,
     key: section.key,
     sectionType: section.section_type,
@@ -543,11 +576,16 @@ export async function loadCmsSectionDetail(
   id: string,
 ): Promise<CmsContentDetail | null> {
   const supabase = await createClient()
-  const { data, error } = await supabase
+  const sectionQuery = supabase
     .from("sections")
     .select("*")
     .eq("id", id)
     .maybeSingle()
+  const [registry, result] = await Promise.all([
+    loadCmsSchemaRegistryMap(),
+    sectionQuery,
+  ])
+  const { data, error } = result
 
   if (error) {
     throw new Error(`Failed to load CMS section detail: ${error.message}`)
@@ -558,7 +596,7 @@ export async function loadCmsSectionDetail(
   }
 
   return {
-    ...schemaSummary(data.schema_key),
+    ...schemaSummary(data.schema_key, registry),
     kind: "section",
     table: "sections",
     title: data.title ?? data.key,
@@ -571,7 +609,7 @@ export async function loadCmsSectionDetail(
 
 export async function loadCmsEntities(): Promise<CmsEntityList> {
   const supabase = await createClient()
-  const { data, error, count } = await supabase
+  const entitiesQuery = supabase
     .from("entities")
     .select(
       "id, entity_type, schema_key, slug, title, subtitle, thumbnail_url, published, sort_at, updated_at",
@@ -579,6 +617,11 @@ export async function loadCmsEntities(): Promise<CmsEntityList> {
     )
     .order("sort_at", { ascending: false })
     .range(0, ENTITY_LIST_LIMIT - 1)
+  const [registry, result] = await Promise.all([
+    loadCmsSchemaRegistryMap(),
+    entitiesQuery,
+  ])
+  const { data, error, count } = result
 
   if (error) {
     throw new Error(`Failed to load CMS entities: ${error.message}`)
@@ -587,7 +630,7 @@ export async function loadCmsEntities(): Promise<CmsEntityList> {
   return {
     count,
     limit: ENTITY_LIST_LIMIT,
-    entities: (data ?? []).map(mapEntitySummary),
+    entities: (data ?? []).map((entity) => mapEntitySummary(entity, registry)),
   }
 }
 
@@ -597,6 +640,7 @@ export async function loadCmsEntityOptions({
   limit = RELATION_ENTITY_SEARCH_LIMIT,
 }: LoadCmsEntityOptionsOptions = {}): Promise<CmsEntitySummary[]> {
   const supabase = await createClient()
+  const registry = await loadCmsSchemaRegistryMap()
   const normalizedQuery = query?.trim()
   const normalizedSchema = schemaKey?.trim()
   const safeLimit = Math.min(Math.max(limit, 1), 100)
@@ -634,7 +678,7 @@ export async function loadCmsEntityOptions({
     throw new Error(`Failed to load CMS entity options: ${error.message}`)
   }
 
-  return (data ?? []).map(mapEntitySummary)
+  return (data ?? []).map((entity) => mapEntitySummary(entity, registry))
 }
 
 export async function loadCmsRelationEditorOptions({
@@ -648,22 +692,27 @@ export async function loadCmsRelationEditorOptions({
   const entityQuery = countEntities
     ? supabase.from("entities").select(entitySelect, { count: "exact" })
     : supabase.from("entities").select(entitySelect)
+  const pagesQuery = supabase
+    .from("pages")
+    .select("id, slug, title, subtitle, published, updated_at")
+    .order("slug", { ascending: true })
+  const sectionsQuery = supabase
+    .from("sections")
+    .select("id, key, section_type, schema_key, title, subtitle, published, updated_at")
+    .order("key", { ascending: true })
   const entitiesPromise = includeEntities
     ? entityQuery
         .order("sort_at", { ascending: false })
         .range(0, Math.min(Math.max(entityLimit, 1), 100) - 1)
     : Promise.resolve({ data: [], error: null, count: null })
-  const [pagesResult, sectionsResult, entitiesResult] = await Promise.all([
-    supabase
-      .from("pages")
-      .select("id, slug, title, subtitle, published, updated_at")
-      .order("slug", { ascending: true }),
-    supabase
-      .from("sections")
-      .select("id, key, section_type, schema_key, title, subtitle, published, updated_at")
-      .order("key", { ascending: true }),
-    entitiesPromise,
-  ])
+  const [registry, schemaOptions, pagesResult, sectionsResult, entitiesResult] =
+    await Promise.all([
+      loadCmsSchemaRegistryMap(),
+      entitySchemaOptions(),
+      pagesQuery,
+      sectionsQuery,
+      entitiesPromise,
+    ])
 
   if (sectionsResult.error) {
     throw new Error(
@@ -685,7 +734,7 @@ export async function loadCmsRelationEditorOptions({
 
   return {
     pages: (pagesResult.data ?? []).map((page) => ({
-      ...schemaSummary("page/default/v1"),
+      ...schemaSummary("page/default/v1", registry),
       id: page.id,
       slug: page.slug,
       title: page.title,
@@ -694,7 +743,7 @@ export async function loadCmsRelationEditorOptions({
       updatedAt: page.updated_at,
     })),
     sections: (sectionsResult.data ?? []).map((section) => ({
-      ...schemaSummary(section.schema_key),
+      ...schemaSummary(section.schema_key, registry),
       id: section.id,
       key: section.key,
       sectionType: section.section_type,
@@ -703,8 +752,10 @@ export async function loadCmsRelationEditorOptions({
       published: section.published,
       updatedAt: section.updated_at,
     })),
-    entitySchemas: entitySchemaOptions(),
-    entities: (entitiesResult.data ?? []).map(mapEntitySummary),
+    entitySchemas: schemaOptions,
+    entities: (entitiesResult.data ?? []).map((entity) =>
+      mapEntitySummary(entity, registry),
+    ),
     entityCount: entitiesResult.count,
     entityLimit: includeEntities ? Math.min(Math.max(entityLimit, 1), 100) : 0,
   }
@@ -714,11 +765,16 @@ export async function loadCmsEntityDetail(
   id: string,
 ): Promise<CmsContentDetail | null> {
   const supabase = await createClient()
-  const { data, error } = await supabase
+  const entityQuery = supabase
     .from("entities")
     .select("*")
     .eq("id", id)
     .maybeSingle()
+  const [registry, result] = await Promise.all([
+    loadCmsSchemaRegistryMap(),
+    entityQuery,
+  ])
+  const { data, error } = result
 
   if (error) {
     throw new Error(`Failed to load CMS entity detail: ${error.message}`)
@@ -729,7 +785,7 @@ export async function loadCmsEntityDetail(
   }
 
   return {
-    ...schemaSummary(data.schema_key),
+    ...schemaSummary(data.schema_key, registry),
     kind: "entity",
     table: "entities",
     title: data.title,
@@ -908,7 +964,8 @@ async function loadPageSectionRelationsFromEntityGraph({
     sectionId,
     ...rawRelations.map((relation) => sourceId(relation.toEntity, "sections")),
   ])
-  const [pagesById, sectionsById] = await Promise.all([
+  const [registry, pagesById, sectionsById] = await Promise.all([
+    loadCmsSchemaRegistryMap(),
     loadPageLinksById(supabase, pageIds),
     loadSectionLinksById(supabase, sectionIds),
   ])
@@ -931,7 +988,7 @@ async function loadPageSectionRelationsFromEntityGraph({
         props: relation.props,
         updatedAt: relation.updated_at,
         page: linkedPage(pagesById.get(mappedPageId) ?? null),
-        section: linkedSection(sectionsById.get(mappedSectionId) ?? null),
+        section: linkedSection(sectionsById.get(mappedSectionId) ?? null, registry),
       }
     })
     .filter((relation): relation is CmsPageSectionRelation => Boolean(relation))
@@ -999,7 +1056,10 @@ async function loadSectionEntityRelationsFromEntityGraph({
     sectionId,
     ...rawRelations.map((relation) => sourceId(relation.fromEntity, "sections")),
   ])
-  const sectionsById = await loadSectionLinksById(supabase, sectionIds)
+  const [registry, sectionsById] = await Promise.all([
+    loadCmsSchemaRegistryMap(),
+    loadSectionLinksById(supabase, sectionIds),
+  ])
 
   const relations = rawRelations
     .map((relation): CmsSectionEntityRelation | null => {
@@ -1022,8 +1082,8 @@ async function loadSectionEntityRelationsFromEntityGraph({
         sortOrder: relation.sort_order,
         props: relation.props,
         updatedAt: relation.updated_at,
-        section: linkedSection(sectionsById.get(mappedSectionId) ?? null),
-        entity: linkedEntity(relation.toEntity),
+        section: linkedSection(sectionsById.get(mappedSectionId) ?? null, registry),
+        entity: linkedEntity(relation.toEntity, registry),
       }
     })
     .filter((relation): relation is CmsSectionEntityRelation => Boolean(relation))
@@ -1071,8 +1131,9 @@ async function loadEntityRelations({
     throw new Error(`Failed to load entity relations: ${error.message}`)
   }
 
+  const registry = await loadCmsSchemaRegistryMap()
   const relations = ((data ?? []) as unknown as RawEntityRelation[])
-    .map(mapEntityRelation)
+    .map((relation) => mapEntityRelation(relation, registry))
     .sort(byEntityRelationOrder)
 
   return relationList(relations, count, limit)
@@ -1105,8 +1166,9 @@ async function loadEntityRelationsForFromEntities({
     throw new Error(`Failed to load entity relations: ${error.message}`)
   }
 
+  const registry = await loadCmsSchemaRegistryMap()
   const relations = ((data ?? []) as unknown as RawEntityRelation[])
-    .map(mapEntityRelation)
+    .map((relation) => mapEntityRelation(relation, registry))
     .sort(byEntityRelationOrder)
 
   return relationList(relations, count, limit)

--- a/lib/cms/entity-editor.server.ts
+++ b/lib/cms/entity-editor.server.ts
@@ -1,0 +1,29 @@
+import {
+  canCreateEntitySchema,
+  editableEntityFieldsForSchema,
+  isEntityEditorSchema,
+} from "@/lib/cms/entity-editor"
+import { loadCmsSchema, loadCmsSchemasByKind } from "@/lib/cms/schema-registry.server"
+
+export async function loadEntityEditorSchema(schemaKey: string) {
+  const schema = await loadCmsSchema(schemaKey)
+  return schema && isEntityEditorSchema(schema) ? schema : null
+}
+
+export async function loadEntityCreationSchema(schemaKey: string) {
+  const schema = await loadEntityEditorSchema(schemaKey)
+  return schema && canCreateEntitySchema(schema) ? schema : null
+}
+
+export async function loadEntityCreationSchemas() {
+  const schemas = await loadCmsSchemasByKind("entity")
+  return schemas
+    .filter(canCreateEntitySchema)
+    .sort((left, right) => left.label.localeCompare(right.label))
+}
+
+export async function loadEditableEntityFields(schemaKey: string) {
+  const schema = await loadEntityEditorSchema(schemaKey)
+  return schema ? editableEntityFieldsForSchema(schema) : []
+}
+

--- a/lib/cms/entity-editor.ts
+++ b/lib/cms/entity-editor.ts
@@ -32,11 +32,15 @@ export function getEntityEditorSchema(
 ): CmsSchemaDefinition | null {
   const schema = getCmsSchema(schemaKey)
 
-  if (!schema || schema.kind !== "entity" || schema.table !== "entities") {
+  if (!schema || !isEntityEditorSchema(schema)) {
     return null
   }
 
   return schema
+}
+
+export function isEntityEditorSchema(schema: CmsSchemaDefinition) {
+  return schema.kind === "entity" && schema.table === "entities"
 }
 
 export function entityTypeFromSchemaKey(schemaKey: string) {
@@ -53,12 +57,16 @@ function hasRequiredReadOnlyField(schema: CmsSchemaDefinition) {
   })
 }
 
+export function canCreateEntitySchema(schema: CmsSchemaDefinition) {
+  return isEntityEditorSchema(schema) && !hasRequiredReadOnlyField(schema)
+}
+
 export function getEntityCreationSchema(
   schemaKey: string,
 ): CmsSchemaDefinition | null {
   const schema = getEntityEditorSchema(schemaKey)
 
-  if (!schema || hasRequiredReadOnlyField(schema)) {
+  if (!schema || !canCreateEntitySchema(schema)) {
     return null
   }
 
@@ -78,6 +86,10 @@ export function getEditableEntityFields(schemaKey: string) {
     return []
   }
 
+  return editableEntityFieldsForSchema(schema)
+}
+
+export function editableEntityFieldsForSchema(schema: CmsSchemaDefinition) {
   return schema.fields.filter((field): field is CmsEditableEntityField => {
     if (field.readOnly) {
       return false

--- a/lib/cms/page-editor.server.ts
+++ b/lib/cms/page-editor.server.ts
@@ -1,0 +1,16 @@
+import {
+  editablePageFieldsForSchema,
+  isPageEditorSchema,
+} from "@/lib/cms/page-editor"
+import { loadCmsSchema } from "@/lib/cms/schema-registry.server"
+
+export async function loadPageEditorSchema() {
+  const schema = await loadCmsSchema("page/default/v1")
+  return schema && isPageEditorSchema(schema) ? schema : null
+}
+
+export async function loadEditablePageFields() {
+  const schema = await loadPageEditorSchema()
+  return schema ? editablePageFieldsForSchema(schema) : []
+}
+

--- a/lib/cms/page-editor.ts
+++ b/lib/cms/page-editor.ts
@@ -27,11 +27,15 @@ export function cmsPageFieldInputName(field: CmsFieldDefinition) {
 export function getPageEditorSchema(): CmsSchemaDefinition | null {
   const schema = getCmsSchema("page/default/v1")
 
-  if (!schema || schema.kind !== "page" || schema.table !== "pages") {
+  if (!schema || !isPageEditorSchema(schema)) {
     return null
   }
 
   return schema
+}
+
+export function isPageEditorSchema(schema: CmsSchemaDefinition) {
+  return schema.kind === "page" && schema.table === "pages"
 }
 
 export function getEditablePageFields() {
@@ -41,6 +45,10 @@ export function getEditablePageFields() {
     return []
   }
 
+  return editablePageFieldsForSchema(schema)
+}
+
+export function editablePageFieldsForSchema(schema: CmsSchemaDefinition) {
   return schema.fields.filter((field): field is CmsEditablePageField => {
     if (field.readOnly) {
       return false

--- a/lib/cms/schema-registry.server.ts
+++ b/lib/cms/schema-registry.server.ts
@@ -1,0 +1,220 @@
+import { cache } from "react"
+
+import { createClient } from "@/lib/supabase/server"
+import type { Database, Json } from "@/lib/supabase/types"
+
+import {
+  cmsSchemaRegistry,
+  getCmsSchema,
+  getCmsSchemasByKind,
+  type CmsFieldDefinition,
+  type CmsFieldOption,
+  type CmsFieldSource,
+  type CmsFieldType,
+  type CmsSchemaDefinition,
+  type CmsSchemaKind,
+} from "./schema-registry"
+
+type EntitySchemaRow = Pick<
+  Database["public"]["Tables"]["entity_schemas"]["Row"],
+  | "schema_key"
+  | "kind"
+  | "table_name"
+  | "label"
+  | "description"
+  | "fields"
+  | "relation_slots"
+>
+
+const fieldTypes = new Set<CmsFieldType>([
+  "text",
+  "textarea",
+  "url",
+  "image",
+  "number",
+  "boolean",
+  "date",
+  "datetime",
+  "select",
+  "string-list",
+  "json",
+])
+
+const fieldSources = new Set<CmsFieldSource>([
+  "column",
+  "props",
+  "data",
+  "relation_props",
+])
+
+const schemaKinds = new Set<CmsSchemaKind>([
+  "page",
+  "section",
+  "entity",
+  "relation",
+])
+
+const schemaTables = new Set<CmsSchemaDefinition["table"]>([
+  "pages",
+  "sections",
+  "entities",
+  "section_entities",
+  "entity_relations",
+])
+
+function isRecord(value: Json | unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value)
+}
+
+function stringValue(value: unknown) {
+  return typeof value === "string" && value.trim() ? value : null
+}
+
+function booleanValue(value: unknown) {
+  return typeof value === "boolean" ? value : undefined
+}
+
+function normalizeOptions(value: unknown): CmsFieldOption[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined
+  }
+
+  const options = value
+    .map((option): CmsFieldOption | null => {
+      if (!isRecord(option)) {
+        return null
+      }
+
+      const label = stringValue(option.label)
+      const optionValue = stringValue(option.value)
+
+      if (!label || !optionValue) {
+        return null
+      }
+
+      return { label, value: optionValue }
+    })
+    .filter((option): option is CmsFieldOption => Boolean(option))
+
+  return options.length ? options : undefined
+}
+
+function normalizeField(value: unknown): CmsFieldDefinition | null {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const key = stringValue(value.key)
+  const label = stringValue(value.label)
+  const type = stringValue(value.type)
+  const source = stringValue(value.source)
+
+  if (
+    !key ||
+    !label ||
+    !type ||
+    !source ||
+    !fieldTypes.has(type as CmsFieldType) ||
+    !fieldSources.has(source as CmsFieldSource)
+  ) {
+    return null
+  }
+
+  const description = stringValue(value.description)
+  const required = booleanValue(value.required)
+  const readOnly = booleanValue(value.readOnly ?? value.read_only)
+  const options = normalizeOptions(value.options)
+
+  return {
+    key,
+    label,
+    type: type as CmsFieldType,
+    source: source as CmsFieldSource,
+    ...(description ? { description } : {}),
+    ...(required === undefined ? {} : { required }),
+    ...(readOnly === undefined ? {} : { readOnly }),
+    ...(options ? { options } : {}),
+  }
+}
+
+function normalizeFields(value: Json): CmsFieldDefinition[] | null {
+  if (!Array.isArray(value)) {
+    return null
+  }
+
+  const fields = value
+    .map((field) => normalizeField(field))
+    .filter((field): field is CmsFieldDefinition => Boolean(field))
+
+  return fields.length === value.length && fields.length > 0 ? fields : null
+}
+
+function normalizeSchemaRow(row: EntitySchemaRow): CmsSchemaDefinition | null {
+  const kind = stringValue(row.kind)
+  const table = stringValue(row.table_name)
+  const fields = normalizeFields(row.fields)
+
+  if (
+    !schemaKinds.has(kind as CmsSchemaKind) ||
+    !schemaTables.has(table as CmsSchemaDefinition["table"]) ||
+    !fields
+  ) {
+    return getCmsSchema(row.schema_key)
+  }
+
+  return {
+    schemaKey: row.schema_key,
+    kind: kind as CmsSchemaKind,
+    table: table as CmsSchemaDefinition["table"],
+    label: row.label,
+    description: row.description,
+    fields,
+    relationSlots: row.relation_slots,
+  }
+}
+
+export const loadCmsSchemaRegistry = cache(
+  async (): Promise<CmsSchemaDefinition[]> => {
+    const supabase = await createClient()
+    const { data, error } = await supabase
+      .from("entity_schemas")
+      .select("schema_key, kind, table_name, label, description, fields, relation_slots")
+      .eq("active", true)
+      .order("schema_key", { ascending: true })
+
+    if (error) {
+      return cmsSchemaRegistry
+    }
+
+    const byKey = new Map(
+      cmsSchemaRegistry.map((schema) => [schema.schemaKey, schema]),
+    )
+
+    for (const row of data ?? []) {
+      const schema = normalizeSchemaRow(row)
+      if (schema) {
+        byKey.set(schema.schemaKey, schema)
+      }
+    }
+
+    return [...byKey.values()]
+  },
+)
+
+export const loadCmsSchemaRegistryMap = cache(
+  async (): Promise<Map<string, CmsSchemaDefinition>> => {
+    const registry = await loadCmsSchemaRegistry()
+    return new Map(registry.map((schema) => [schema.schemaKey, schema]))
+  },
+)
+
+export async function loadCmsSchema(schemaKey: string) {
+  const registry = await loadCmsSchemaRegistryMap()
+  return registry.get(schemaKey) ?? getCmsSchema(schemaKey)
+}
+
+export async function loadCmsSchemasByKind(kind: CmsSchemaKind) {
+  const registry = await loadCmsSchemaRegistry()
+  const schemas = registry.filter((schema) => schema.kind === kind)
+  return schemas.length ? schemas : getCmsSchemasByKind(kind)
+}

--- a/lib/cms/section-editor.server.ts
+++ b/lib/cms/section-editor.server.ts
@@ -1,0 +1,29 @@
+import {
+  canCreateSectionSchema,
+  editableSectionFieldsForSchema,
+  isSectionEditorSchema,
+} from "@/lib/cms/section-editor"
+import { loadCmsSchema, loadCmsSchemasByKind } from "@/lib/cms/schema-registry.server"
+
+export async function loadSectionEditorSchema(schemaKey: string) {
+  const schema = await loadCmsSchema(schemaKey)
+  return schema && isSectionEditorSchema(schema) ? schema : null
+}
+
+export async function loadSectionCreationSchema(schemaKey: string) {
+  const schema = await loadSectionEditorSchema(schemaKey)
+  return schema && canCreateSectionSchema(schema) ? schema : null
+}
+
+export async function loadSectionCreationSchemas() {
+  const schemas = await loadCmsSchemasByKind("section")
+  return schemas
+    .filter(canCreateSectionSchema)
+    .sort((left, right) => left.label.localeCompare(right.label))
+}
+
+export async function loadEditableSectionFields(schemaKey: string) {
+  const schema = await loadSectionEditorSchema(schemaKey)
+  return schema ? editableSectionFieldsForSchema(schema) : []
+}
+

--- a/lib/cms/section-editor.ts
+++ b/lib/cms/section-editor.ts
@@ -24,11 +24,15 @@ export function getSectionEditorSchema(
 ): CmsSchemaDefinition | null {
   const schema = getCmsSchema(schemaKey)
 
-  if (!schema || schema.kind !== "section" || schema.table !== "sections") {
+  if (!schema || !isSectionEditorSchema(schema)) {
     return null
   }
 
   return schema
+}
+
+export function isSectionEditorSchema(schema: CmsSchemaDefinition) {
+  return schema.kind === "section" && schema.table === "sections"
 }
 
 const sectionTypeBySchemaKey: Record<string, string> = {
@@ -70,16 +74,20 @@ function hasRequiredReadOnlyField(schema: CmsSchemaDefinition) {
   })
 }
 
+export function canCreateSectionSchema(schema: CmsSchemaDefinition) {
+  return (
+    isSectionEditorSchema(schema) &&
+    Boolean(sectionTypeFromSchemaKey(schema.schemaKey)) &&
+    !hasRequiredReadOnlyField(schema)
+  )
+}
+
 export function getSectionCreationSchema(
   schemaKey: string,
 ): CmsSchemaDefinition | null {
   const schema = getSectionEditorSchema(schemaKey)
 
-  if (!schema || !sectionTypeFromSchemaKey(schema.schemaKey)) {
-    return null
-  }
-
-  if (hasRequiredReadOnlyField(schema)) {
+  if (!schema || !canCreateSectionSchema(schema)) {
     return null
   }
 
@@ -99,6 +107,10 @@ export function getEditableSectionFields(schemaKey: string) {
     return []
   }
 
+  return editableSectionFieldsForSchema(schema)
+}
+
+export function editableSectionFieldsForSchema(schema: CmsSchemaDefinition) {
   return schema.fields.filter((field): field is CmsEditableSectionField => {
     if (field.readOnly) {
       return false


### PR DESCRIPTION
## Summary

- Closes #89.
- Adds server-only DB-first CMS schema registry loading from active `entity_schemas` rows.
- Keeps `lib/cms/schema-registry.ts` as the reviewed fallback and renderer compatibility contract.
- Routes PONIX entity, section, page, detail, relation, and composer editor flows through DB metadata where server-rendered.
- Passes DB-loaded entity field metadata into the client composer drawer instead of importing server loaders into client code.
- Updates docs to describe the current DB-first/fallback registry state.

## Supabase Impact

- No schema migration or production write.
- Read-only use of existing `entity_schemas.fields` and `relation_slots`.

## Verification

- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `pnpm run qa:cms-schema-registry -- --strict`
- `pnpm run qa:content-graph`
- `git diff --check`
- `pnpm run build`

## Notes

- Authenticated browser click-through of the PONIX editor forms was not run in this commit. The build covers the dynamic PONIX routes and server/client import boundaries.