### PR TITLE
Guard DB-first CMS loader boundaries

### DIFF
--- a/docs/content-graph.md
+++ b/docs/content-graph.md
@@ -126,6 +126,12 @@ with active DB `entity_schemas`. The command is intentionally read-only and
 should report `dbFieldMissing = 0` before DB-first editor behavior is considered
 safe.
 
+Use `pnpm run qa:cms-db-first-loaders` after PONIX editor or CMS loader changes.
+It is a read-only static guard that fails if server-rendered PONIX surfaces
+reintroduce direct code-only schema lookup helpers instead of the DB-first
+server loaders. The sync registry remains allowed only in reviewed fallback
+modules.
+
 ## Entity Schema Direction
 
 The long-term content contract is:

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "eslint .",
     "qa:content-graph": "node scripts/qa-content-graph-parity.mjs",
+    "qa:cms-db-first-loaders": "node scripts/qa-cms-db-first-loaders.mjs",
     "qa:cms-schema-registry": "node scripts/qa-cms-schema-registry.mjs"
   },
   "dependencies": {

--- a/scripts/qa-cms-db-first-loaders.mjs
+++ b/scripts/qa-cms-db-first-loaders.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs"
+import path from "node:path"
+
+const repoRoot = process.cwd()
+const scanRoots = ["app/ponix", "app/ponix-canvas", "lib/cms"]
+const codeExtensions = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs"])
+
+const fallbackFiles = new Set([
+  "lib/cms/schema-registry.ts",
+  "lib/cms/schema-registry.server.ts",
+  "lib/cms/entity-editor.ts",
+  "lib/cms/section-editor.ts",
+  "lib/cms/page-editor.ts",
+])
+
+const forbiddenNames = [
+  "getCmsSchema",
+  "getCmsSchemasByKind",
+  "getCmsSchemaStats",
+  "getEntityEditorSchema",
+  "getEntityCreationSchema",
+  "getEntityCreationSchemas",
+  "getEditableEntityFields",
+  "getSectionEditorSchema",
+  "getSectionCreationSchema",
+  "getSectionCreationSchemas",
+  "getEditableSectionFields",
+  "getPageEditorSchema",
+  "getEditablePageFields",
+]
+
+function repoRelative(filePath) {
+  return path.relative(repoRoot, filePath).split(path.sep).join("/")
+}
+
+function listFiles(dir) {
+  if (!existsSync(dir)) return []
+
+  const entries = readdirSync(dir)
+  return entries.flatMap((entry) => {
+    const absolute = path.join(dir, entry)
+    const stat = statSync(absolute)
+
+    if (stat.isDirectory()) {
+      if (entry === "node_modules" || entry === ".next") return []
+      return listFiles(absolute)
+    }
+
+    return codeExtensions.has(path.extname(entry)) ? [absolute] : []
+  })
+}
+
+function findForbiddenReferences(relativePath, source) {
+  if (fallbackFiles.has(relativePath)) {
+    return []
+  }
+
+  const lines = source.split(/\r?\n/)
+  const violations = []
+
+  for (const name of forbiddenNames) {
+    const pattern = new RegExp(`\\b${name}\\b`)
+    lines.forEach((line, index) => {
+      if (!pattern.test(line)) return
+
+      violations.push({
+        file: relativePath,
+        line: index + 1,
+        symbol: name,
+        text: line.trim(),
+      })
+    })
+  }
+
+  return violations
+}
+
+function runSelfTest() {
+  const blocked = findForbiddenReferences(
+    "app/ponix/example/page.tsx",
+    'import { getCmsSchema } from "@/lib/cms/schema-registry"\ngetCmsSchema("page/default/v1")',
+  )
+  const allowedFallback = findForbiddenReferences(
+    "lib/cms/schema-registry.server.ts",
+    'import { getCmsSchema } from "./schema-registry"\ngetCmsSchema("page/default/v1")',
+  )
+  const allowedTypeAndPureHelpers = findForbiddenReferences(
+    "app/ponix/example/component.tsx",
+    [
+      'import type { CmsSchemaDefinition } from "@/lib/cms/schema-registry"',
+      'import { editableEntityFieldsForSchema } from "@/lib/cms/entity-editor"',
+      "editableEntityFieldsForSchema(schema)",
+    ].join("\n"),
+  )
+
+  if (blocked.length === 0) {
+    throw new Error("Self-test failed: forbidden sync lookup was not detected.")
+  }
+
+  if (allowedFallback.length > 0 || allowedTypeAndPureHelpers.length > 0) {
+    throw new Error("Self-test failed: allowed fallback/type usage was rejected.")
+  }
+}
+
+runSelfTest()
+
+const files = scanRoots.flatMap((root) => listFiles(path.join(repoRoot, root)))
+const violations = files.flatMap((file) =>
+  findForbiddenReferences(repoRelative(file), readFileSync(file, "utf8")),
+)
+
+console.log("CMS DB-first loader guard")
+console.table([
+  {
+    scannedFiles: files.length,
+    fallbackFiles: fallbackFiles.size,
+    forbiddenSymbols: forbiddenNames.length,
+    violations: violations.length,
+    selfTest: "ok",
+  },
+])
+
+if (violations.length > 0) {
+  console.error("Forbidden code-only CMS schema lookup usage found:")
+  console.table(violations)
+  console.error(
+    [
+      "Use server DB-first loaders from lib/cms/*-editor.server.ts or",
+      "lib/cms/schema-registry.server.ts. Keep sync lookup helpers only in",
+      "the reviewed fallback modules.",
+    ].join(" "),
+  )
+  process.exit(1)
+}
+


### PR DESCRIPTION
## Summary

- Closes #92.
- Adds `pnpm run qa:cms-db-first-loaders` as a read-only static guard.
- The guard scans `app/ponix`, `app/ponix-canvas`, and `lib/cms` for forbidden direct code-only schema lookup helpers outside reviewed fallback modules.
- Includes built-in self-tests proving direct `getCmsSchema` usage is caught while fallback/type/pure helper usage remains allowed.
- Documents when to run the new guard in `docs/content-graph.md`.

## Supabase Impact

- None. No DB reads/writes, migrations, RLS, auth, or storage changes.

## Verification

- `pnpm run qa:cms-db-first-loaders`
- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `git diff --check`
- `pnpm run qa:cms-schema-registry -- --strict`
- `pnpm run qa:content-graph`
- `pnpm run build`

## Notes

- CI wiring for the new script is still a follow-up; this PR only adds the guard and npm script.
- Supersedes #93; the previous PR used a branch prefix not accepted by the issue-driven guard.