### PR TITLE
Generate graph-primary seed migration SQL

### DIFF
--- a/docs/content-graph.md
+++ b/docs/content-graph.md
@@ -58,15 +58,16 @@ Current PONIX contract:
 - Routine CMS composition writes target `entity_relations`; graph-to-legacy
   triggers mirror those writes back into `page_sections` and
   `section_entities`.
-- Maintenance apply scripts that refresh scraped or Instagram content should
-  also write section placement through `entity_relations`, not directly through
-  `page_sections` or `section_entities`.
+- Maintenance apply scripts and generated seed migrations that refresh scraped
+  or Instagram content should also write section placement through
+  `entity_relations`, not directly through `page_sections` or
+  `section_entities`.
 - Code that mutates page or section composition must pass the graph relation id,
   not the legacy `source_id`.
 - `pnpm run qa:content-graph` checks both page-render parity and global
   graph/legacy mirror integrity for page-section and section-entity relations.
-- `pnpm run qa:graph-primary-seed-writes` checks that seed apply scripts do not
-  reintroduce direct legacy composition writes.
+- `pnpm run qa:graph-primary-seed-writes` checks that seed apply scripts and
+  migration generators do not reintroduce direct legacy composition writes.
 
 ## Tables
 

--- a/scripts/generate-instagram-feed-migration.mjs
+++ b/scripts/generate-instagram-feed-migration.mjs
@@ -338,17 +338,43 @@ set section_type = excluded.section_type,
     props = excluded.props;
 
 with target as (
-  select page.id as page_id, section.id as section_id
+  select page_entity.id as page_entity_id, section_entity.id as section_entity_id
   from public.pages page
   join public.sections section on section.key = 'performances-updates'
+  join public.entities page_entity
+    on page_entity.source_table = 'pages'
+   and page_entity.source_id = page.id
+  join public.entities section_entity
+    on section_entity.source_table = 'sections'
+   and section_entity.source_id = section.id
   where page.slug = 'performances'
 )
-insert into public.page_sections (page_id, section_id, sort_order, props)
-select page_id, section_id, 25, '{}'::jsonb
+insert into public.entity_relations (
+  from_entity_id,
+  to_entity_id,
+  schema_key,
+  relation_type,
+  slot,
+  sort_order,
+  props,
+  source_table
+)
+select
+  page_entity_id,
+  section_entity_id,
+  'relation/page-section/v1',
+  'contains_section',
+  'sections',
+  25,
+  '{}'::jsonb,
+  'page_sections'
 from target
