### PR TITLE
Run CMS DB-first loader guard in CI

### DIFF
--- a/.github/workflows/cms-db-first-loader-guard.yml
+++ b/.github/workflows/cms-db-first-loader-guard.yml
@@ -1,0 +1,41 @@
+name: CMS DB-first loader guard
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/cms-db-first-loader-guard.yml"
+      - "app/ponix/**"
+      - "app/ponix-canvas/**"
+      - "lib/cms/**"
+      - "scripts/qa-cms-db-first-loaders.mjs"
+      - "package.json"
+      - "pnpm-lock.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cms-db-first-loaders:
+    name: CMS DB-first loaders
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.27.0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run CMS DB-first loader guard
+        run: pnpm run qa:cms-db-first-loaders


### PR DESCRIPTION
## Summary

- Closes #95.
- Adds a targeted GitHub Actions workflow for `pnpm run qa:cms-db-first-loaders`.
- Runs only when PONIX/CMS loader, guard script, package, lockfile, or workflow files change.
- Keeps the check read-only and credential-free.

## Supabase Impact

- None. No DB reads/writes, migrations, RLS, auth, storage, or secrets involved.

## Verification

- `pnpm run qa:cms-db-first-loaders`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/cms-db-first-loader-guard.yml"); puts "yaml: ok"'`\n- `git diff --cached --check`\n\n## Notes\n\n- The new GitHub Actions workflow itself still needs to run on this PR before merge.