### PR TITLE
Track legacy mirror removal readiness

### DIFF
--- a/.github/workflows/legacy-mirror-readiness.yml
+++ b/.github/workflows/legacy-mirror-readiness.yml
@@ -1,0 +1,46 @@
+name: Legacy mirror readiness
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/legacy-mirror-readiness.yml"
+      - "app/ponix/**"
+      - "app/ponix-canvas/**"
+      - "lib/cms/**"
+      - "lib/data/content-graph.ts"
+      - "scripts/**"
+      - "docs/content-graph.md"
+      - "docs/cms-audit.md"
+      - "docs/agentic-workflow.md"
+      - "supabase/migrations/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  legacy-mirror-readiness:
+    name: Legacy mirror readiness
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.27.0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run legacy mirror readiness guard
+        run: pnpm run qa:legacy-mirror-readiness

--- a/docs/content-graph.md
+++ b/docs/content-graph.md
@@ -69,6 +69,12 @@ Current PONIX contract:
 - Runtime CMS code may read `page_sections` and `section_entities` only through
   `lib/cms/legacy-bridge-health.ts`, and only for temporary mirror health
   counts. Use `pnpm run qa:cms-legacy-bridge-boundary` after CMS loader changes.
+- Use `pnpm run qa:legacy-mirror-readiness` before any legacy mirror removal
+  work. The command classifies every remaining `page_sections` /
+  `section_entities` reference and fails only on unclassified references.
+  Treat reported bridge triggers, audit/RLS/index references, parity QA,
+  `source_table` markers, and schema registry compatibility entries as the
+  removal blocker list.
 - `pnpm run qa:graph-primary-seed-writes` checks that seed apply scripts and
   migration generators do not reintroduce direct legacy composition writes.
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "qa:cms-db-first-loaders": "node scripts/qa-cms-db-first-loaders.mjs",
     "qa:cms-schema-registry": "node scripts/qa-cms-schema-registry.mjs",
     "qa:cms-legacy-bridge-boundary": "node scripts/qa-cms-legacy-bridge-boundary.mjs",
-    "qa:graph-primary-seed-writes": "node scripts/qa-graph-primary-seed-writes.mjs"
+    "qa:graph-primary-seed-writes": "node scripts/qa-graph-primary-seed-writes.mjs",
+    "qa:legacy-mirror-readiness": "node scripts/qa-legacy-mirror-readiness.mjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",

