### PR TITLE
Move seed apply scripts to graph-primary composition writes

### DIFF
--- a/docs/content-graph.md
+++ b/docs/content-graph.md
@@ -58,10 +58,15 @@ Current PONIX contract:
 - Routine CMS composition writes target `entity_relations`; graph-to-legacy
   triggers mirror those writes back into `page_sections` and
   `section_entities`.
+- Maintenance apply scripts that refresh scraped or Instagram content should
+  also write section placement through `entity_relations`, not directly through
+  `page_sections` or `section_entities`.
 - Code that mutates page or section composition must pass the graph relation id,
   not the legacy `source_id`.
 - `pnpm run qa:content-graph` checks both page-render parity and global
   graph/legacy mirror integrity for page-section and section-entity relations.
+- `pnpm run qa:graph-primary-seed-writes` checks that seed apply scripts do not
+  reintroduce direct legacy composition writes.
 
 ## Tables
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "qa:content-graph": "node scripts/qa-content-graph-parity.mjs",
     "qa:cms-db-first-loaders": "node scripts/qa-cms-db-first-loaders.mjs",
-    "qa:cms-schema-registry": "node scripts/qa-cms-schema-registry.mjs"
+    "qa:cms-schema-registry": "node scripts/qa-cms-schema-registry.mjs",
+    "qa:graph-primary-seed-writes": "node scripts/qa-graph-primary-seed-writes.mjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",

--- a/scripts/apply-instagram-feed.mjs
+++ b/scripts/apply-instagram-feed.mjs
@@ -1,5 +1,10 @@
 import { createClient } from "@supabase/supabase-js"
 import { readFileSync } from "node:fs"
+import {
+  deleteSectionEntityRelations,
+  upsertPageSectionRelations,
+  upsertSectionEntityRelations,
+} from "./content-graph-write-helpers.mjs"
 
 const rowsPath = process.argv[2] ?? "/tmp/bremen_instagram_seed_rows.json"
 const envPath = ".env.local"
