### PR TITLE
Run graph-primary seed write guard in CI

### DIFF
--- a/.github/workflows/graph-primary-seed-write-guard.yml
+++ b/.github/workflows/graph-primary-seed-write-guard.yml
@@ -1,0 +1,43 @@
+name: Graph-primary seed write guard
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/graph-primary-seed-write-guard.yml"
+      - "scripts/apply-instagram-feed.mjs"
+      - "scripts/apply-scraped-content.mjs"
+      - "scripts/content-graph-write-helpers.mjs"
+      - "scripts/generate-instagram-feed-migration.mjs"
+      - "scripts/generate-scraped-content-migration.mjs"
+      - "scripts/qa-graph-primary-seed-writes.mjs"
+      - "package.json"
+      - "pnpm-lock.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  graph-primary-seed-writes:
+    name: Graph-primary seed writes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.27.0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run graph-primary seed write guard
+        run: pnpm run qa:graph-primary-seed-writes


### PR DESCRIPTION
## Summary

- Closes #101.
- Adds a targeted GitHub Actions workflow for `pnpm run qa:graph-primary-seed-writes`.
- Triggers only when seed apply/generator/helper/guard/package/workflow files change.
- Keeps the check read-only and credential-free.

## Supabase Impact

- None. No DB reads/writes, migrations, RLS, auth, storage, or secrets involved.

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/graph-primary-seed-write-guard.yml"); puts "yaml: ok"'`\n- `pnpm run qa:graph-primary-seed-writes`\n- `git diff --check`\n\n## Notes\n\n- The new GitHub Actions workflow itself still needs to run on this PR before merge.