### PR TITLE
Stage legacy mirror removal plan and guard output

### DIFF
--- a/docs/content-graph.md
+++ b/docs/content-graph.md
@@ -74,7 +74,8 @@ Current PONIX contract:
   `section_entities` reference and fails only on unclassified references.
   Treat reported bridge triggers, audit/RLS/index references, parity QA,
   `source_table` markers, and schema registry compatibility entries as the
-  removal blocker list.
+  removal blocker list. The staged cleanup sequence lives in
+  `docs/legacy-mirror-removal-plan.md`.
 - `pnpm run qa:graph-primary-seed-writes` checks that seed apply scripts and
   migration generators do not reintroduce direct legacy composition writes.
 

--- a/docs/legacy-mirror-removal-plan.md
+++ b/docs/legacy-mirror-removal-plan.md
@@ -1,0 +1,160 @@
+# Legacy Mirror Removal Plan
+
+This document stages the removal of the legacy composition mirror tables:
+
+- `page_sections`
+- `section_entities`
+
+The current production-safe state is graph-primary runtime composition with
+legacy mirrors kept for compatibility, triggers, and parity QA. Do not drop the
+legacy tables until every blocker reported by `pnpm run qa:legacy-mirror-readiness`
+has moved out of the removal-blocker categories.
+
+## Current State
+
+Completed:
+
+- Public page composition reads from `entity_relations`.
+- PONIX relation loaders read from `entity_relations`.
+- Runtime CMS code no longer reads `page_sections` or `section_entities`.
+- Routine CMS composition writes target `entity_relations`.
+- Legacy mirrors are still maintained by bridge triggers.
+- Parity QA still compares graph rows against legacy mirror rows.
+
+Remaining blocker classes:
+
+- Graph source markers still use legacy table names as `entity_relations.source_table`.
+- Bridge triggers still mirror graph writes into legacy tables.
+- Audit, index, RLS helper, and schema compatibility migrations still mention the legacy tables.
+- Parity QA still depends on the legacy mirrors as the comparison target.
+
+## Stage 1: Canonical Graph Identity
+
+Goal: make graph composition independent from legacy table identity.
+
+Current blocker category:
+
+- `graph_source_marker`
+- `schema_registry_compatibility`
+
+Work:
+
+- Stop treating `page_sections` and `section_entities` as runtime relation
+  kinds. They are table names, not long-term graph semantics.
+- Decide the canonical replacement before migrating data. Likely candidates are
+  relation schema keys, relation kinds, or a new compatibility column that can
+  be removed later.
+- Ensure UI/actions use `entity_relations.id` as the primary mutation id and do
+  not depend on legacy `source_id` for composition editing.
+- Keep the migration additive first. Do not overwrite or delete the legacy
+  markers until code and QA can read the canonical representation.
+
+Exit checks:
+
+- Runtime loaders and actions no longer filter composition by legacy table-name
+  markers except through an explicitly named compatibility layer.
+- `qa:legacy-mirror-readiness` no longer reports runtime graph source marker
+  blockers outside that compatibility layer.
+- `qa:cms-legacy-bridge-boundary`, `qa:cms-db-first-loaders`, typecheck, lint,
+  and build pass.
+
+## Stage 2: Bridge Trigger Retirement
+
+Goal: stop writing legacy mirror rows from graph writes.
+
+Current blocker category:
+
+- `active_bridge_migration`
+
+Work:
+
+- Add a migration that supersedes the graph-to-legacy bridge triggers.
+- Preserve reversibility: keep data intact and drop/disable only the sync path
+  after Stage 1 proves runtime no longer needs legacy identity.
+- Run parity QA before and after the migration so data drift is visible.
+- Regenerate Supabase types if schema-level constraints or columns change.
+
+Exit checks:
+
+- Graph writes no longer attempt to maintain `page_sections` or
+  `section_entities`.
+- Bridge trigger references are historical only or moved to a clearly retired
+  migration path.
+- Supabase advisors do not report new RLS or performance regressions.
+
+## Stage 3: Audit, Policy, And Index Cleanup
+
+Goal: remove active operational dependencies on the legacy mirrors.
+
+Current blocker categories:
+
+- `active_audit_migration`
+- `active_index_policy_migration`
+
+Work:
+
+- Update audit trigger target allowlists so they no longer require the legacy
+  tables.
+- Remove active indexes and helper policies that exist only for mirror reads or
+  writes.
+- Preserve RLS. Never disable row level security to make cleanup easier.
+
+Exit checks:
+
+- `qa:legacy-mirror-readiness` no longer reports active audit, policy, or index
+  blockers.
+- Supabase security and performance advisors are checked after the migration.
+
+## Stage 4: Parity QA Retirement
+
+Goal: stop using legacy mirrors as the truth source.
+
+Current blocker category:
+
+- `parity_qa`
+
+Work:
+
+- Replace graph-vs-legacy parity QA with graph-internal integrity QA.
+- Validate page composition, section ordering, relation cardinality, and missing
+  entity references directly from `entity_relations`.
+- Keep historical migrations untouched.
+
+Exit checks:
+
+- `qa:content-graph` no longer requires legacy mirror table reads.
+- A graph-only QA command covers the integrity checks previously provided by
+  parity comparisons.
+
+## Stage 5: Legacy Table Removal
+
+Goal: remove `page_sections` and `section_entities`.
+
+Preconditions:
+
+- Stages 1-4 are complete.
+- `qa:legacy-mirror-readiness` reports zero removal-blocker references.
+- Supabase types, app build, and all CMS QA pass.
+- A maintainer explicitly approves the destructive migration.
+
+Work:
+
+- Apply a reviewed migration that drops only the legacy tables and obsolete
+  constraints/functions proven unused by the previous stages.
+- Regenerate Supabase types.
+- Run security and performance advisors.
+
+Exit checks:
+
+- No runtime, QA, migration, docs, or generated-code path expects live legacy
+  mirror tables.
+- Production pages and PONIX CMS composition editing still pass smoke tests.
+
+## Guardrails
+
+- Do not run destructive SQL without explicit maintainer approval.
+- Do not disable RLS.
+- Do not rewrite historical migrations.
+- Do not remove parity QA before graph-only QA exists.
+- Do not collapse all stages into one migration. Each stage should leave a
+  reversible, testable state.

