### PR TITLE
Use shadcn controls for CMS dropdown editing

### DIFF
--- a/.github/workflows/cms-native-controls.yml
+++ b/.github/workflows/cms-native-controls.yml
@@ -1,0 +1,41 @@
+name: CMS native control guard
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/cms-native-controls.yml"
+      - "app/ponix/**"
+      - "app/ponix-canvas/**"
+      - "components/**"
+      - "scripts/qa-cms-native-controls.mjs"
+      - "package.json"
+      - "pnpm-lock.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cms-native-controls:
+    name: CMS native controls
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.27.0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run CMS native control guard
+        run: pnpm run qa:cms-native-controls

--- a/app/ponix/_components/cms-entity-form.tsx
+++ b/app/ponix/_components/cms-entity-form.tsx
@@ -4,6 +4,7 @@ import {
   CmsSaveNotice,
   CmsSubmitButton,
 } from "@/app/ponix/_components/cms-save-controls"
+import { CmsSelectField } from "@/app/ponix/_components/cms-select-field"
 import { updateCmsEntityAction } from "@/app/ponix/entities/actions"
 import { ProfileImageInput } from "@/components/profile-image-input"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
@@ -319,19 +320,14 @@ export function renderFieldInput({
 
   if (field.type === "select") {
     return (
-      <select
+      <CmsSelectField
         id={id}
         name={name}
         defaultValue={fieldDefaultText(field, value)}
-        className="border-input h-11 w-full rounded-md border bg-background/70 px-3 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
-      >
-        {!field.required && <option value="">Empty</option>}
-        {(field.options ?? []).map((option) => (
-          <option key={option.value} value={option.value}>
-            {option.label}
-          </option>
-        ))}
-      </select>
+        options={field.options ?? []}
+        placeholder={`Select ${field.label}`}
+        required={field.required}
+      />
     )
   }
 

--- a/app/ponix/_components/cms-relations.tsx
+++ b/app/ponix/_components/cms-relations.tsx
@@ -12,6 +12,10 @@ import {
   updateEntityRelationAction,
   updateSectionEntityRelationAction,
 } from "@/app/ponix/relations/actions"
+import {
+  CmsComboboxField,
+  CmsSelectField,
+} from "@/app/ponix/_components/cms-select-field"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -354,12 +358,20 @@ function SectionEntityAddForm({
         </FieldGroup>
       )}
       <FieldGroup label="Type">
-        <Input
+        <CmsComboboxField
           name="relation_type"
           defaultValue="item"
-          list="section-relation-types"
-          required
-          className="h-10 bg-background/80"
+          options={[
+            { value: "item", label: "item" },
+            { value: "features_photo", label: "features_photo" },
+            { value: "features_post", label: "features_post" },
+            { value: "contains_video", label: "contains_video" },
+          ]}
+          placeholder="Select type"
+          searchPlaceholder="Search or type a relation type"
+          emptyLabel="Type a relation type to add it"
+          customLabel="Use"
+          triggerClassName="h-10 bg-background/80"
         />
       </FieldGroup>
       <FieldGroup label="Slot">
@@ -382,12 +394,6 @@ function SectionEntityAddForm({
           Add
         </Button>
       </div>
-      <datalist id="section-relation-types">
-        <option value="item" />
-        <option value="features_photo" />
-        <option value="features_post" />
-        <option value="contains_video" />
-      </datalist>
     </form>
   )
 }
@@ -434,12 +440,20 @@ function EntityRelationAddForm({
         </FieldGroup>
       )}
       <FieldGroup label="Type">
-        <Input
+        <CmsComboboxField
           name="relation_type"
           defaultValue="has_recording"
-          list="entity-relation-types"
-          required
-          className="h-10 bg-background/80"
+          options={[
+            { value: "has_recording", label: "has_recording" },
+            { value: "has_photo", label: "has_photo" },
+            { value: "has_post", label: "has_post" },
+            { value: "related", label: "related" },
+          ]}
+          placeholder="Select type"
+          searchPlaceholder="Search or type a relation type"
+          emptyLabel="Type a relation type to add it"
+          customLabel="Use"
+          triggerClassName="h-10 bg-background/80"
         />
       </FieldGroup>
       <FieldGroup label="Slot">
@@ -462,12 +476,6 @@ function EntityRelationAddForm({
           Add
         </Button>
       </div>
-      <datalist id="entity-relation-types">
-        <option value="has_recording" />
-        <option value="has_photo" />
-        <option value="has_post" />
-        <option value="related" />
-      </datalist>
     </form>
   )
 }
@@ -495,21 +503,17 @@ function PageSelect({
   pages: CmsRelationEditorOptions["pages"]
 }) {
   return (
-    <select
+    <CmsSelectField
       name={name}
       required
-      className={selectClassName}
       defaultValue=""
-    >
-      <option value="" disabled>
-        Select page
-      </option>
-      {pages.map((page) => (
-        <option key={page.id} value={page.id}>
-          {page.slug} · {page.title}
-        </option>
-      ))}
-    </select>
+      placeholder="Select page"
+      triggerClassName="h-10 bg-background/80"
+      options={pages.map((page) => ({
+        value: page.id,
+        label: `${page.slug} · ${page.title}`,
+      }))}
+    />
   )
 }
 
@@ -521,26 +525,19 @@ function SectionSelect({
   sections: CmsRelationEditorOptions["sections"]
 }) {
   return (
-    <select
+    <CmsSelectField
       name={name}
       required
-      className={selectClassName}
       defaultValue=""
-    >
-      <option value="" disabled>
-        Select section
-      </option>
-      {sections.map((section) => (
-        <option key={section.id} value={section.id}>
-          {section.key} · {section.title ?? "Untitled"}
-        </option>
-      ))}
-    </select>
+      placeholder="Select section"
+      triggerClassName="h-10 bg-background/80"
+      options={sections.map((section) => ({
+        value: section.id,
+        label: `${section.key} · ${section.title ?? "Untitled"}`,
+      }))}
+    />
   )
 }
-
-const selectClassName =
-  "flex h-10 w-full rounded-md border border-input bg-background/80 px-3 py-2 text-sm shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50"
 
 function RelationCard({
   title,

--- a/app/ponix/_components/cms-section-form.tsx
+++ b/app/ponix/_components/cms-section-form.tsx
@@ -4,6 +4,7 @@ import {
   CmsSaveNotice,
   CmsSubmitButton,
 } from "@/app/ponix/_components/cms-save-controls"
+import { CmsSelectField } from "@/app/ponix/_components/cms-select-field"
 import { updateCmsSectionAction } from "@/app/ponix/sections/actions"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Badge } from "@/components/ui/badge"
@@ -280,19 +281,14 @@ export function renderFieldInput({
 
   if (field.type === "select") {
     return (
-      <select
+      <CmsSelectField
         id={id}
         name={name}
         defaultValue={fieldDefaultText(field, value)}
-        className="border-input h-11 w-full rounded-md border bg-background/70 px-3 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
-      >
-        {!field.required && <option value="">Empty</option>}
-        {(field.options ?? []).map((option) => (
-          <option key={option.value} value={option.value}>
-            {option.label}
-          </option>
-        ))}
-      </select>
+        options={field.options ?? []}
+        placeholder={`Select ${field.label}`}
+        required={field.required}
+      />
     )
   }
 

--- a/app/ponix/_components/cms-select-field.tsx
+++ b/app/ponix/_components/cms-select-field.tsx
@@ -1,0 +1,225 @@
+"use client"
+
+import { useId, useMemo, useRef, useState } from "react"
+import { Check, ChevronsUpDown } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { cn } from "@/lib/utils"
+
+const EMPTY_VALUE = "__cms_select_empty__"
+
+export type CmsSelectOption = {
+  value: string
+  label: string
+}
+
+export function CmsSelectField({
+  id,
+  name,
+  defaultValue,
+  options,
+  placeholder = "Select",
+  emptyLabel = "Empty",
+  required = false,
+  triggerClassName,
+}: {
+  id?: string
+  name: string
+  defaultValue?: string | null
+  options: CmsSelectOption[]
+  placeholder?: string
+  emptyLabel?: string
+  required?: boolean
+  triggerClassName?: string
+}) {
+  const generatedId = useId()
+  const fieldId = id ?? generatedId
+  const normalizedDefault = defaultValue?.trim() ?? ""
+  const inputRef = useRef<HTMLInputElement>(null)
+  const selectOptions = useMemo(() => {
+    if (!normalizedDefault) return options
+    if (options.some((option) => option.value === normalizedDefault)) return options
+    return [{ value: normalizedDefault, label: normalizedDefault }, ...options]
+  }, [normalizedDefault, options])
+  const [selectedValue, setSelectedValue] = useState<string | undefined>(
+    normalizedDefault || (required ? undefined : EMPTY_VALUE),
+  )
+  const [open, setOpen] = useState(false)
+  const formValue = selectedValue === EMPTY_VALUE ? "" : selectedValue ?? ""
+
+  function updateValue(value: string) {
+    setSelectedValue(value)
+    setOpen(false)
+    window.queueMicrotask(() => {
+      inputRef.current?.dispatchEvent(new Event("change", { bubbles: true }))
+    })
+  }
+
+  return (
+    <>
+      <input ref={inputRef} type="hidden" name={name} value={formValue} />
+      <Select
+        open={open}
+        onOpenChange={setOpen}
+        value={selectedValue}
+        onValueChange={updateValue}
+        required={required}
+      >
+        <SelectTrigger
+          id={fieldId}
+          aria-required={required}
+          className={cn("h-11 w-full bg-background/70", triggerClassName)}
+        >
+          <SelectValue placeholder={placeholder} />
+        </SelectTrigger>
+        <SelectContent
+          onEscapeKeyDown={() => setOpen(false)}
+          onPointerDownOutside={() => setOpen(false)}
+        >
+          {!required && <SelectItem value={EMPTY_VALUE}>{emptyLabel}</SelectItem>}
+          {selectOptions.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </>
+  )
+}
+
+export function CmsComboboxField({
+  id,
+  name,
+  defaultValue,
+  options,
+  placeholder = "Select",
+  searchPlaceholder = "Search",
+  emptyLabel = "No matching option",
+  customLabel = "Use custom value",
+  triggerClassName,
+}: {
+  id?: string
+  name: string
+  defaultValue?: string | null
+  options: CmsSelectOption[]
+  placeholder?: string
+  searchPlaceholder?: string
+  emptyLabel?: string
+  customLabel?: string
+  triggerClassName?: string
+}) {
+  const generatedId = useId()
+  const fieldId = id ?? generatedId
+  const inputRef = useRef<HTMLInputElement>(null)
+  const normalizedDefault = defaultValue?.trim() ?? ""
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState("")
+  const [selectedValue, setSelectedValue] = useState(normalizedDefault)
+  const selectOptions = useMemo(() => {
+    if (!selectedValue) return options
+    if (options.some((option) => option.value === selectedValue)) return options
+    return [{ value: selectedValue, label: selectedValue }, ...options]
+  }, [options, selectedValue])
+  const selectedOption = selectOptions.find((option) => option.value === selectedValue)
+  const trimmedQuery = query.trim()
+  const canUseCustom =
+    trimmedQuery.length > 0 &&
+    !selectOptions.some((option) => option.value === trimmedQuery)
+
+  function updateValue(value: string) {
+    setSelectedValue(value)
+    setOpen(false)
+    window.queueMicrotask(() => {
+      inputRef.current?.dispatchEvent(new Event("change", { bubbles: true }))
+    })
+  }
+
+  return (
+    <>
+      <input ref={inputRef} type="hidden" name={name} value={selectedValue} />
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            id={fieldId}
+            type="button"
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            className={cn(
+              "h-11 w-full justify-between bg-background/70 px-3 font-normal",
+              triggerClassName,
+            )}
+          >
+            <span className="min-w-0 truncate text-left">
+              {selectedOption?.label || selectedValue || placeholder}
+            </span>
+            <ChevronsUpDown className="size-4 shrink-0 text-muted-foreground" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent align="start" className="w-[var(--radix-popover-trigger-width)] p-0">
+          <Command>
+            <CommandInput
+              value={query}
+              onValueChange={setQuery}
+              placeholder={searchPlaceholder}
+            />
+            <CommandList className="max-h-72">
+              <CommandEmpty>{emptyLabel}</CommandEmpty>
+              <CommandGroup>
+                {canUseCustom && (
+                  <CommandItem
+                    value={trimmedQuery}
+                    onSelect={() => updateValue(trimmedQuery)}
+                    className="py-2.5"
+                  >
+                    <Check className="size-4 opacity-0" />
+                    <span className="min-w-0 flex-1 truncate">
+                      {customLabel}: {trimmedQuery}
+                    </span>
+                  </CommandItem>
+                )}
+                {selectOptions.map((option) => (
+                  <CommandItem
+                    key={option.value}
+                    value={`${option.label} ${option.value}`}
+                    onSelect={() => updateValue(option.value)}
+                    className="py-2.5"
+                  >
+                    <Check
+                      className={cn(
+                        "size-4",
+                        selectedValue === option.value ? "opacity-100" : "opacity-0",
+                      )}
+                    />
+                    <span className="min-w-0 flex-1 truncate">{option.label}</span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+    </>
+  )
+}

--- a/app/ponix/pages/[id]/compose/composer-relation-list.tsx
+++ b/app/ponix/pages/[id]/compose/composer-relation-list.tsx
@@ -13,6 +13,10 @@ import {
 
 import { updateCmsEntityInlineAction } from "@/app/ponix/entities/actions"
 import {
+  CmsComboboxField,
+  CmsSelectField,
+} from "@/app/ponix/_components/cms-select-field"
+import {
   deleteSectionEntityRelationAction,
   reorderSectionEntityRelationsAction,
   updateSectionEntityRelationInlineAction,
@@ -213,8 +217,6 @@ function SectionEntityRelationEditor({
   onDragOver: React.DragEventHandler<HTMLDivElement>
   onDrop: React.DragEventHandler<HTMLDivElement>
 }) {
-  const typeListId = `relation-types-${relation.id}`
-  const slotListId = `relation-slots-${relation.id}`
   const [saveState, setSaveState] = useState<SaveState>({ status: "idle" })
   const [isPending, startTransition] = useTransition()
 
@@ -406,12 +408,19 @@ function SectionEntityRelationEditor({
                     >
                       Type
                     </Label>
-                    <Input
+                    <CmsComboboxField
                       id={`relation-type-${relation.id}`}
                       name="relation_type"
                       defaultValue={relation.relationType}
-                      list={typeListId}
-                      className="h-10 bg-card"
+                      options={typeOptions.map((option) => ({
+                        value: option,
+                        label: option,
+                      }))}
+                      placeholder="Select type"
+                      searchPlaceholder="Search or type a relation type"
+                      emptyLabel="Type a relation type to add it"
+                      customLabel="Use"
+                      triggerClassName="h-10 bg-card"
                     />
                   </div>
                   <div className="space-y-1.5">
@@ -421,12 +430,19 @@ function SectionEntityRelationEditor({
                     >
                       Slot
                     </Label>
-                    <Input
+                    <CmsComboboxField
                       id={`relation-slot-${relation.id}`}
                       name="slot"
                       defaultValue={relation.slot}
-                      list={slotListId}
-                      className="h-10 bg-card"
+                      options={slotOptions.map((option) => ({
+                        value: option,
+                        label: option,
+                      }))}
+                      placeholder="Select slot"
+                      searchPlaceholder="Search or type a slot"
+                      emptyLabel="Type a slot to add it"
+                      customLabel="Use"
+                      triggerClassName="h-10 bg-card"
                     />
                   </div>
                   <div className="space-y-1.5">
@@ -445,12 +461,6 @@ function SectionEntityRelationEditor({
                     />
                   </div>
                 </div>
-                <RelationDatalists
-                  typeOptions={typeOptions}
-                  slotOptions={slotOptions}
-                  typeListId={typeListId}
-                  slotListId={slotListId}
-                />
                 <SaveFeedbackBar
                   state={saveState}
                   pending={isPending}
@@ -839,19 +849,14 @@ function renderInlineFieldInput({
 
   if (field.type === "select") {
     return (
-      <select
+      <CmsSelectField
         id={id}
         name={name}
         defaultValue={inlineFieldDefaultText(field, value)}
-        className="border-input h-11 w-full rounded-md border bg-background/70 px-3 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
-      >
-        {!field.required && <option value="">Empty</option>}
-        {(field.options ?? []).map((option) => (
-          <option key={option.value} value={option.value}>
-            {option.label}
-          </option>
-        ))}
-      </select>
+        options={field.options ?? []}
+        placeholder={`Select ${field.label}`}
+        required={field.required}
+      />
     )
   }
 
@@ -863,33 +868,6 @@ function renderInlineFieldInput({
       defaultValue={inlineFieldDefaultText(field, value)}
       className="h-11 bg-background/70"
     />
-  )
-}
-
-function RelationDatalists({
-  typeOptions,
-  slotOptions,
-  typeListId = "composer-relation-types",
-  slotListId = "composer-slots",
-}: {
-  typeOptions: string[]
-  slotOptions: string[]
-  typeListId?: string
-  slotListId?: string
-}) {
-  return (
-    <>
-      <datalist id={typeListId}>
-        {typeOptions.map((option) => (
-          <option key={option} value={option} />
-        ))}
-      </datalist>
-      <datalist id={slotListId}>
-        {slotOptions.map((option) => (
-          <option key={option} value={option} />
-        ))}
-      </datalist>
-    </>
   )
 }
 

--- a/app/ponix/pages/[id]/compose/page.tsx
+++ b/app/ponix/pages/[id]/compose/page.tsx
@@ -6,6 +6,7 @@ import { Database, Layers3, PencilLine } from "lucide-react"
 import { CmsEntityPicker } from "@/app/ponix/_components/cms-entity-picker"
 import { renderFieldInput } from "@/app/ponix/_components/cms-section-form"
 import { CmsSubmitButton } from "@/app/ponix/_components/cms-save-controls"
+import { CmsComboboxField } from "@/app/ponix/_components/cms-select-field"
 import { ComposerRelationList } from "@/app/ponix/pages/[id]/compose/composer-relation-list"
 import { ComposerSaveFeedback } from "@/app/ponix/pages/[id]/compose/composer-save-feedback"
 import { PonixComposerWorkspace } from "@/app/ponix/pages/[id]/compose/composer-workspace"
@@ -414,22 +415,36 @@ function SectionEntityWorkspace({
           <div className="grid grid-cols-3 gap-2">
             <div className="space-y-2">
               <Label htmlFor="composer-relation-type">관계</Label>
-              <Input
+              <CmsComboboxField
                 id="composer-relation-type"
                 name="relation_type"
                 defaultValue="item"
-                list="composer-relation-types"
-                className="h-10 bg-background/80"
+                options={relationTypeOptions.map((option) => ({
+                  value: option,
+                  label: option,
+                }))}
+                placeholder="관계 선택"
+                searchPlaceholder="관계 검색 또는 입력"
+                emptyLabel="새 관계 이름을 입력하세요"
+                customLabel="사용"
+                triggerClassName="h-10 bg-background/80"
               />
             </div>
             <div className="space-y-2">
               <Label htmlFor="composer-slot">슬롯</Label>
-              <Input
+              <CmsComboboxField
                 id="composer-slot"
                 name="slot"
                 defaultValue={slotOptions[0] ?? "default"}
-                list="composer-slots"
-                className="h-10 bg-background/80"
+                options={slotOptions.map((option) => ({
+                  value: option,
+                  label: option,
+                }))}
+                placeholder="슬롯 선택"
+                searchPlaceholder="슬롯 검색 또는 입력"
+                emptyLabel="새 슬롯 이름을 입력하세요"
+                customLabel="사용"
+                triggerClassName="h-10 bg-background/80"
               />
             </div>
             <div className="space-y-2">
@@ -446,10 +461,6 @@ function SectionEntityWorkspace({
           <CmsSubmitButton className="w-full rounded-full">
             데이터 연결
           </CmsSubmitButton>
-          <RelationDatalists
-            typeOptions={relationTypeOptions}
-            slotOptions={slotOptions}
-          />
         </form>
 
         <Separator />
@@ -513,33 +524,6 @@ function SectionAdvancedSettingsCard({ section }: { section: GraphSection }) {
         </AccordionItem>
       </Accordion>
     </Card>
-  )
-}
-
-function RelationDatalists({
-  typeOptions,
-  slotOptions,
-  typeListId = "composer-relation-types",
-  slotListId = "composer-slots",
-}: {
-  typeOptions: string[]
-  slotOptions: string[]
-  typeListId?: string
-  slotListId?: string
-}) {
-  return (
-    <>
-      <datalist id={typeListId}>
-        {typeOptions.map((option) => (
-          <option key={option} value={option} />
-        ))}
-      </datalist>
-      <datalist id={slotListId}>
-        {slotOptions.map((option) => (
-          <option key={option} value={option} />
-        ))}
-      </datalist>
-    </>
   )
 }
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "qa:cms-db-first-loaders": "node scripts/qa-cms-db-first-loaders.mjs",
     "qa:cms-schema-registry": "node scripts/qa-cms-schema-registry.mjs",
     "qa:cms-legacy-bridge-boundary": "node scripts/qa-cms-legacy-bridge-boundary.mjs",
+    "qa:cms-native-controls": "node scripts/qa-cms-native-controls.mjs",
     "qa:graph-primary-seed-writes": "node scripts/qa-graph-primary-seed-writes.mjs",
     "qa:legacy-mirror-readiness": "node scripts/qa-legacy-mirror-readiness.mjs"
   },

--- a/scripts/qa-cms-native-controls.mjs
+++ b/scripts/qa-cms-native-controls.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs"
+import path from "node:path"
+
+const repoRoot = process.cwd()
+const scanRoots = ["app/ponix", "app/ponix-canvas", "components"]
+const codeExtensions = new Set([".tsx", ".ts", ".jsx", ".js"])
+const ignoredFiles = new Set(["components/ui/select.tsx"])
+
+const forbiddenPatterns = [
+  {
+    label: "native select element",
+    pattern: /<\s*select\b/,
+  },
+  {
+    label: "native option element",
+    pattern: /<\s*option\b/,
+  },
+  {
+    label: "native datalist element",
+    pattern: /<\s*datalist\b/,
+  },
+  {
+    label: "native datalist list attribute",
+    pattern: /\blist\s*=/,
+  },
+]
+
+function repoRelative(filePath) {
+  return path.relative(repoRoot, filePath).split(path.sep).join("/")
+}
+
+function listFiles(dir) {
+  if (!existsSync(dir)) return []
+
+  return readdirSync(dir).flatMap((entry) => {
+    const absolute = path.join(dir, entry)
+    const relative = repoRelative(absolute)
+    const stat = statSync(absolute)
+
+    if (stat.isDirectory()) {
+      if (entry === "node_modules" || entry === ".next") return []
+      return listFiles(absolute)
+    }
+
+    if (ignoredFiles.has(relative)) return []
+    return codeExtensions.has(path.extname(entry)) ? [absolute] : []
+  })
+}
+
+function findViolations(relativePath, source) {
+  const violations = []
+
+  for (const [index, line] of source.split(/\r?\n/).entries()) {
+    for (const forbidden of forbiddenPatterns) {
+      if (!forbidden.pattern.test(line)) continue
+
+      violations.push({
+        file: relativePath,
+        line: index + 1,
+        rule: forbidden.label,
+        text: line.trim(),
+      })
+    }
+  }
+
+  return violations
+}
+
+function runSelfTest() {
+  const blockedSelect = findViolations("app/ponix/example.tsx", "<select>")
+  const blockedDatalist = findViolations("app/ponix/example.tsx", "<Input list=\"x\" />")
+  const allowedShadcnSelect = findViolations("app/ponix/example.tsx", "<Select>")
+  const allowedText = findViolations("components/example.tsx", "<PlaylistCard />")
+
+  if (
+    blockedSelect.length !== 1 ||
+    blockedDatalist.length !== 1 ||
+    allowedShadcnSelect.length !== 0 ||
+    allowedText.length !== 0
+  ) {
+    throw new Error("Self-test failed for CMS native control guard.")
+  }
+}
+
+runSelfTest()
+
+const files = scanRoots.flatMap((root) => listFiles(path.join(repoRoot, root)))
+const violations = files.flatMap((file) =>
+  findViolations(repoRelative(file), readFileSync(file, "utf8")),
+)
+
+console.log("CMS native control guard")
+console.table([
+  {
+    scannedFiles: files.length,
+    ignoredFiles: ignoredFiles.size,
+    forbiddenPatterns: forbiddenPatterns.length,
+    violations: violations.length,
+    selfTest: "ok",
+  },
+])
+
+if (violations.length) {
+  console.error("\nNative dropdown controls found in CMS/PONIX surfaces:")
+  for (const violation of violations) {
+    console.error(
+      `- ${violation.file}:${violation.line} ${violation.rule}: ${violation.text}`,
+    )
+  }
+  console.error(
+    "\nUse shadcn/Radix controls such as Select, Popover, Command, or a shared CMS field wrapper instead of native dropdown primitives.",
+  )
+  process.exitCode = 1
+}


### PR DESCRIPTION
## Summary
- Replace PONIX/CMS native select and datalist controls with shared shadcn-based fields.
- Add CmsSelectField for fixed schema enum values and CmsComboboxField for relation/slot values that need search plus custom entry.
- Add a CI-backed native control guard so CMS surfaces do not regress to raw select/datalist/list attributes.

## QA
- pnpm run qa:cms-native-controls
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm run build
- pnpm run qa:cms-db-first-loaders
- pnpm run qa:cms-schema-registry
- git diff --check
- cmux browser smoke: entity edit data type Select opens/selects/closes; page composer relation Combobox searches/selects a custom value/closes; browser errors list empty

Closes #110