### PR TITLE
Isolate legacy bridge health reads

### DIFF
--- a/.github/workflows/cms-db-first-loader-guard.yml
+++ b/.github/workflows/cms-db-first-loader-guard.yml
@@ -8,6 +8,7 @@ on:
       - "app/ponix-canvas/**"
       - "lib/cms/**"
       - "scripts/qa-cms-db-first-loaders.mjs"
+      - "scripts/qa-cms-legacy-bridge-boundary.mjs"
       - "package.json"
       - "pnpm-lock.yaml"
   workflow_dispatch:
@@ -39,3 +40,6 @@ jobs:
 
       - name: Run CMS DB-first loader guard
         run: pnpm run qa:cms-db-first-loaders
+
+      - name: Run CMS legacy bridge boundary guard
+        run: pnpm run qa:cms-legacy-bridge-boundary

--- a/docs/content-graph.md
+++ b/docs/content-graph.md
@@ -66,6 +66,9 @@ Current PONIX contract:
   not the legacy `source_id`.
 - `pnpm run qa:content-graph` checks both page-render parity and global
   graph/legacy mirror integrity for page-section and section-entity relations.
+- Runtime CMS code may read `page_sections` and `section_entities` only through
+  `lib/cms/legacy-bridge-health.ts`, and only for temporary mirror health
+  counts. Use `pnpm run qa:cms-legacy-bridge-boundary` after CMS loader changes.
 - `pnpm run qa:graph-primary-seed-writes` checks that seed apply scripts and
   migration generators do not reintroduce direct legacy composition writes.
 

--- a/lib/cms/content.ts
+++ b/lib/cms/content.ts
@@ -3,6 +3,10 @@ import type { Database, Json } from "@/lib/supabase/types"
 
 import type { CmsSchemaDefinition } from "./schema-registry"
 import {
+  countLegacyPageSectionMirrorRows,
+  countLegacySectionEntityMirrorRows,
+} from "./legacy-bridge-health"
+import {
   loadCmsSchemaRegistryMap,
   loadCmsSchemasByKind,
 } from "./schema-registry.server"