@@ -113,16 +118,16 @@ async function main() {
   )
 
   if (page && performanceUpdatesSection) {
-    requireOk(
-      await supabase.from("page_sections").upsert(
+    await upsertPageSectionRelations(
+      supabase,
+      [
         {
           page_id: page.id,
           section_id: performanceUpdatesSection.id,
           sort_order: 25,
           props: {},
         },
-        { onConflict: "page_id,section_id" },
-      ),
+      ],
       "upsert performances page section",
     )
   }
@@ -218,17 +223,12 @@ async function main() {
   )
 
   const sectionIds = [gallerySection?.id, performanceUpdatesSection?.id].filter(Boolean)
-  for (const sectionId of sectionIds) {
-    for (const ids of chunk(instagramIds)) {
-      requireOk(
-        await supabase
-          .from("section_entities")
-          .delete()
-          .eq("section_id", sectionId)
-          .in("entity_id", ids),
-        "delete old Instagram section links",
-      )
-    }
+  if (sectionIds.length && instagramIds.length) {
+    await deleteSectionEntityRelations(supabase, {
+      sectionIds,
+      entityIds: instagramIds,
+      label: "delete old Instagram section links",
+    })
   }
 
   const photos = entities
@@ -275,11 +275,9 @@ async function main() {
   ]
 
   if (sectionEntities.length) {
-    await upsertChunked(
+    await upsertSectionEntityRelations(
       supabase,
-      "section_entities",
       sectionEntities,
-      { onConflict: "section_id,entity_id,relation_type,slot" },
       "upsert Instagram section links",
     )
   }

--- a/scripts/apply-scraped-content.mjs
+++ b/scripts/apply-scraped-content.mjs
@@ -1,5 +1,10 @@
 import { createClient } from "@supabase/supabase-js"
 import { readFileSync } from "node:fs"
+import {
+  deleteSectionEntityRelations,
+  upsertPageSectionRelations,
+  upsertSectionEntityRelations,
+} from "./content-graph-write-helpers.mjs"
 
 const envPath = ".env.local"
 const rowsPath = process.argv[2] ?? "/tmp/bremen_seed_rows.json"
@@ -151,24 +156,22 @@ async function main() {
   const pageBySlug = new Map(pages.map((page) => [page.slug, page]))
   const sectionByKey = new Map(sections.map((section) => [section.key, section]))
 
-  requireOk(
-    await supabase.from("page_sections").upsert(
-      [
-        {
-          page_id: pageBySlug.get("videos").id,
-          section_id: sectionByKey.get("videos-by-event").id,
-          sort_order: 25,
-          props: {},
-        },
-        {
-          page_id: pageBySlug.get("history").id,
-          section_id: sectionByKey.get("history-timeline").id,
-          sort_order: 10,
-          props: {},
-        },
-      ],
-      { onConflict: "page_id,section_id" },
-    ),
+  await upsertPageSectionRelations(
+    supabase,
+    [
+      {
+        page_id: pageBySlug.get("videos").id,
+        section_id: sectionByKey.get("videos-by-event").id,
+        sort_order: 25,
+        props: {},
+      },
+      {
+        page_id: pageBySlug.get("history").id,
+        section_id: sectionByKey.get("history-timeline").id,
+        sort_order: 10,
+        props: {},
+      },
+    ],
     "upsert page sections",
   )
 
@@ -288,10 +291,10 @@ async function main() {
   const seededSectionByKey = new Map(seededSections.map((section) => [section.key, section]))
   const sectionIds = seededSections.map((section) => section.id)
 
-  requireOk(
-    await supabase.from("section_entities").delete().in("section_id", sectionIds),
-    "clear section entities",
-  )
+  await deleteSectionEntityRelations(supabase, {
+    sectionIds,
+    label: "clear section entities",
+  })
 
   const allPerformances = requireOk(
     await supabase
@@ -387,11 +390,9 @@ async function main() {
   )
   addSectionItems("history-timeline", allHistory.sort(sortByRank))
 
-  await upsertChunked(
+  await upsertSectionEntityRelations(
     supabase,
-    "section_entities",
     sectionEntities,
-    { onConflict: "section_id,entity_id,relation_type,slot" },
     "upsert section entities",
   )
 

--- a/scripts/content-graph-write-helpers.mjs
+++ b/scripts/content-graph-write-helpers.mjs
@@ -1,0 +1,204 @@
+const CHUNK_SIZE = 100
+
+function requireOk(result, label) {
+  if (result.error) {
+    throw new Error(`${label}: ${result.error.message}`)
+  }
+
+  return result.data ?? []
+}
+
+function chunk(items, size = CHUNK_SIZE) {
+  const chunks = []
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size))
+  }
+  return chunks
+}
+
+function uniqueStrings(values) {
+  return [...new Set(values.filter((value) => typeof value === "string" && value))]
+}
+
+async function upsertRelationRows(supabase, rows, label) {
+  for (const [index, part] of chunk(rows).entries()) {
+    requireOk(
+      await supabase
+        .from("entity_relations")
+        .upsert(part, { onConflict: "from_entity_id,to_entity_id,relation_type,slot" }),
+      `${label} chunk ${index + 1}`,
+    )
+  }
+}
+
+async function loadShadowEntityMap(supabase, sourceTable, sourceIds, label) {
+  const ids = uniqueStrings(sourceIds)
+  if (!ids.length) return new Map()
+
+  const rows = []
+  for (const part of chunk(ids)) {
+    rows.push(
+      ...requireOk(
+        await supabase
+          .from("entities")
+          .select("id,source_id")
+          .eq("source_table", sourceTable)
+          .in("source_id", part),
+        `${label} ${sourceTable} shadow entities`,
+      ),
+    )
+  }
+
+  const bySourceId = new Map(rows.map((row) => [row.source_id, row.id]))
+  const missing = ids.filter((id) => !bySourceId.has(id))
+  if (missing.length) {
+    throw new Error(
+      `${label}: missing ${sourceTable} shadow entities for ${missing.join(", ")}`,
+    )
+  }
+
+  return bySourceId
+}
+
+function relationId(value, camelKey, snakeKey) {
+  return value[camelKey] ?? value[snakeKey]
+}
+
+function requiredRelationId(value, camelKey, snakeKey, label) {
+  const id = relationId(value, camelKey, snakeKey)
+  if (typeof id !== "string" || !id) {
+    throw new Error(`${label}: missing ${camelKey}/${snakeKey}`)
+  }
+
+  return id
+}
+
+function relationNumber(value, camelKey, snakeKey, fallback = 0) {
+  return Number(value[camelKey] ?? value[snakeKey] ?? fallback)
+}
+
+function relationProps(value) {
+  return value.props ?? {}
+}
+
+export async function upsertPageSectionRelations(
+  supabase,
+  placements,
+  label = "upsert page-section graph relations",
+) {
+  const rows = placements.filter(Boolean)
+  if (!rows.length) return 0
+
+  const pageIds = rows.map((row) =>
+    requiredRelationId(row, "pageId", "page_id", label),
+  )
+  const sectionIds = rows.map((row) =>
+    requiredRelationId(row, "sectionId", "section_id", label),
+  )
+  const [pageEntities, sectionEntities] = await Promise.all([
+    loadShadowEntityMap(supabase, "pages", pageIds, label),
+    loadShadowEntityMap(supabase, "sections", sectionIds, label),
+  ])
+
+  await upsertRelationRows(
+    supabase,
+    rows.map((row) => {
+      const pageId = requiredRelationId(row, "pageId", "page_id", label)
+      const sectionId = requiredRelationId(row, "sectionId", "section_id", label)
+
+      return {
+        from_entity_id: pageEntities.get(pageId),
+        to_entity_id: sectionEntities.get(sectionId),
+        schema_key: "relation/page-section/v1",
+        relation_type: "contains_section",
+        slot: "sections",
+        sort_order: relationNumber(row, "sortOrder", "sort_order"),
+        props: relationProps(row),
+        source_table: "page_sections",
+      }
+    }),
+    label,
+  )
+
+  return rows.length
+}
+
+export async function deleteSectionEntityRelations(
+  supabase,
+  { sectionIds = [], entityIds = [], label = "delete section-entity graph relations" },
+) {
+  const normalizedSectionIds = uniqueStrings(sectionIds)
+  const normalizedEntityIds = uniqueStrings(entityIds)
+
+  if (!normalizedSectionIds.length && !normalizedEntityIds.length) {
+    throw new Error(`${label}: refusing to delete unscoped section-entity relations`)
+  }
+
+  const sectionEntities = normalizedSectionIds.length
+    ? await loadShadowEntityMap(supabase, "sections", normalizedSectionIds, label)
+    : new Map()
+  const fromEntityIds = [...sectionEntities.values()]
+
+  if (normalizedSectionIds.length && !fromEntityIds.length) return 0
+
+  const entityChunks = normalizedEntityIds.length ? chunk(normalizedEntityIds) : [null]
+  for (const [index, entityChunk] of entityChunks.entries()) {
+    let query = supabase
+      .from("entity_relations")
+      .delete()
+      .eq("source_table", "section_entities")
+
+    if (fromEntityIds.length) {
+      query = query.in("from_entity_id", fromEntityIds)
+    }
+
+    if (entityChunk) {
+      query = query.in("to_entity_id", entityChunk)
+    }
+
+    requireOk(await query, `${label} chunk ${index + 1}`)
+  }
+
+  return entityChunks.length
+}
+
+export async function upsertSectionEntityRelations(
+  supabase,
+  placements,
+  label = "upsert section-entity graph relations",
+) {
+  const rows = placements.filter(Boolean)
+  if (!rows.length) return 0
+
+  const sectionIds = rows.map((row) =>
+    requiredRelationId(row, "sectionId", "section_id", label),
+  )
+  const sectionEntities = await loadShadowEntityMap(
+    supabase,
+    "sections",
+    sectionIds,
+    label,
+  )
+
+  await upsertRelationRows(
+    supabase,
+    rows.map((row) => {
+      const sectionId = requiredRelationId(row, "sectionId", "section_id", label)
+      const entityId = requiredRelationId(row, "entityId", "entity_id", label)
+
+      return {
+        from_entity_id: sectionEntities.get(sectionId),
+        to_entity_id: entityId,
+        schema_key: "relation/section-entity/v1",
+        relation_type: relationId(row, "relationType", "relation_type") ?? "item",
+        slot: row.slot ?? "default",
+        sort_order: relationNumber(row, "sortOrder", "sort_order"),
+        props: relationProps(row),
+        source_table: "section_entities",
+      }
+    }),
+    label,
+  )
+
+  return rows.length
+}

--- a/scripts/qa-graph-primary-seed-writes.mjs
+++ b/scripts/qa-graph-primary-seed-writes.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs"
+
+const scanFiles = [
+  "scripts/apply-instagram-feed.mjs",
+  "scripts/apply-scraped-content.mjs",
+]
+
+const forbiddenPatterns = [
+  {
+    label: "direct page_sections Supabase table access",
+    pattern: /(?:^|[^\w])from\(\s*["'`]page_sections["'`]\s*\)/,
+  },
+  {
+    label: "direct section_entities Supabase table access",
+    pattern: /(?:^|[^\w])from\(\s*["'`]section_entities["'`]\s*\)/,
+  },
+  {
+    label: "direct page_sections upsert helper target",
+    pattern: /upsertChunked\(\s*supabase\s*,\s*["'`]page_sections["'`]/,
+  },
+  {
+    label: "direct section_entities upsert helper target",
+    pattern: /upsertChunked\(\s*supabase\s*,\s*["'`]section_entities["'`]/,
+  },
+]
+
+function scanText(file, text) {
+  const violations = []
+
+  for (const [index, line] of text.split(/\r?\n/).entries()) {
+    for (const forbidden of forbiddenPatterns) {
+      if (forbidden.pattern.test(line)) {
+        violations.push({
+          file,
+          line: index + 1,
+          rule: forbidden.label,
+          text: line.trim(),
+        })
+      }
+    }
+  }
+
+  return violations
+}
+
+function runSelfTest() {
+  const shouldFail = scanText(
+    "scripts/apply-example.mjs",
+    'await supabase.from("section_entities").upsert(rows)',
+  )
+  const shouldPass = scanText(
+    "scripts/apply-example.mjs",
+    'await upsertSectionEntityRelations(supabase, rows, "seed links")',
+  )
+
+  if (shouldFail.length !== 1 || shouldPass.length !== 0) {
+    throw new Error("Self-test failed for graph-primary seed write guard.")
+  }
+}
+
+runSelfTest()
+
+const violations = scanFiles.flatMap((file) => scanText(file, readFileSync(file, "utf8")))
+
+console.log("Graph-primary seed write guard")
+console.table([
+  {
+    scannedFiles: scanFiles.length,
+    forbiddenPatterns: forbiddenPatterns.length,
+    violations: violations.length,
+    selfTest: "ok",
+  },
+])
+
+if (violations.length) {
+  console.error("\nLegacy composition writes found in seed apply scripts:")
+  for (const violation of violations) {
+    console.error(
+      `- ${violation.file}:${violation.line} ${violation.rule}: ${violation.text}`,
+    )
+  }
+  console.error(
+    "\nUse scripts/content-graph-write-helpers.mjs so writes target entity_relations and database triggers maintain the legacy mirrors.",
+  )
+  process.exitCode = 1
+}


### PR DESCRIPTION
## Summary

- Closes #97.
- Adds `scripts/content-graph-write-helpers.mjs` for graph-primary page-section and section-entity writes.
- Updates `apply-scraped-content` and `apply-instagram-feed` so composition deletes/upserts target `entity_relations`, with DB triggers maintaining legacy mirrors.
- Adds `pnpm run qa:graph-primary-seed-writes` to prevent direct legacy composition writes from returning to apply scripts.
- Documents the maintenance-script graph-primary contract in `docs/content-graph.md`.

## Supabase Impact

- No schema changes or production writes in this PR.
- The apply scripts were not executed.
- Future script executions still require the existing service-role maintenance flow, but composition writes will go through `entity_relations`.

## Verification

- `node --check scripts/content-graph-write-helpers.mjs`
- `node --check scripts/qa-graph-primary-seed-writes.mjs`
- `node --check scripts/apply-instagram-feed.mjs`
- `node --check scripts/apply-scraped-content.mjs`
- `pnpm run qa:graph-primary-seed-writes`
- `pnpm run lint`
- `pnpm exec tsc --noEmit`
- `pnpm run qa:cms-db-first-loaders`
- `git diff --check`
- `pnpm run qa:content-graph`
- `pnpm run build`

## Not Tested

- Did not run `scripts/apply-scraped-content.mjs` or `scripts/apply-instagram-feed.mjs` against Supabase because that would mutate content data.