### PR TITLE
Use relation schemas as composition identity

### DIFF
--- a/app/ponix/_components/cms-relations.tsx
+++ b/app/ponix/_components/cms-relations.tsx
@@ -882,7 +882,7 @@ function BridgeSourceHint({
 }) {
   return (
     <div className="mt-1 space-y-0.5 text-[10px] leading-tight text-muted-foreground">
-      <div>저장 행: {shortId(relation.sourceId)}</div>
+      <div>미러 행: {relation.sourceId ? shortId(relation.sourceId) : "없음"}</div>
       <div>그래프 행: {shortId(relation.graphRelationId)}</div>
     </div>
   )

--- a/app/ponix/relations/actions.ts
+++ b/app/ponix/relations/actions.ts
@@ -47,6 +47,8 @@ type ActionResult =
 
 const uuidPattern =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const PAGE_SECTION_RELATION_SCHEMA_KEY = "relation/page-section/v1"
+const SECTION_ENTITY_RELATION_SCHEMA_KEY = "relation/section-entity/v1"
 
 function stringField(formData: FormData, key: string) {
   const value = formData.get(key)
@@ -200,7 +202,7 @@ async function loadPageSectionGraphRelation(
       `,
     )
     .eq("id", graphRelationId)
-    .eq("source_table", "page_sections")
+    .eq("schema_key", PAGE_SECTION_RELATION_SCHEMA_KEY)
     .maybeSingle()
 
   const relation = data as unknown as PageSectionGraphRelation | null
@@ -234,7 +236,7 @@ async function loadSectionEntityGraphRelation(
       `,
     )
     .eq("id", graphRelationId)
-    .eq("source_table", "section_entities")
+    .eq("schema_key", SECTION_ENTITY_RELATION_SCHEMA_KEY)
     .maybeSingle()
 
   const relation = data as unknown as SectionEntityGraphRelation | null
@@ -276,7 +278,7 @@ export async function addPageSectionRelationAction(formData: FormData) {
     const payload: EntityRelationInsert = {
       from_entity_id: pageEntityId,
       to_entity_id: sectionEntityId,
-      schema_key: "relation/page-section/v1",
+      schema_key: PAGE_SECTION_RELATION_SCHEMA_KEY,
       relation_type: "contains_section",
       slot: "sections",
       sort_order: parseSortOrder(formData),
@@ -287,7 +289,7 @@ export async function addPageSectionRelationAction(formData: FormData) {
     const { data: existing, error: existingError } = await supabase
       .from("entity_relations")
       .select("id")
-      .eq("source_table", "page_sections")
+      .eq("schema_key", PAGE_SECTION_RELATION_SCHEMA_KEY)
       .eq("from_entity_id", pageEntityId)
       .eq("to_entity_id", sectionEntityId)
       .eq("relation_type", "contains_section")
@@ -398,7 +400,7 @@ export async function addSectionEntityRelationAction(formData: FormData) {
     const payload: EntityRelationInsert = {
       from_entity_id: sectionEntityId,
       to_entity_id: entityId,
-      schema_key: "relation/section-entity/v1",
+      schema_key: SECTION_ENTITY_RELATION_SCHEMA_KEY,
       relation_type: relationType,
       slot,
       sort_order: parseSortOrder(formData),
@@ -409,7 +411,7 @@ export async function addSectionEntityRelationAction(formData: FormData) {
     const { data: existing, error: existingError } = await supabase
       .from("entity_relations")
       .select("id")
-      .eq("source_table", "section_entities")
+      .eq("schema_key", SECTION_ENTITY_RELATION_SCHEMA_KEY)
       .eq("from_entity_id", payload.from_entity_id)
       .eq("to_entity_id", payload.to_entity_id)
       .eq("relation_type", relationType)
@@ -585,7 +587,7 @@ export async function reorderSectionEntityRelationsAction({
     const { data: relations, error: loadError } = await supabase
       .from("entity_relations")
       .select("id, to_entity_id")
-      .eq("source_table", "section_entities")
+      .eq("schema_key", SECTION_ENTITY_RELATION_SCHEMA_KEY)
       .eq("from_entity_id", sectionShadow.id)
       .in("id", orderedIds)
 
@@ -603,7 +605,7 @@ export async function reorderSectionEntityRelationsAction({
         .from("entity_relations")
         .update({ sort_order: (index + 1) * 10 } satisfies EntityRelationUpdate)
         .eq("id", relationId)
-        .eq("source_table", "section_entities")
+        .eq("schema_key", SECTION_ENTITY_RELATION_SCHEMA_KEY)
         .eq("from_entity_id", sectionShadow.id),
     )
     const results = await Promise.all(updates)

--- a/docs/content-graph.md
+++ b/docs/content-graph.md
@@ -52,7 +52,8 @@ Current PONIX contract:
   The legacy `page_sections` / `section_entities` path is kept in QA scripts
   only as a parity check while the transition is in progress.
 - CMS relation lists read page/section placement through `entity_relations`
-  bridge rows.
+  bridge rows, using relation `schema_key` values as the runtime identity:
+  `relation/page-section/v1` and `relation/section-entity/v1`.
 - Those bridge rows expose both the `entity_relations.id` and the legacy
   `source_id`.
 - Routine CMS composition writes target `entity_relations`; graph-to-legacy

--- a/docs/legacy-mirror-removal-plan.md
+++ b/docs/legacy-mirror-removal-plan.md
@@ -17,6 +17,8 @@ Completed:
 - Public page composition reads from `entity_relations`.
 - PONIX relation loaders read from `entity_relations`.
 - Runtime CMS code no longer reads `page_sections` or `section_entities`.
+- Runtime composition now identifies graph relations by relation `schema_key`
+  instead of legacy table-name markers.
 - Routine CMS composition writes target `entity_relations`.
 - Legacy mirrors are still maintained by bridge triggers.
 - Parity QA still compares graph rows against legacy mirror rows.

--- a/lib/cms/content.ts
+++ b/lib/cms/content.ts
@@ -11,6 +11,9 @@ const ENTITY_LIST_LIMIT = 200
 const RELATION_ENTITY_OPTION_LIMIT = 80
 const RELATION_ENTITY_SEARCH_LIMIT = 60
 const RELATION_LIST_LIMIT = 300
+const DEFAULT_RELATION_SCHEMA_KEY = "relation/default/v1"
+const PAGE_SECTION_RELATION_SCHEMA_KEY = "relation/page-section/v1"
+const SECTION_ENTITY_RELATION_SCHEMA_KEY = "relation/section-entity/v1"
 
 type PageRow = Database["public"]["Tables"]["pages"]["Row"]
 type SectionRow = Database["public"]["Tables"]["sections"]["Row"]
@@ -113,8 +116,7 @@ export type CmsLinkedEntity = SchemaSummary & {
 export type CmsPageSectionRelation = {
   id: string
   graphRelationId: string
-  sourceTable: "page_sections"
-  sourceId: string
+  sourceId: string | null
   pageId: string
   sectionId: string
   sortOrder: number
@@ -127,8 +129,7 @@ export type CmsPageSectionRelation = {
 export type CmsSectionEntityRelation = {
   id: string
   graphRelationId: string
-  sourceTable: "section_entities"
-  sourceId: string
+  sourceId: string | null
   sectionId: string
   entityId: string
   relationType: string
@@ -858,7 +859,7 @@ async function loadPageSectionRelationsFromEntityGraph({
   let query = supabase
     .from("entity_relations")
     .select(ENTITY_RELATION_SELECT, { count: "exact" })
-    .eq("source_table", "page_sections")
+    .eq("schema_key", PAGE_SECTION_RELATION_SCHEMA_KEY)
 
   if (pageShadowId) query = query.eq("from_entity_id", pageShadowId)
   if (sectionShadowId) query = query.eq("to_entity_id", sectionShadowId)
@@ -892,12 +893,11 @@ async function loadPageSectionRelationsFromEntityGraph({
       const mappedPageId = sourceId(relation.fromEntity, "pages") ?? pageId
       const mappedSectionId = sourceId(relation.toEntity, "sections") ?? sectionId
 
-      if (!mappedPageId || !mappedSectionId || !relation.source_id) return null
+      if (!mappedPageId || !mappedSectionId) return null
 
       return {
-        id: relation.source_id,
+        id: relation.id,
         graphRelationId: relation.id,
-        sourceTable: "page_sections",
         sourceId: relation.source_id,
         pageId: mappedPageId,
         sectionId: mappedSectionId,
@@ -940,7 +940,7 @@ async function loadSectionEntityRelationsFromEntityGraph({
   let query = supabase
     .from("entity_relations")
     .select(ENTITY_RELATION_SELECT, { count: "exact" })
-    .eq("source_table", "section_entities")
+    .eq("schema_key", SECTION_ENTITY_RELATION_SCHEMA_KEY)
 
   if (sectionShadowId) query = query.eq("from_entity_id", sectionShadowId)
   if (entityId) query = query.eq("to_entity_id", entityId)
@@ -970,14 +970,13 @@ async function loadSectionEntityRelationsFromEntityGraph({
       const mappedSectionId =
         sourceId(relation.fromEntity, "sections") ?? sectionId
 
-      if (!mappedSectionId || !relation.source_id || !relation.toEntity) {
+      if (!mappedSectionId || !relation.toEntity) {
         return null
       }
 
       return {
-        id: relation.source_id,
+        id: relation.id,
         graphRelationId: relation.id,
-        sourceTable: "section_entities",
         sourceId: relation.source_id,
         sectionId: mappedSectionId,
         entityId: relation.to_entity_id,
@@ -1010,7 +1009,7 @@ async function loadEntityRelations({
   let query = supabase
     .from("entity_relations")
     .select(ENTITY_RELATION_SELECT, { count: "exact" })
-    .is("source_table", null)
+    .eq("schema_key", DEFAULT_RELATION_SCHEMA_KEY)
 
   if (fromEntityId) {
     query = query.eq("from_entity_id", fromEntityId)

--- a/lib/data/content-graph.ts
+++ b/lib/data/content-graph.ts
@@ -21,6 +21,9 @@ type EntityRow = Database["public"]["Tables"]["entities"]["Row"]
 type PageRow = Database["public"]["Tables"]["pages"]["Row"]
 type EntityRelationRow = Database["public"]["Tables"]["entity_relations"]["Row"]
 
+const PAGE_SECTION_RELATION_SCHEMA_KEY = "relation/page-section/v1"
+const SECTION_ENTITY_RELATION_SCHEMA_KEY = "relation/section-entity/v1"
+
 export type GraphSectionItem = {
   entity: EntityRow
   relationType: string
@@ -543,7 +546,7 @@ async function loadGraphPageFromEntityRelations({
         toEntity:entities!entity_relations_to_entity_id_fkey(id, source_table, source_id)
       `,
     )
-    .eq("source_table", "page_sections")
+    .eq("schema_key", PAGE_SECTION_RELATION_SCHEMA_KEY)
     .eq("from_entity_id", pageEntity.id)
     .order("sort_order", { ascending: true })
 
@@ -583,7 +586,7 @@ async function loadGraphPageFromEntityRelations({
       ? await supabase
           .from("entity_relations")
           .select("*")
-          .eq("source_table", "section_entities")
+          .eq("schema_key", SECTION_ENTITY_RELATION_SCHEMA_KEY)
           .in("from_entity_id", sectionShadowIds)
       : { data: [], error: null }
 

--- a/scripts/content-graph-write-helpers.mjs
+++ b/scripts/content-graph-write-helpers.mjs
@@ -146,7 +146,7 @@ export async function deleteSectionEntityRelations(
     let query = supabase
       .from("entity_relations")
       .delete()
-      .eq("source_table", "section_entities")
+      .eq("schema_key", "relation/section-entity/v1")
 
     if (fromEntityIds.length) {
       query = query.in("from_entity_id", fromEntityIds)

--- a/scripts/generate-instagram-feed-migration.mjs
+++ b/scripts/generate-instagram-feed-migration.mjs
@@ -445,7 +445,7 @@ set sort_order = excluded.sort_order,
 
 delete from public.entity_relations relation
 using public.entities section_entity, public.sections section_ref, public.entities entity
-where relation.source_table = 'section_entities'
+where relation.schema_key = 'relation/section-entity/v1'
   and relation.from_entity_id = section_entity.id
   and relation.to_entity_id = entity.id
   and section_entity.source_table = 'sections'
@@ -501,7 +501,7 @@ set schema_key = excluded.schema_key,
 
 delete from public.entity_relations relation
 using public.entities section_entity, public.sections section_ref, public.entities entity
-where relation.source_table = 'section_entities'
+where relation.schema_key = 'relation/section-entity/v1'
   and relation.from_entity_id = section_entity.id
   and relation.to_entity_id = entity.id
   and section_entity.source_table = 'sections'

--- a/scripts/generate-scraped-content-migration.mjs
+++ b/scripts/generate-scraped-content-migration.mjs
@@ -768,7 +768,7 @@ set sort_order = excluded.sort_order,
 
 delete from public.entity_relations relation
 using public.entities section_entity, public.sections section_ref
-where relation.source_table = 'section_entities'
+where relation.schema_key = 'relation/section-entity/v1'
   and relation.from_entity_id = section_entity.id
   and section_entity.source_table = 'sections'
   and section_entity.source_id = section_ref.id

--- a/scripts/qa-legacy-mirror-readiness.mjs
+++ b/scripts/qa-legacy-mirror-readiness.mjs
@@ -30,6 +30,9 @@ const graphSourceMarkerFiles = new Set([
   "lib/cms/content.ts",
   "lib/data/content-graph.ts",
   "app/ponix/relations/actions.ts",
+])
+const bridgeCompatibilityMarkerFiles = new Set([
+  "app/ponix/relations/actions.ts",
   "scripts/content-graph-write-helpers.mjs",
   "scripts/generate-instagram-feed-migration.mjs",
   "scripts/generate-scraped-content-migration.mjs",
@@ -64,6 +67,12 @@ const categories = {
     stage: 2,
     removalBlocker: true,
     note: "Drop/supersede graph<->legacy bridge triggers before removing mirrors.",
+  },
+  bridge_compatibility_marker: {
+    label: "Bridge compatibility markers",
+    stage: 2,
+    removalBlocker: true,
+    note: "Runtime and maintenance writes still populate legacy source_table markers for bridge triggers.",
   },
   active_audit_migration: {
     label: "Audit migration compatibility",
@@ -144,7 +153,7 @@ function listFiles(dir) {
   })
 }
 
-function classify(file) {
+function classify(file, line = "") {
   if (file === "scripts/qa-legacy-mirror-readiness.mjs") {
     return "readiness_guard"
   }
@@ -188,6 +197,17 @@ function classify(file) {
     file === "supabase/migrations/20260508000043_graph_primary_composition_writes.sql"
   ) {
     return "active_bridge_migration"
+  }
+
+  if (bridgeCompatibilityMarkerFiles.has(file)) {
+    if (
+      /\.eq\(\s*["'`]source_table["'`]/.test(line) ||
+      /where\s+relation\.source_table\s*=/.test(line)
+    ) {
+      return "graph_source_marker"
+    }
+
+    return "bridge_compatibility_marker"
   }
 
   if (graphSourceMarkerFiles.has(file)) {

--- a/supabase/migrations/20260509000045_relation_schema_runtime_identity_indexes.sql
+++ b/supabase/migrations/20260509000045_relation_schema_runtime_identity_indexes.sql
@@ -1,0 +1,15 @@
+-- Bremen - relation schema-key runtime identity indexes.
+--
+-- Runtime composition now identifies page-section and section-entity graph
+-- relations by relation schema_key instead of legacy source_table markers.
+-- These additive indexes support the new read/write query shape without
+-- changing data, triggers, policies, or RLS behavior.
+
+create index if not exists entity_relations_schema_from_sort_idx
+  on public.entity_relations(schema_key, from_entity_id, sort_order);
+
+create index if not exists entity_relations_schema_from_slot_sort_idx
+  on public.entity_relations(schema_key, from_entity_id, slot, sort_order);
+
+create index if not exists entity_relations_schema_to_slot_sort_idx
+  on public.entity_relations(schema_key, to_entity_id, slot, sort_order);


### PR DESCRIPTION
## Summary
- switch runtime page-section and section-entity composition filters from legacy source_table markers to relation schema keys
- keep source_table/source_id only as bridge compatibility metadata until trigger retirement
- add additive entity_relations schema-key indexes for the new query shape
- document Stage 1 completion in the legacy mirror removal plan

## Verification
- pnpm run qa:legacy-mirror-readiness
- pnpm run qa:content-graph
- pnpm run qa:cms-legacy-bridge-boundary
- pnpm run qa:cms-db-first-loaders
- pnpm run qa:graph-primary-seed-writes
- pnpm run qa:cms-schema-registry
- pnpm run qa:cms-native-controls
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm run build
- git diff --cached --check

## Supabase
- Includes additive index migration only.
- Not applied to production Supabase in this PR session.

Closes #115