@@ -823,54 +827,6 @@ async function loadShadowEntityId({
   return data?.id ?? null
 }
 
-async function countLegacyPageSections({
-  supabase,
-  pageId,
-  sectionId,
-}: {
-  supabase: SupabaseClient
-  pageId?: string
-  sectionId?: string
-}) {
-  let query = supabase
-    .from("page_sections")
-    .select("id", { count: "exact", head: true })
-
-  if (pageId) query = query.eq("page_id", pageId)
-  if (sectionId) query = query.eq("section_id", sectionId)
-
-  const { error, count } = await query
-  if (error) {
-    throw new Error(`Failed to count page-section bridge rows: ${error.message}`)
-  }
-
-  return count
-}
-
-async function countLegacySectionEntities({
-  supabase,
-  sectionId,
-  entityId,
-}: {
-  supabase: SupabaseClient
-  sectionId?: string
-  entityId?: string
-}) {
-  let query = supabase
-    .from("section_entities")
-    .select("id", { count: "exact", head: true })
-
-  if (sectionId) query = query.eq("section_id", sectionId)
-  if (entityId) query = query.eq("entity_id", entityId)
-
-  const { error, count } = await query
-  if (error) {
-    throw new Error(`Failed to count section-entity bridge rows: ${error.message}`)
-  }
-
-  return count
-}
-
 async function loadPageLinksById(supabase: SupabaseClient, pageIds: string[]) {
   if (!pageIds.length) return new Map<string, RawPageLink>()
 
@@ -926,7 +882,7 @@ async function loadPageSectionRelationsFromEntityGraph({
           sourceId: sectionId,
         })
       : Promise.resolve(null),
-    countLegacyPageSections({ supabase, pageId, sectionId }),
+    countLegacyPageSectionMirrorRows({ supabase, pageId, sectionId }),
   ])
 
   if ((pageId && !pageShadowId) || (sectionId && !sectionShadowId)) {
@@ -1021,7 +977,7 @@ async function loadSectionEntityRelationsFromEntityGraph({
           sourceId: sectionId,
         })
       : Promise.resolve(null),
-    countLegacySectionEntities({ supabase, sectionId, entityId }),
+    countLegacySectionEntityMirrorRows({ supabase, sectionId, entityId }),
   ])
 
   if (sectionId && !sectionShadowId) {

--- a/lib/cms/legacy-bridge-health.ts
+++ b/lib/cms/legacy-bridge-health.ts
@@ -1,0 +1,59 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+import type { Database } from "@/lib/supabase/types"
+
+type CmsSupabaseClient = SupabaseClient<Database>
+
+export type LegacyPageSectionCountScope = {
+  pageId?: string
+  sectionId?: string
+}
+
+export type LegacySectionEntityCountScope = {
+  sectionId?: string
+  entityId?: string
+}
+
+export async function countLegacyPageSectionMirrorRows({
+  supabase,
+  pageId,
+  sectionId,
+}: {
+  supabase: CmsSupabaseClient
+} & LegacyPageSectionCountScope) {
+  let query = supabase
+    .from("page_sections")
+    .select("id", { count: "exact", head: true })
+
+  if (pageId) query = query.eq("page_id", pageId)
+  if (sectionId) query = query.eq("section_id", sectionId)
+
+  const { error, count } = await query
+  if (error) {
+    throw new Error(`Failed to count page-section bridge rows: ${error.message}`)
+  }
+
+  return count
+}
+
+export async function countLegacySectionEntityMirrorRows({
+  supabase,
+  sectionId,
+  entityId,
+}: {
+  supabase: CmsSupabaseClient
+} & LegacySectionEntityCountScope) {
+  let query = supabase
+    .from("section_entities")
+    .select("id", { count: "exact", head: true })
+
+  if (sectionId) query = query.eq("section_id", sectionId)
+  if (entityId) query = query.eq("entity_id", entityId)
+
+  const { error, count } = await query
+  if (error) {
+    throw new Error(`Failed to count section-entity bridge rows: ${error.message}`)
+  }
+
+  return count
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "qa:content-graph": "node scripts/qa-content-graph-parity.mjs",
     "qa:cms-db-first-loaders": "node scripts/qa-cms-db-first-loaders.mjs",
     "qa:cms-schema-registry": "node scripts/qa-cms-schema-registry.mjs",
+    "qa:cms-legacy-bridge-boundary": "node scripts/qa-cms-legacy-bridge-boundary.mjs",
     "qa:graph-primary-seed-writes": "node scripts/qa-graph-primary-seed-writes.mjs"
   },
   "dependencies": {

--- a/scripts/qa-cms-legacy-bridge-boundary.mjs
+++ b/scripts/qa-cms-legacy-bridge-boundary.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs"
+import path from "node:path"
+
+const repoRoot = process.cwd()
+const scanRoots = ["app/ponix", "app/ponix-canvas", "lib/cms"]
+const codeExtensions = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs"])
+const allowedFiles = new Set(["lib/cms/legacy-bridge-health.ts"])
+
+const forbiddenPatterns = [
+  {
+    label: "direct page_sections Supabase access",
+    pattern: /(?:^|[^\w])from\(\s*["'`]page_sections["'`]\s*\)/,
+  },
+  {
+    label: "direct section_entities Supabase access",
+    pattern: /(?:^|[^\w])from\(\s*["'`]section_entities["'`]\s*\)/,
+  },
+]
+
+function repoRelative(filePath) {
+  return path.relative(repoRoot, filePath).split(path.sep).join("/")
+}
+
+function listFiles(dir) {
+  if (!existsSync(dir)) return []
+
+  const entries = readdirSync(dir)
+  return entries.flatMap((entry) => {
+    const absolute = path.join(dir, entry)
+    const stat = statSync(absolute)
+
+    if (stat.isDirectory()) {
+      if (entry === "node_modules" || entry === ".next") return []
+      return listFiles(absolute)
+    }
+
+    return codeExtensions.has(path.extname(entry)) ? [absolute] : []
+  })
+}
+
+function findViolations(relativePath, source) {
+  if (allowedFiles.has(relativePath)) return []
+
+  const violations = []
+  for (const [index, line] of source.split(/\r?\n/).entries()) {
+    for (const forbidden of forbiddenPatterns) {
+      if (!forbidden.pattern.test(line)) continue
+
+      violations.push({
+        file: relativePath,
+        line: index + 1,
+        rule: forbidden.label,
+        text: line.trim(),
+      })
+    }
+  }
+
+  return violations
+}
+
+function runSelfTest() {
+  const blocked = findViolations(
+    "lib/cms/content.ts",
+    'await supabase.from("page_sections").select("id")',
+  )
+  const allowed = findViolations(
+    "lib/cms/legacy-bridge-health.ts",
+    'await supabase.from("page_sections").select("id")',
+  )
+  const sourceMarker = findViolations(
+    "app/ponix/relations/actions.ts",
+    'source_table: "section_entities"',
+  )
+
+  if (blocked.length !== 1 || allowed.length !== 0 || sourceMarker.length !== 0) {
+    throw new Error("Self-test failed for CMS legacy bridge boundary guard.")
+  }
+}
+
+runSelfTest()
+
+const files = scanRoots.flatMap((root) => listFiles(path.join(repoRoot, root)))
+const violations = files.flatMap((file) =>
+  findViolations(repoRelative(file), readFileSync(file, "utf8")),
+)
+
+console.log("CMS legacy bridge boundary guard")
+console.table([
+  {
+    scannedFiles: files.length,
+    allowedFiles: allowedFiles.size,
+    forbiddenPatterns: forbiddenPatterns.length,
+    violations: violations.length,
+    selfTest: "ok",
+  },
+])
+
+if (violations.length) {
+  console.error("\nDirect legacy composition table access found outside the health boundary:")
+  for (const violation of violations) {
+    console.error(
+      `- ${violation.file}:${violation.line} ${violation.rule}: ${violation.text}`,
+    )
+  }
+  console.error(
+    "\nUse lib/cms/legacy-bridge-health.ts for temporary mirror health reads. Runtime composition loading should stay graph-primary through entity_relations.",
+  )
+  process.exitCode = 1
+}


### PR DESCRIPTION
## Summary

- Closes #103.
- Moves the remaining CMS runtime legacy mirror counts into `lib/cms/legacy-bridge-health.ts`.
- Keeps relation loading graph-primary through `entity_relations`; legacy reads are now explicit health accounting only.
- Adds `pnpm run qa:cms-legacy-bridge-boundary` to prevent direct `page_sections` / `section_entities` access from returning to CMS runtime code.
- Wires the new guard into the existing CMS DB-first loader GitHub Actions workflow.
- Documents that this is preparation for, not execution of, legacy mirror removal.

## Supabase Impact

- No schema changes, migrations, production writes, RLS, auth, or storage changes.
- Existing read-only mirror counts remain in use for bridge health.

## Verification

- `pnpm run qa:cms-legacy-bridge-boundary`
- `node --check scripts/qa-cms-legacy-bridge-boundary.mjs`
- `rg` direct legacy access check
- `git diff --check`
- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `pnpm run qa:cms-db-first-loaders`
- `pnpm run qa:content-graph`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/cms-db-first-loader-guard.yml"); puts "yaml: ok"'`\n- `pnpm run build`\n\n## Not Tested\n\n- Did not remove legacy mirrors or run a legacy-removal migration. That needs a separate DB issue after bridge/audit/QA dependencies are retired.