### PR TITLE
Retire legacy schema registry table compatibility

### DIFF
--- a/lib/cms/schema-registry.server.ts
+++ b/lib/cms/schema-registry.server.ts
@@ -58,7 +58,6 @@ const schemaTables = new Set<CmsSchemaDefinition["table"]>([
   "pages",
   "sections",
   "entities",
-  "section_entities",
   "entity_relations",
 ])
 

--- a/lib/cms/schema-registry.ts
+++ b/lib/cms/schema-registry.ts
@@ -34,7 +34,7 @@ export type CmsFieldDefinition = {
 export type CmsSchemaDefinition = {
   schemaKey: string
   kind: CmsSchemaKind
-  table: "pages" | "sections" | "entities" | "section_entities" | "entity_relations"
+  table: "pages" | "sections" | "entities" | "entity_relations"
   label: string
   description: string
   fields: CmsFieldDefinition[]

--- a/scripts/qa-legacy-mirror-readiness.mjs
+++ b/scripts/qa-legacy-mirror-readiness.mjs
@@ -258,7 +258,10 @@ console.log("\nReference categories")
 console.table(summaryRows)
 
 const blockerRows = Object.entries(categories)
-  .filter(([, metadata]) => metadata.removalBlocker)
+  .filter(
+    ([category, metadata]) =>
+      metadata.removalBlocker && (byCategory.get(category) ?? 0) > 0,
+  )
   .map(([category, metadata]) => ({
     category,
     count: byCategory.get(category) ?? 0,


### PR DESCRIPTION
## Summary
- remove unused section_entities table compatibility from the CMS schema registry type/parser
- keep schema registry targets limited to pages, sections, entities, and entity_relations
- hide zero-count categories from the legacy mirror readiness blocker table

## Verification
- pnpm run qa:cms-schema-registry
- pnpm run qa:legacy-mirror-readiness
- pnpm run qa:cms-legacy-bridge-boundary
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm run build
- git diff --check

## Readiness impact
- schema_registry_compatibility: 2 -> 0
- total classified removal blocker references: 122 -> 120
- no Supabase writes or migrations

Closes #107