-on conflict (page_id, section_id) do update
-set sort_order = excluded.sort_order,
-    props = excluded.props;
+on conflict (from_entity_id, to_entity_id, relation_type, slot) do update
+set schema_key = excluded.schema_key,
+    sort_order = excluded.sort_order,
+    props = excluded.props,
+    source_table = excluded.source_table,
+    source_id = excluded.source_id;
 
 insert into public.entities (
   entity_type,
@@ -417,15 +443,23 @@ on conflict (from_entity_id, to_entity_id, relation_type, slot) do update
 set sort_order = excluded.sort_order,
     props = excluded.props;
 
-delete from public.section_entities section_entity
-using public.sections section_ref, public.entities entity
-where section_entity.section_id = section_ref.id
-  and section_entity.entity_id = entity.id
+delete from public.entity_relations relation
+using public.entities section_entity, public.sections section_ref, public.entities entity
+where relation.source_table = 'section_entities'
+  and relation.from_entity_id = section_entity.id
+  and relation.to_entity_id = entity.id
+  and section_entity.source_table = 'sections'
+  and section_entity.source_id = section_ref.id
   and section_ref.key = 'photos-gallery'
   and entity.data->>'source' = 'instagram';
 
 with target_section as (
-  select id from public.sections where key = 'photos-gallery'
+  select section_entity.id as section_entity_id
+  from public.sections section_ref
+  join public.entities section_entity
+    on section_entity.source_table = 'sections'
+   and section_entity.source_id = section_ref.id
+  where section_ref.key = 'photos-gallery'
 ),
 ordered as (
   select
@@ -437,36 +471,51 @@ ordered as (
     and coalesce((entity.data->>'gallery_include')::boolean, false) = true
     and entity.published = true
 )
-insert into public.section_entities (
-  section_id,
-  entity_id,
+insert into public.entity_relations (
+  from_entity_id,
+  to_entity_id,
+  schema_key,
   relation_type,
   slot,
   sort_order,
-  props
+  props,
+  source_table
 )
 select
-  target_section.id,
+  target_section.section_entity_id,
   ordered.id,
+  'relation/section-entity/v1',
   'features_photo',
   'gallery',
   ordered.rank * 10,
-  '{}'::jsonb
+  '{}'::jsonb,
+  'section_entities'
 from target_section
 cross join ordered
-on conflict (section_id, entity_id, relation_type, slot) do update
-set sort_order = excluded.sort_order,
-    props = excluded.props;
+on conflict (from_entity_id, to_entity_id, relation_type, slot) do update
+set schema_key = excluded.schema_key,
+    sort_order = excluded.sort_order,
+    props = excluded.props,
+    source_table = excluded.source_table,
+    source_id = excluded.source_id;
 
-delete from public.section_entities section_entity
-using public.sections section_ref, public.entities entity
-where section_entity.section_id = section_ref.id
-  and section_entity.entity_id = entity.id
+delete from public.entity_relations relation
+using public.entities section_entity, public.sections section_ref, public.entities entity
+where relation.source_table = 'section_entities'
+  and relation.from_entity_id = section_entity.id
+  and relation.to_entity_id = entity.id
+  and section_entity.source_table = 'sections'
+  and section_entity.source_id = section_ref.id
   and section_ref.key = 'performances-updates'
   and entity.data->>'source' = 'instagram';
 
 with target_section as (
-  select id from public.sections where key = 'performances-updates'
+  select section_entity.id as section_entity_id
+  from public.sections section_ref
+  join public.entities section_entity
+    on section_entity.source_table = 'sections'
+   and section_entity.source_id = section_ref.id
+  where section_ref.key = 'performances-updates'
 ),
 ordered as (
   select
@@ -479,26 +528,33 @@ ordered as (
     and coalesce((entity.data->>'gallery_include')::boolean, false) = false
     and entity.published = true
 )
-insert into public.section_entities (
-  section_id,
-  entity_id,
+insert into public.entity_relations (
+  from_entity_id,
+  to_entity_id,
+  schema_key,
   relation_type,
   slot,
   sort_order,
-  props
+  props,
+  source_table
 )
 select
-  target_section.id,
+  target_section.section_entity_id,
   ordered.id,
+  'relation/section-entity/v1',
   'features_post',
   ordered.content_kind,
   ordered.rank * 10,
-  '{}'::jsonb
+  '{}'::jsonb,
+  'section_entities'
 from target_section
 cross join ordered
-on conflict (section_id, entity_id, relation_type, slot) do update
-set sort_order = excluded.sort_order,
-    props = excluded.props;
+on conflict (from_entity_id, to_entity_id, relation_type, slot) do update
+set schema_key = excluded.schema_key,
+    sort_order = excluded.sort_order,
+    props = excluded.props,
+    source_table = excluded.source_table,
+    source_id = excluded.source_id;
 `
 
 writeFileSync(outputPath, sql)

--- a/scripts/generate-scraped-content-migration.mjs
+++ b/scripts/generate-scraped-content-migration.mjs
@@ -604,14 +604,40 @@ with links(page_slug, section_key, sort_order) as (
     ('videos', 'videos-by-event', 25),
     ('history', 'history-timeline', 10)
 )
-insert into public.page_sections (page_id, section_id, sort_order, props)
-select page_ref.id, section_ref.id, links.sort_order, '{}'::jsonb
+insert into public.entity_relations (
+  from_entity_id,
+  to_entity_id,
+  schema_key,
+  relation_type,
+  slot,
+  sort_order,
+  props,
+  source_table
+)
+select
+  page_entity.id,
+  section_entity.id,
+  'relation/page-section/v1',
+  'contains_section',
+  'sections',
+  links.sort_order,
+  '{}'::jsonb,
+  'page_sections'
 from links
 join public.pages page_ref on page_ref.slug = links.page_slug
 join public.sections section_ref on section_ref.key = links.section_key
-on conflict (page_id, section_id) do update
-set sort_order = excluded.sort_order,
-    props = excluded.props;
+join public.entities page_entity
+  on page_entity.source_table = 'pages'
+ and page_entity.source_id = page_ref.id
+join public.entities section_entity
+  on section_entity.source_table = 'sections'
+ and section_entity.source_id = section_ref.id
+on conflict (from_entity_id, to_entity_id, relation_type, slot) do update
+set schema_key = excluded.schema_key,
+    sort_order = excluded.sort_order,
+    props = excluded.props,
+    source_table = excluded.source_table,
+    source_id = excluded.source_id;
 
 insert into public.entities (entity_type, schema_key, slug, title, subtitle, summary, thumbnail_url, sort_at, data, published)
 values
@@ -740,13 +766,21 @@ on conflict (from_entity_id, to_entity_id, relation_type, slot) do update
 set sort_order = excluded.sort_order,
     props = excluded.props;
 
-delete from public.section_entities section_entity
-using public.sections section_ref
-where section_entity.section_id = section_ref.id
+delete from public.entity_relations relation
+using public.entities section_entity, public.sections section_ref
+where relation.source_table = 'section_entities'
+  and relation.from_entity_id = section_entity.id
+  and section_entity.source_table = 'sections'
+  and section_entity.source_id = section_ref.id
   and section_ref.key in (${sectionKeys.map(sqlString).join(", ")});
 
 with target_section as (
-  select id from public.sections where key = 'performances-current-season'
+  select section_entity.id as section_entity_id
+  from public.sections section_ref
+  join public.entities section_entity
+    on section_entity.source_table = 'sections'
+   and section_entity.source_id = section_ref.id
+  where section_ref.key = 'performances-current-season'
 ),
 ordered as (
   select
@@ -757,15 +791,40 @@ ordered as (
     and entity.published = true
     and coalesce(entity.data->>'year', extract(year from entity.sort_at)::text) = '2026'
 )
-insert into public.section_entities (section_id, entity_id, relation_type, slot, sort_order, props)
-select target_section.id, ordered.id, 'item', 'default', (ordered.rank * 10)::int, '{}'::jsonb
+insert into public.entity_relations (
+  from_entity_id,
+  to_entity_id,
+  schema_key,
+  relation_type,
+  slot,
+  sort_order,
+  props,
+  source_table
+)
+select
+  target_section.section_entity_id,
+  ordered.id,
+  'relation/section-entity/v1',
+  'item',
+  'default',
+  (ordered.rank * 10)::int,
+  '{}'::jsonb,
+  'section_entities'
 from target_section cross join ordered
-on conflict (section_id, entity_id, relation_type, slot) do update
-set sort_order = excluded.sort_order,
-    props = excluded.props;
+on conflict (from_entity_id, to_entity_id, relation_type, slot) do update
+set schema_key = excluded.schema_key,
+    sort_order = excluded.sort_order,
+    props = excluded.props,
+    source_table = excluded.source_table,
+    source_id = excluded.source_id;
 
 with target_section as (
-  select id from public.sections where key = 'performances-archive'
+  select section_entity.id as section_entity_id
+  from public.sections section_ref
+  join public.entities section_entity
+    on section_entity.source_table = 'sections'
+   and section_entity.source_id = section_ref.id
+  where section_ref.key = 'performances-archive'
 ),
 ordered as (
   select
@@ -779,15 +838,40 @@ ordered as (
   where entity.entity_type = 'performance'
     and entity.published = true
 )
-insert into public.section_entities (section_id, entity_id, relation_type, slot, sort_order, props)
-select target_section.id, ordered.id, 'item', ordered.slot, (ordered.rank * 10)::int, '{}'::jsonb
+insert into public.entity_relations (
+  from_entity_id,
+  to_entity_id,
+  schema_key,
+  relation_type,
+  slot,
+  sort_order,
+  props,
+  source_table
+)
+select
+  target_section.section_entity_id,
+  ordered.id,
+  'relation/section-entity/v1',
+  'item',
+  ordered.slot,
+  (ordered.rank * 10)::int,
+  '{}'::jsonb,
+  'section_entities'
 from target_section cross join ordered
-on conflict (section_id, entity_id, relation_type, slot) do update
-set sort_order = excluded.sort_order,
-    props = excluded.props;
+on conflict (from_entity_id, to_entity_id, relation_type, slot) do update
+set schema_key = excluded.schema_key,
+    sort_order = excluded.sort_order,
+    props = excluded.props,
+    source_table = excluded.source_table,
+    source_id = excluded.source_id;
 
 with target_section as (
-  select id from public.sections where key = 'videos-featured'
+  select section_entity.id as section_entity_id
+  from public.sections section_ref
+  join public.entities section_entity
+    on section_entity.source_table = 'sections'
+   and section_entity.source_id = section_ref.id
+  where section_ref.key = 'videos-featured'
 ),
 ordered as (
   select
@@ -799,15 +883,40 @@ ordered as (
     and coalesce((entity.data->>'is_highlight')::boolean, false) = true
   limit 6
 )
-insert into public.section_entities (section_id, entity_id, relation_type, slot, sort_order, props)
-select target_section.id, ordered.id, 'item', 'default', (ordered.rank * 10)::int, '{}'::jsonb
+insert into public.entity_relations (
+  from_entity_id,
+  to_entity_id,
+  schema_key,
+  relation_type,
+  slot,
+  sort_order,
+  props,
+  source_table
+)
+select
+  target_section.section_entity_id,
+  ordered.id,
+  'relation/section-entity/v1',
+  'item',
+  'default',
+  (ordered.rank * 10)::int,
+  '{}'::jsonb,
+  'section_entities'
 from target_section cross join ordered
-on conflict (section_id, entity_id, relation_type, slot) do update
-set sort_order = excluded.sort_order,
-    props = excluded.props;
+on conflict (from_entity_id, to_entity_id, relation_type, slot) do update
+set schema_key = excluded.schema_key,
+    sort_order = excluded.sort_order,
+    props = excluded.props,
+    source_table = excluded.source_table,
+    source_id = excluded.source_id;
 
 with target_section as (
-  select id from public.sections where key = 'videos-popular'
+  select section_entity.id as section_entity_id
+  from public.sections section_ref
+  join public.entities section_entity
+    on section_entity.source_table = 'sections'
+   and section_entity.source_id = section_ref.id
+  where section_ref.key = 'videos-popular'
 ),
 ordered as (
   select
@@ -820,15 +929,40 @@ ordered as (
     and entity.published = true
   limit 6
 )
-insert into public.section_entities (section_id, entity_id, relation_type, slot, sort_order, props)
-select target_section.id, ordered.id, 'item', 'default', (ordered.rank * 10)::int, '{}'::jsonb
+insert into public.entity_relations (
+  from_entity_id,
+  to_entity_id,
+  schema_key,
+  relation_type,
+  slot,
+  sort_order,
+  props,
+  source_table
+)
+select
+  target_section.section_entity_id,
+  ordered.id,
+  'relation/section-entity/v1',
+  'item',
+  'default',
+  (ordered.rank * 10)::int,
+  '{}'::jsonb,
+  'section_entities'
 from target_section cross join ordered
-on conflict (section_id, entity_id, relation_type, slot) do update
-set sort_order = excluded.sort_order,
-    props = excluded.props;
+on conflict (from_entity_id, to_entity_id, relation_type, slot) do update
+set schema_key = excluded.schema_key,
+    sort_order = excluded.sort_order,
+    props = excluded.props,
+    source_table = excluded.source_table,
+    source_id = excluded.source_id;
 
 with target_section as (
-  select id from public.sections where key = 'videos-library'
+  select section_entity.id as section_entity_id
+  from public.sections section_ref
+  join public.entities section_entity
+    on section_entity.source_table = 'sections'
+   and section_entity.source_id = section_ref.id
+  where section_ref.key = 'videos-library'
 ),
 ordered as (
   select
@@ -838,15 +972,40 @@ ordered as (
   where entity.entity_type = 'video'
     and entity.published = true
 )
-insert into public.section_entities (section_id, entity_id, relation_type, slot, sort_order, props)
-select target_section.id, ordered.id, 'item', 'default', (ordered.rank * 10)::int, '{}'::jsonb
+insert into public.entity_relations (
+  from_entity_id,
+  to_entity_id,
+  schema_key,
+  relation_type,
+  slot,
+  sort_order,
+  props,
+  source_table
+)
+select
+  target_section.section_entity_id,
+  ordered.id,
+  'relation/section-entity/v1',
+  'item',
+  'default',
+  (ordered.rank * 10)::int,
+  '{}'::jsonb,
+  'section_entities'
 from target_section cross join ordered
-on conflict (section_id, entity_id, relation_type, slot) do update
-set sort_order = excluded.sort_order,
-    props = excluded.props;
+on conflict (from_entity_id, to_entity_id, relation_type, slot) do update
+set schema_key = excluded.schema_key,
+    sort_order = excluded.sort_order,
+    props = excluded.props,
+    source_table = excluded.source_table,
+    source_id = excluded.source_id;
 
 with target_section as (
-  select id from public.sections where key = 'videos-by-event'
+  select section_entity.id as section_entity_id
+  from public.sections section_ref
+  join public.entities section_entity
+    on section_entity.source_table = 'sections'
+   and section_entity.source_id = section_ref.id
+  where section_ref.key = 'videos-by-event'
 ),
 ordered as (
   select
@@ -856,15 +1015,40 @@ ordered as (
   where entity.entity_type = 'playlist'
     and entity.published = true
 )
-insert into public.section_entities (section_id, entity_id, relation_type, slot, sort_order, props)
-select target_section.id, ordered.id, 'item', 'default', (ordered.rank * 10)::int, '{}'::jsonb
+insert into public.entity_relations (
+  from_entity_id,
+  to_entity_id,
+  schema_key,
+  relation_type,
+  slot,
+  sort_order,
+  props,
+  source_table
+)
+select
+  target_section.section_entity_id,
+  ordered.id,
+  'relation/section-entity/v1',
+  'item',
+  'default',
+  (ordered.rank * 10)::int,
+  '{}'::jsonb,
+  'section_entities'
 from target_section cross join ordered
-on conflict (section_id, entity_id, relation_type, slot) do update
-set sort_order = excluded.sort_order,
-    props = excluded.props;
+on conflict (from_entity_id, to_entity_id, relation_type, slot) do update
+set schema_key = excluded.schema_key,
+    sort_order = excluded.sort_order,
+    props = excluded.props,
+    source_table = excluded.source_table,
+    source_id = excluded.source_id;
 
 with target_section as (
-  select id from public.sections where key = 'photos-gallery'
+  select section_entity.id as section_entity_id
+  from public.sections section_ref
+  join public.entities section_entity
+    on section_entity.source_table = 'sections'
+   and section_entity.source_id = section_ref.id
+  where section_ref.key = 'photos-gallery'
 ),
 ordered as (
   select
@@ -875,15 +1059,40 @@ ordered as (
   where entity.entity_type = 'photo'
     and entity.published = true
 )
-insert into public.section_entities (section_id, entity_id, relation_type, slot, sort_order, props)
-select target_section.id, ordered.id, 'item', ordered.slot, (ordered.rank * 10)::int, '{}'::jsonb
+insert into public.entity_relations (
+  from_entity_id,
+  to_entity_id,
+  schema_key,
+  relation_type,
+  slot,
+  sort_order,
+  props,
+  source_table
+)
+select
+  target_section.section_entity_id,
+  ordered.id,
+  'relation/section-entity/v1',
+  'item',
+  ordered.slot,
+  (ordered.rank * 10)::int,
+  '{}'::jsonb,
+  'section_entities'
 from target_section cross join ordered
-on conflict (section_id, entity_id, relation_type, slot) do update
-set sort_order = excluded.sort_order,
-    props = excluded.props;
+on conflict (from_entity_id, to_entity_id, relation_type, slot) do update
+set schema_key = excluded.schema_key,
+    sort_order = excluded.sort_order,
+    props = excluded.props,
+    source_table = excluded.source_table,
+    source_id = excluded.source_id;
 
 with target_section as (
-  select id from public.sections where key = 'history-timeline'
+  select section_entity.id as section_entity_id
+  from public.sections section_ref
+  join public.entities section_entity
+    on section_entity.source_table = 'sections'
+   and section_entity.source_id = section_ref.id
+  where section_ref.key = 'history-timeline'
 ),
 ordered as (
   select
@@ -893,12 +1102,32 @@ ordered as (
   where entity.entity_type = 'history_milestone'
     and entity.published = true
 )
-insert into public.section_entities (section_id, entity_id, relation_type, slot, sort_order, props)
-select target_section.id, ordered.id, 'item', 'default', (ordered.rank * 10)::int, '{}'::jsonb
+insert into public.entity_relations (
+  from_entity_id,
+  to_entity_id,
+  schema_key,
+  relation_type,
+  slot,
+  sort_order,
+  props,
+  source_table
+)
+select
+  target_section.section_entity_id,
+  ordered.id,
+  'relation/section-entity/v1',
+  'item',
+  'default',
+  (ordered.rank * 10)::int,
+  '{}'::jsonb,
+  'section_entities'
 from target_section cross join ordered
-on conflict (section_id, entity_id, relation_type, slot) do update
-set sort_order = excluded.sort_order,
-    props = excluded.props;
+on conflict (from_entity_id, to_entity_id, relation_type, slot) do update
+set schema_key = excluded.schema_key,
+    sort_order = excluded.sort_order,
+    props = excluded.props,
+    source_table = excluded.source_table,
+    source_id = excluded.source_id;
 `
 
 writeFileSync(outputPath, sql)

--- a/scripts/qa-graph-primary-seed-writes.mjs
+++ b/scripts/qa-graph-primary-seed-writes.mjs
@@ -5,6 +5,8 @@ import { readFileSync } from "node:fs"
 const scanFiles = [
   "scripts/apply-instagram-feed.mjs",
   "scripts/apply-scraped-content.mjs",
+  "scripts/generate-instagram-feed-migration.mjs",
+  "scripts/generate-scraped-content-migration.mjs",
 ]
 
 const forbiddenPatterns = [
@@ -23,6 +25,30 @@ const forbiddenPatterns = [
   {
     label: "direct section_entities upsert helper target",
     pattern: /upsertChunked\(\s*supabase\s*,\s*["'`]section_entities["'`]/,
+  },
+  {
+    label: "generated page_sections insert SQL",
+    pattern: /insert\s+into\s+public\.page_sections/i,
+  },
+  {
+    label: "generated section_entities insert SQL",
+    pattern: /insert\s+into\s+public\.section_entities/i,
+  },
+  {
+    label: "generated page_sections delete SQL",
+    pattern: /delete\s+from\s+public\.page_sections/i,
+  },
+  {
+    label: "generated section_entities delete SQL",
+    pattern: /delete\s+from\s+public\.section_entities/i,
+  },
+  {
+    label: "generated page_sections update SQL",
+    pattern: /update\s+public\.page_sections/i,
+  },
+  {
+    label: "generated section_entities update SQL",
+    pattern: /update\s+public\.section_entities/i,
   },
 ]
 
@@ -50,12 +76,19 @@ function runSelfTest() {
     "scripts/apply-example.mjs",
     'await supabase.from("section_entities").upsert(rows)',
   )
+  const sqlShouldFail = scanText(
+    "scripts/generate-example.mjs",
+    "insert into public.section_entities (section_id, entity_id) select ...",
+  )
   const shouldPass = scanText(
     "scripts/apply-example.mjs",
-    'await upsertSectionEntityRelations(supabase, rows, "seed links")',
+    `
+await upsertSectionEntityRelations(supabase, rows, "seed links")
+insert into public.entity_relations (source_table) values ('section_entities')
+`,
   )
 
-  if (shouldFail.length !== 1 || shouldPass.length !== 0) {
+  if (shouldFail.length !== 1 || sqlShouldFail.length !== 1 || shouldPass.length !== 0) {
     throw new Error("Self-test failed for graph-primary seed write guard.")
   }
 }
@@ -75,7 +108,7 @@ console.table([
 ])
 
 if (violations.length) {
-  console.error("\nLegacy composition writes found in seed apply scripts:")
+  console.error("\nLegacy composition writes found in seed scripts:")
   for (const violation of violations) {
     console.error(
       `- ${violation.file}:${violation.line} ${violation.rule}: ${violation.text}`,


### PR DESCRIPTION
## Summary

- Closes #99.
- Updates scraped and Instagram migration generators so page/section placement SQL writes to `entity_relations`.
- Keeps bridge markers via `source_table = 'page_sections'` and `source_table = 'section_entities'` so DB triggers can maintain compatibility mirrors.\n- Extends `qa:graph-primary-seed-writes` to scan generator scripts as well as apply scripts.\n- Documents that generated seed migrations must follow the same graph-primary composition contract.\n\n## Supabase Impact\n\n- No schema changes or production writes in this PR.\n- Historical migrations are unchanged.\n- Generated SQL was not executed against Supabase.\n\n## Verification\n\n- `node --check scripts/generate-instagram-feed-migration.mjs`\n- `node --check scripts/generate-scraped-content-migration.mjs`\n- `node --check scripts/qa-graph-primary-seed-writes.mjs`\n- `pnpm run qa:graph-primary-seed-writes`\n- `git diff --check`\n- Generated minimal fixture SQL to `/tmp` and confirmed no direct `public.page_sections` / `public.section_entities` DML\n- `pnpm run lint`\n- `pnpm exec tsc --noEmit`\n- `pnpm run qa:cms-db-first-loaders`\n- `pnpm run qa:content-graph`\n- `pnpm run build`\n\n## Not Tested\n\n- Did not execute generated SQL against Supabase because that would mutate content data.