--- a/scripts/qa-legacy-mirror-readiness.mjs
+++ b/scripts/qa-legacy-mirror-readiness.mjs
@@ -1,0 +1,280 @@
+#!/usr/bin/env node
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs"
+import path from "node:path"
+
+const repoRoot = process.cwd()
+const scanRoots = [
+  "app",
+  "lib",
+  "scripts",
+  "docs",
+  ".github",
+  "supabase/migrations",
+]
+const ignoredFiles = new Set(["lib/supabase/types.ts", "supabase/_apply_all.sql"])
+const codeExtensions = new Set([
+  ".md",
+  ".mjs",
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+  ".sql",
+  ".yml",
+  ".yaml",
+  ".json",
+])
+const legacyPattern = /\b(page_sections|section_entities)\b/g
+const graphSourceMarkerFiles = new Set([
+  "lib/cms/content.ts",
+  "lib/data/content-graph.ts",
+  "app/ponix/relations/actions.ts",
+  "scripts/content-graph-write-helpers.mjs",
+  "scripts/generate-instagram-feed-migration.mjs",
+  "scripts/generate-scraped-content-migration.mjs",
+])
+
+const categories = {
+  active_bridge_migration: {
+    label: "Active bridge migrations",
+    removalBlocker: true,
+    note: "Drop/supersede graph<->legacy bridge triggers before removing mirrors.",
+  },
+  active_audit_migration: {
+    label: "Audit migration compatibility",
+    removalBlocker: true,
+    note: "Audit target-table checks and triggers still mention legacy mirrors.",
+  },
+  active_index_policy_migration: {
+    label: "Legacy indexes/RLS helpers",
+    removalBlocker: true,
+    note: "Indexes, policies, or helper functions target legacy mirrors.",
+  },
+  runtime_health_boundary: {
+    label: "Runtime health boundary",
+    removalBlocker: true,
+    note: "Temporary mirror counts live here until parity health is retired.",
+  },
+  parity_qa: {
+    label: "Parity QA",
+    removalBlocker: true,
+    note: "Current QA compares graph rows with legacy mirror rows.",
+  },
+  graph_source_marker: {
+    label: "Graph source markers",
+    removalBlocker: true,
+    note: "Graph rows still use legacy table names as source_table markers.",
+  },
+  schema_registry_compatibility: {
+    label: "Schema registry compatibility",
+    removalBlocker: true,
+    note: "Registry metadata still allows/mentions legacy relation tables.",
+  },
+  static_guard: {
+    label: "Static guard self-tests",
+    removalBlocker: false,
+    note: "Guard patterns intentionally mention legacy names.",
+  },
+  docs: {
+    label: "Documentation",
+    removalBlocker: false,
+    note: "Docs describe the transition and must be updated during removal.",
+  },
+  historical_migration: {
+    label: "Historical migrations",
+    removalBlocker: false,
+    note: "Committed history remains as-is; do not rewrite old migrations.",
+  },
+  readiness_guard: {
+    label: "Readiness guard",
+    removalBlocker: false,
+    note: "This inventory script intentionally names legacy mirrors.",
+  },
+}
+
+function repoRelative(filePath) {
+  return path.relative(repoRoot, filePath).split(path.sep).join("/")
+}
+
+function listFiles(dir) {
+  if (!existsSync(dir)) return []
+
+  const entries = readdirSync(dir)
+  return entries.flatMap((entry) => {
+    const absolute = path.join(dir, entry)
+    const relative = repoRelative(absolute)
+    const stat = statSync(absolute)
+
+    if (stat.isDirectory()) {
+      if (entry === "node_modules" || entry === ".next") return []
+      return listFiles(absolute)
+    }
+
+    if (ignoredFiles.has(relative)) return []
+    return codeExtensions.has(path.extname(entry)) ? [absolute] : []
+  })
+}
+
+function classify(file) {
+  if (file === "scripts/qa-legacy-mirror-readiness.mjs") {
+    return "readiness_guard"
+  }
+
+  if (file.startsWith("docs/")) {
+    return "docs"
+  }
+
+  if (file === "scripts/qa-content-graph-parity.mjs") {
+    return "parity_qa"
+  }
+
+  if (
+    file === "scripts/qa-cms-legacy-bridge-boundary.mjs" ||
+    file === "scripts/qa-graph-primary-seed-writes.mjs"
+  ) {
+    return "static_guard"
+  }
+
+  if (file === "lib/cms/legacy-bridge-health.ts") {
+    return "runtime_health_boundary"
+  }
+
+  if (
+    file === "lib/cms/schema-registry.ts" ||
+    file === "lib/cms/schema-registry.server.ts"
+  ) {
+    return "schema_registry_compatibility"
+  }
+
+  if (file === "supabase/migrations/20260505000039_cms_audit_events.sql") {
+    return "active_audit_migration"
+  }
+
+  if (
+    file === "supabase/migrations/20260430000034_private_rls_helpers.sql" ||
+    file === "supabase/migrations/20260506000041_cms_query_indexes.sql"
+  ) {
+    return "active_index_policy_migration"
+  }
+
+  if (
+    file === "supabase/migrations/20260506000040_entity_schema_registry.sql" ||
+    file === "supabase/migrations/20260506000042_entity_graph_bridge.sql" ||
+    file === "supabase/migrations/20260508000043_graph_primary_composition_writes.sql"
+  ) {
+    return "active_bridge_migration"
+  }
+
+  if (graphSourceMarkerFiles.has(file)) {
+    return "graph_source_marker"
+  }
+
+  if (file.startsWith("supabase/migrations/202604")) {
+    return "historical_migration"
+  }
+
+  return null
+}
+
+function findReferences(filePath) {
+  const file = repoRelative(filePath)
+  const source = readFileSync(filePath, "utf8")
+  const references = []
+
+  source.split(/\r?\n/).forEach((line, index) => {
+    legacyPattern.lastIndex = 0
+    if (!legacyPattern.test(line)) return
+
+    references.push({
+      file,
+      line: index + 1,
+      category: classify(file, line),
+      text: line.trim(),
+    })
+  })
+
+  return references
+}
+
+function runSelfTest() {
+  const expected = [
+    classify("lib/cms/legacy-bridge-health.ts", 'from("page_sections")'),
+    classify("scripts/qa-content-graph-parity.mjs", 'from("section_entities")'),
+    classify("lib/cms/content.ts", '.eq("source_table", "page_sections")'),
+    classify("scripts/generate-instagram-feed-migration.mjs", "'section_entities'"),
+    classify("supabase/migrations/20260430000034_private_rls_helpers.sql", "section_entities"),
+    classify("supabase/migrations/20260429000009_scraped_content_seed.sql", "page_sections"),
+    classify("docs/content-graph.md", "`section_entities`"),
+  ]
+  const unexpected = classify("lib/cms/unexpected.ts", 'from("page_sections")')
+
+  if (
+    expected.includes(null) ||
+    unexpected !== null
+  ) {
+    throw new Error("Self-test failed for legacy mirror readiness classifier.")
+  }
+}
+
+runSelfTest()
+
+const files = scanRoots.flatMap((root) => listFiles(path.join(repoRoot, root)))
+const references = files.flatMap(findReferences)
+const unclassified = references.filter((reference) => !reference.category)
+const byCategory = new Map()
+
+for (const reference of references) {
+  const category = reference.category ?? "unclassified"
+  byCategory.set(category, (byCategory.get(category) ?? 0) + 1)
+}
+
+const summaryRows = [...byCategory.entries()]
+  .sort(([left], [right]) => left.localeCompare(right))
+  .map(([category, count]) => ({
+    category,
+    count,
+    removalBlocker: categories[category]?.removalBlocker ?? true,
+    label: categories[category]?.label ?? "Unclassified",
+  }))
+
+const blockerCount = references.filter(
+  (reference) => categories[reference.category]?.removalBlocker,
+).length
+
+console.log("Legacy mirror removal readiness")
+console.table([
+  {
+    scannedFiles: files.length,
+    references: references.length,
+    categories: summaryRows.length,
+    removalBlockerReferences: blockerCount,
+    unclassified: unclassified.length,
+    selfTest: "ok",
+  },
+])
+
+console.log("\nReference categories")
+console.table(summaryRows)
+
+const blockerRows = Object.entries(categories)
+  .filter(([, metadata]) => metadata.removalBlocker)
+  .map(([category, metadata]) => ({
+    category,
+    count: byCategory.get(category) ?? 0,
+    nextStep: metadata.note,
+  }))
+
+console.log("\nRemoval blockers to clear before dropping legacy mirrors")
+console.table(blockerRows)
+
+if (unclassified.length) {
+  console.error("\nUnclassified legacy mirror references:")
+  for (const reference of unclassified) {
+    console.error(`- ${reference.file}:${reference.line}: ${reference.text}`)
+  }
+  console.error(
+    "\nClassify this reference in scripts/qa-legacy-mirror-readiness.mjs or remove it.",
+  )
+  process.exitCode = 1
+}


### PR DESCRIPTION
## Summary
- add a read-only legacy mirror readiness QA script for page_sections / section_entities references
- classify remaining references into known removal blockers, safe guard/docs refs, and historical migrations
- wire the guard into CI and document the blocker list before any mirror removal work

## Verification
- pnpm run qa:legacy-mirror-readiness
- pnpm run qa:cms-legacy-bridge-boundary
- pnpm run qa:graph-primary-seed-writes
- pnpm run qa:cms-db-first-loaders
- pnpm run qa:content-graph
- pnpm run qa:cms-schema-registry
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm run build
- node --check scripts/qa-legacy-mirror-readiness.mjs
- ruby YAML parse for .github/workflows/legacy-mirror-readiness.yml
- git diff --check

## Notes
- No Supabase writes or migrations in this PR.
- Current readiness output has 0 unclassified references and 122 classified removal-blocker references.

Closes #105