--- a/scripts/qa-legacy-mirror-readiness.mjs
+++ b/scripts/qa-legacy-mirror-readiness.mjs
@@ -35,54 +35,87 @@ const graphSourceMarkerFiles = new Set([
   "scripts/generate-scraped-content-migration.mjs",
 ])
 
+const removalStages = {
+  1: {
+    stage: "Canonical graph identity",
+    goal: "Replace legacy table-name relation markers with durable graph semantics.",
+  },
+  2: {
+    stage: "Bridge trigger retirement",
+    goal: "Stop graph writes from maintaining legacy mirror rows.",
+  },
+  3: {
+    stage: "Audit, policy, and index cleanup",
+    goal: "Remove active operational dependencies on legacy mirror tables.",
+  },
+  4: {
+    stage: "Parity QA retirement",
+    goal: "Replace graph-vs-legacy checks with graph-internal integrity QA.",
+  },
+  5: {
+    stage: "Legacy table removal",
+    goal: "Drop the legacy mirror tables after all blockers are gone.",
+  },
+}
+
 const categories = {
   active_bridge_migration: {
     label: "Active bridge migrations",
+    stage: 2,
     removalBlocker: true,
     note: "Drop/supersede graph<->legacy bridge triggers before removing mirrors.",
   },
   active_audit_migration: {
     label: "Audit migration compatibility",
+    stage: 3,
     removalBlocker: true,
     note: "Audit target-table checks and triggers still mention legacy mirrors.",
   },
   active_index_policy_migration: {
     label: "Legacy indexes/RLS helpers",
+    stage: 3,
     removalBlocker: true,
     note: "Indexes, policies, or helper functions target legacy mirrors.",
   },
   parity_qa: {
     label: "Parity QA",
+    stage: 4,
     removalBlocker: true,
     note: "Current QA compares graph rows with legacy mirror rows.",
   },
   graph_source_marker: {
     label: "Graph source markers",
+    stage: 1,
     removalBlocker: true,
     note: "Graph rows still use legacy table names as source_table markers.",
   },
   schema_registry_compatibility: {
     label: "Schema registry compatibility",
+    stage: 1,
     removalBlocker: true,
     note: "Registry metadata still allows/mentions legacy relation tables.",
   },
   static_guard: {
     label: "Static guard self-tests",
+    stage: null,
     removalBlocker: false,
     note: "Guard patterns intentionally mention legacy names.",
   },
   docs: {
     label: "Documentation",
+    stage: null,
     removalBlocker: false,
     note: "Docs describe the transition and must be updated during removal.",
   },
   historical_migration: {
     label: "Historical migrations",
+    stage: null,
     removalBlocker: false,
     note: "Committed history remains as-is; do not rewrite old migrations.",
   },
   readiness_guard: {
     label: "Readiness guard",
+    stage: null,
     removalBlocker: false,
     note: "This inventory script intentionally names legacy mirrors.",
   },
@@ -224,6 +257,7 @@ const summaryRows = [...byCategory.entries()]
   .map(([category, count]) => ({
     category,
     count,
+    stage: categories[category]?.stage ?? null,
     removalBlocker: categories[category]?.removalBlocker ?? true,
     label: categories[category]?.label ?? "Unclassified",
   }))
@@ -252,7 +286,9 @@ const blockerRows = Object.entries(categories)
     ([category, metadata]) =>
       metadata.removalBlocker && (byCategory.get(category) ?? 0) > 0,
   )
+  .sort(([, left], [, right]) => (left.stage ?? 99) - (right.stage ?? 99))
   .map(([category, metadata]) => ({
+    stage: metadata.stage,
     category,
     count: byCategory.get(category) ?? 0,
     nextStep: metadata.note,
@@ -260,6 +296,27 @@ const blockerRows = Object.entries(categories)
 
 console.log("\nRemoval blockers to clear before dropping legacy mirrors")
 console.table(blockerRows)
+
+const stageRows = Object.entries(removalStages).map(([stage, metadata]) => {
+  const stageCategories = Object.entries(categories).filter(
+    ([, category]) => category.stage === Number(stage),
+  )
+  const referenceCount = stageCategories.reduce(
+    (total, [category]) => total + (byCategory.get(category) ?? 0),
+    0,
+  )
+
+  return {
+    stage: Number(stage),
+    name: metadata.stage,
+    blockerReferences: referenceCount,
+    categories: stageCategories.map(([category]) => category).join(", "),
+    goal: metadata.goal,
+  }
+})
+
+console.log("\nSuggested removal stages")
+console.table(stageRows)
 
 if (unclassified.length) {
   console.error("\nUnclassified legacy mirror references:")


### PR DESCRIPTION
## Summary
- Add a staged legacy mirror removal plan for page_sections / section_entities.
- Link the plan from the content graph docs.
- Extend qa:legacy-mirror-readiness output with stage/order information and suggested removal stages.

## QA
- pnpm run qa:legacy-mirror-readiness
- pnpm run qa:cms-legacy-bridge-boundary
- pnpm run qa:cms-db-first-loaders
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm run build
- git diff --check

## Notes
- No Supabase writes or migrations.
- This PR intentionally does not remove triggers, policies, source markers, parity QA, or tables.

Closes #113