### PR TITLE
Retire graph-to-legacy composition writes

### DIFF
--- a/app/ponix/relations/actions.ts
+++ b/app/ponix/relations/actions.ts
@@ -283,7 +283,6 @@ export async function addPageSectionRelationAction(formData: FormData) {
       slot: "sections",
       sort_order: parseSortOrder(formData),
       props: {},
-      source_table: "page_sections",
       created_by_member_id: admin.id,
     }
     const { data: existing, error: existingError } = await supabase
@@ -405,7 +404,6 @@ export async function addSectionEntityRelationAction(formData: FormData) {
       slot,
       sort_order: parseSortOrder(formData),
       props: parseProps(formData),
-      source_table: "section_entities",
       created_by_member_id: admin.id,
     }
     const { data: existing, error: existingError } = await supabase

--- a/docs/content-graph.md
+++ b/docs/content-graph.md
@@ -54,11 +54,12 @@ Current PONIX contract:
 - CMS relation lists read page/section placement through `entity_relations`
   bridge rows, using relation `schema_key` values as the runtime identity:
   `relation/page-section/v1` and `relation/section-entity/v1`.
-- Those bridge rows expose both the `entity_relations.id` and the legacy
-  `source_id`.
-- Routine CMS composition writes target `entity_relations`; graph-to-legacy
-  triggers mirror those writes back into `page_sections` and
-  `section_entities`.
+- Existing mirrored rows may still expose a legacy `source_id`; new runtime
+  composition writes use `entity_relations.id` and do not require one.
+- Routine CMS composition writes target `entity_relations` without legacy
+  relation `source_table` markers. The graph-to-legacy source bridge is retired
+  as a no-op migration; legacy tables remain only for transition compatibility
+  and parity QA.
 - Maintenance apply scripts and generated seed migrations that refresh scraped
   or Instagram content should also write section placement through
   `entity_relations`, not directly through `page_sections` or

--- a/docs/legacy-mirror-removal-plan.md
+++ b/docs/legacy-mirror-removal-plan.md
@@ -20,13 +20,14 @@ Completed:
 - Runtime composition now identifies graph relations by relation `schema_key`
   instead of legacy table-name markers.
 - Routine CMS composition writes target `entity_relations`.
-- Legacy mirrors are still maintained by bridge triggers.
+- Graph-to-legacy mirror writes are retired by replacing the source bridge
+  function with a no-op.
+- Legacy mirror compatibility triggers remain for the legacy tables themselves.
 - Parity QA still compares graph rows against legacy mirror rows.
 
 Remaining blocker classes:
 
-- Graph source markers still use legacy table names as `entity_relations.source_table`.
-- Bridge triggers still mirror graph writes into legacy tables.
+- Legacy mirror compatibility migrations still mention the legacy tables.
 - Audit, index, RLS helper, and schema compatibility migrations still mention the legacy tables.
 - Parity QA still depends on the legacy mirrors as the comparison target.
 
@@ -70,7 +71,7 @@ Current blocker category:
 
 Work:
 
-- Add a migration that supersedes the graph-to-legacy bridge triggers.
+- Add a migration that supersedes the graph-to-legacy source bridge behavior.
 - Preserve reversibility: keep data intact and drop/disable only the sync path
   after Stage 1 proves runtime no longer needs legacy identity.
 - Run parity QA before and after the migration so data drift is visible.
@@ -80,8 +81,9 @@ Exit checks:
 
 - Graph writes no longer attempt to maintain `page_sections` or
   `section_entities`.
-- Bridge trigger references are historical only or moved to a clearly retired
-  migration path.
+- Runtime and maintenance writes no longer populate legacy relation
+  `source_table` markers.
+- The graph-to-legacy source bridge function is superseded by a no-op migration.
 - Supabase advisors do not report new RLS or performance regressions.
 
 ## Stage 3: Audit, Policy, And Index Cleanup
@@ -143,6 +145,7 @@ Work:
 
 - Apply a reviewed migration that drops only the legacy tables and obsolete
   constraints/functions proven unused by the previous stages.
+- Remove remaining legacy mirror compatibility trigger/function definitions.
 - Regenerate Supabase types.
 - Run security and performance advisors.
 

--- a/scripts/content-graph-write-helpers.mjs
+++ b/scripts/content-graph-write-helpers.mjs
@@ -114,7 +114,6 @@ export async function upsertPageSectionRelations(
         slot: "sections",
         sort_order: relationNumber(row, "sortOrder", "sort_order"),
         props: relationProps(row),
-        source_table: "page_sections",
       }
     }),
     label,
@@ -194,7 +193,6 @@ export async function upsertSectionEntityRelations(
         slot: row.slot ?? "default",
         sort_order: relationNumber(row, "sortOrder", "sort_order"),
         props: relationProps(row),
-        source_table: "section_entities",
       }
     }),
     label,

--- a/scripts/generate-instagram-feed-migration.mjs
+++ b/scripts/generate-instagram-feed-migration.mjs
@@ -356,8 +356,7 @@ insert into public.entity_relations (
   relation_type,
   slot,
   sort_order,
-  props,
-  source_table
+  props
 )
 select
   page_entity_id,
@@ -366,15 +365,12 @@ select
   'contains_section',
   'sections',
   25,
-  '{}'::jsonb,
-  'page_sections'
+  '{}'::jsonb
 from target
 on conflict (from_entity_id, to_entity_id, relation_type, slot) do update
 set schema_key = excluded.schema_key,
     sort_order = excluded.sort_order,
-    props = excluded.props,
-    source_table = excluded.source_table,
-    source_id = excluded.source_id;
+    props = excluded.props;
 
 insert into public.entities (
   entity_type,
@@ -478,8 +474,7 @@ insert into public.entity_relations (
   relation_type,
   slot,
   sort_order,
-  props,
-  source_table
+  props
 )
 select
   target_section.section_entity_id,
@@ -488,16 +483,13 @@ select
   'features_photo',
   'gallery',
   ordered.rank * 10,
-  '{}'::jsonb,
-  'section_entities'
+  '{}'::jsonb
 from target_section
 cross join ordered
 on conflict (from_entity_id, to_entity_id, relation_type, slot) do update
 set schema_key = excluded.schema_key,
     sort_order = excluded.sort_order,
-    props = excluded.props,
-    source_table = excluded.source_table,
-    source_id = excluded.source_id;
+    props = excluded.props;
 
 delete from public.entity_relations relation
 using public.entities section_entity, public.sections section_ref, public.entities entity
@@ -535,8 +527,7 @@ insert into public.entity_relations (
   relation_type,
   slot,
   sort_order,
-  props,
-  source_table
+  props
 )
 select
   target_section.section_entity_id,
@@ -545,16 +536,13 @@ select
   'features_post',
   ordered.content_kind,
   ordered.rank * 10,
-  '{}'::jsonb,
-  'section_entities'
+  '{}'::jsonb
 from target_section
 cross join ordered
 on conflict (from_entity_id, to_entity_id, relation_type, slot) do update
 set schema_key = excluded.schema_key,
     sort_order = excluded.sort_order,
-    props = excluded.props,
-    source_table = excluded.source_table,
-    source_id = excluded.source_id;
+    props = excluded.props;
 `
 
 writeFileSync(outputPath, sql)

--- a/scripts/generate-scraped-content-migration.mjs
+++ b/scripts/generate-scraped-content-migration.mjs
@@ -611,8 +611,7 @@ insert into public.entity_relations (
   relation_type,
   slot,
   sort_order,
-  props,
-  source_table
+  props
 )
 select
   page_entity.id,
@@ -621,8 +620,7 @@ select
   'contains_section',
   'sections',
   links.sort_order,
-  '{}'::jsonb,
-  'page_sections'
+  '{}'::jsonb
 from links
 join public.pages page_ref on page_ref.slug = links.page_slug
 join public.sections section_ref on section_ref.key = links.section_key
@@ -635,9 +633,7 @@ join public.entities section_entity
 on conflict (from_entity_id, to_entity_id, relation_type, slot) do update
 set schema_key = excluded.schema_key,
     sort_order = excluded.sort_order,
-    props = excluded.props,
-    source_table = excluded.source_table,
-    source_id = excluded.source_id;
+    props = excluded.props;
 
 insert into public.entities (entity_type, schema_key, slug, title, subtitle, summary, thumbnail_url, sort_at, data, published)
 values
@@ -798,8 +794,7 @@ insert into public.entity_relations (
   relation_type,
   slot,
   sort_order,
-  props,
-  source_table
+  props
 )
 select
   target_section.section_entity_id,
@@ -808,15 +803,12 @@ select
   'item',
   'default',
   (ordered.rank * 10)::int,
-  '{}'::jsonb,
-  'section_entities'
+  '{}'::jsonb
 from target_section cross join ordered
 on conflict (from_entity_id, to_entity_id, relation_type, slot) do update
 set schema_key = excluded.schema_key,
     sort_order = excluded.sort_order,
-    props = excluded.props,
-    source_table = excluded.source_table,
-    source_id = excluded.source_id;
+    props = excluded.props;
 
 with target_section as (
   select section_entity.id as section_entity_id
@@ -845,8 +837,7 @@ insert into public.entity_relations (
   relation_type,
   slot,
   sort_order,
-  props,
-  source_table
+  props
 )
 select
   target_section.section_entity_id,
@@ -855,15 +846,12 @@ select
   'item',
   ordered.slot,
   (ordered.rank * 10)::int,
-  '{}'::jsonb,
-  'section_entities'
+  '{}'::jsonb
 from target_section cross join ordered
 on conflict (from_entity_id, to_entity_id, relation_type, slot) do update
 set schema_key = excluded.schema_key,
     sort_order = excluded.sort_order,
-    props = excluded.props,
-    source_table = excluded.source_table,
-    source_id = excluded.source_id;
+    props = excluded.props;
 
 with target_section as (
   select section_entity.id as section_entity_id
@@ -890,8 +878,7 @@ insert into public.entity_relations (
   relation_type,
   slot,
   sort_order,
-  props,
-  source_table
+  props
 )
 select
   target_section.section_entity_id,
@@ -900,15 +887,12 @@ select
   'item',
   'default',
   (ordered.rank * 10)::int,
-  '{}'::jsonb,
-  'section_entities'
+  '{}'::jsonb
 from target_section cross join ordered
 on conflict (from_entity_id, to_entity_id, relation_type, slot) do update
 set schema_key = excluded.schema_key,
     sort_order = excluded.sort_order,
-    props = excluded.props,
-    source_table = excluded.source_table,
-    source_id = excluded.source_id;
+    props = excluded.props;
 
 with target_section as (
   select section_entity.id as section_entity_id
@@ -936,8 +920,7 @@ insert into public.entity_relations (
   relation_type,
   slot,
   sort_order,
-  props,
-  source_table
+  props
 )
 select
   target_section.section_entity_id,
@@ -946,15 +929,12 @@ select
   'item',
   'default',
   (ordered.rank * 10)::int,
-  '{}'::jsonb,
-  'section_entities'
+  '{}'::jsonb
 from target_section cross join ordered
 on conflict (from_entity_id, to_entity_id, relation_type, slot) do update
 set schema_key = excluded.schema_key,
     sort_order = excluded.sort_order,
-    props = excluded.props,
-    source_table = excluded.source_table,
-    source_id = excluded.source_id;
+    props = excluded.props;
 
 with target_section as (
   select section_entity.id as section_entity_id
@@ -979,8 +959,7 @@ insert into public.entity_relations (
   relation_type,
   slot,
   sort_order,
-  props,
-  source_table
+  props
 )
 select
   target_section.section_entity_id,
@@ -989,15 +968,12 @@ select
   'item',
   'default',
   (ordered.rank * 10)::int,
-  '{}'::jsonb,
-  'section_entities'
+  '{}'::jsonb
 from target_section cross join ordered
 on conflict (from_entity_id, to_entity_id, relation_type, slot) do update
 set schema_key = excluded.schema_key,
     sort_order = excluded.sort_order,
-    props = excluded.props,
-    source_table = excluded.source_table,
-    source_id = excluded.source_id;
+    props = excluded.props;
 
 with target_section as (
   select section_entity.id as section_entity_id
@@ -1022,8 +998,7 @@ insert into public.entity_relations (
   relation_type,
   slot,
   sort_order,
-  props,
-  source_table
+  props
 )
 select
   target_section.section_entity_id,
@@ -1032,15 +1007,12 @@ select
   'item',
   'default',
   (ordered.rank * 10)::int,
-  '{}'::jsonb,
-  'section_entities'
+  '{}'::jsonb
 from target_section cross join ordered
 on conflict (from_entity_id, to_entity_id, relation_type, slot) do update
 set schema_key = excluded.schema_key,
     sort_order = excluded.sort_order,
-    props = excluded.props,
-    source_table = excluded.source_table,
-    source_id = excluded.source_id;
+    props = excluded.props;
 
 with target_section as (
   select section_entity.id as section_entity_id
@@ -1066,8 +1038,7 @@ insert into public.entity_relations (
   relation_type,
   slot,
   sort_order,
-  props,
-  source_table
+  props
 )
 select
   target_section.section_entity_id,
@@ -1076,15 +1047,12 @@ select
   'item',
   ordered.slot,
   (ordered.rank * 10)::int,
-  '{}'::jsonb,
-  'section_entities'
+  '{}'::jsonb
 from target_section cross join ordered
 on conflict (from_entity_id, to_entity_id, relation_type, slot) do update
 set schema_key = excluded.schema_key,
     sort_order = excluded.sort_order,
-    props = excluded.props,
-    source_table = excluded.source_table,
-    source_id = excluded.source_id;
+    props = excluded.props;
 
 with target_section as (
   select section_entity.id as section_entity_id
@@ -1109,8 +1077,7 @@ insert into public.entity_relations (
   relation_type,
   slot,
   sort_order,
-  props,
-  source_table
+  props
 )
 select
   target_section.section_entity_id,
@@ -1119,15 +1086,12 @@ select
   'item',
   'default',
   (ordered.rank * 10)::int,
-  '{}'::jsonb,
-  'section_entities'
+  '{}'::jsonb
 from target_section cross join ordered
 on conflict (from_entity_id, to_entity_id, relation_type, slot) do update
 set schema_key = excluded.schema_key,
     sort_order = excluded.sort_order,
-    props = excluded.props,
-    source_table = excluded.source_table,
-    source_id = excluded.source_id;
+    props = excluded.props;
 `
 
 writeFileSync(outputPath, sql)

--- a/scripts/qa-cms-legacy-bridge-boundary.mjs
+++ b/scripts/qa-cms-legacy-bridge-boundary.mjs
@@ -17,6 +17,10 @@ const forbiddenPatterns = [
     label: "direct section_entities Supabase access",
     pattern: /(?:^|[^\w])from\(\s*["'`]section_entities["'`]\s*\)/,
   },
+  {
+    label: "legacy relation source_table marker",
+    pattern: /source_table\s*:\s*["'`](page_sections|section_entities)["'`]/,
+  },
 ]
 
 function repoRelative(filePath) {
@@ -77,7 +81,7 @@ function runSelfTest() {
   if (
     blocked.length !== 1 ||
     retiredBoundary.length !== 1 ||
-    sourceMarker.length !== 0
+    sourceMarker.length !== 1
   ) {
     throw new Error("Self-test failed for CMS legacy bridge boundary guard.")
   }

--- a/scripts/qa-graph-primary-seed-writes.mjs
+++ b/scripts/qa-graph-primary-seed-writes.mjs
@@ -50,6 +50,22 @@ const forbiddenPatterns = [
     label: "generated section_entities update SQL",
     pattern: /update\s+public\.section_entities/i,
   },
+  {
+    label: "legacy relation source_table object marker",
+    pattern: /source_table\s*:\s*["'`](page_sections|section_entities)["'`]/,
+  },
+  {
+    label: "generated legacy relation source_table value",
+    pattern: /^\s*["'`](page_sections|section_entities)["'`]/,
+  },
+  {
+    label: "inline generated legacy relation source_table value",
+    pattern: /source_table\)\s*values\s*\(\s*["'`](page_sections|section_entities)["'`]/i,
+  },
+  {
+    label: "generated legacy relation source_table upsert",
+    pattern: /source_table\s*=\s*excluded\.source_table/i,
+  },
 ]
 
 function scanText(file, text) {
@@ -80,15 +96,21 @@ function runSelfTest() {
     "scripts/generate-example.mjs",
     "insert into public.section_entities (section_id, entity_id) select ...",
   )
+  const sourceMarkerShouldFail = scanText(
+    "scripts/apply-example.mjs",
+    "insert into public.entity_relations (source_table) values ('section_entities')",
+  )
   const shouldPass = scanText(
     "scripts/apply-example.mjs",
-    `
-await upsertSectionEntityRelations(supabase, rows, "seed links")
-insert into public.entity_relations (source_table) values ('section_entities')
-`,
+    'await upsertSectionEntityRelations(supabase, rows, "seed links")',
   )
 
-  if (shouldFail.length !== 1 || sqlShouldFail.length !== 1 || shouldPass.length !== 0) {
+  if (
+    shouldFail.length !== 1 ||
+    sqlShouldFail.length !== 1 ||
+    sourceMarkerShouldFail.length !== 1 ||
+    shouldPass.length !== 0
+  ) {
     throw new Error("Self-test failed for graph-primary seed write guard.")
   }
 }
@@ -115,7 +137,7 @@ if (violations.length) {
     )
   }
   console.error(
-    "\nUse scripts/content-graph-write-helpers.mjs so writes target entity_relations and database triggers maintain the legacy mirrors.",
+    "\nUse scripts/content-graph-write-helpers.mjs so writes target entity_relations without legacy relation source markers.",
   )
   process.exitCode = 1
 }

--- a/scripts/qa-legacy-mirror-readiness.mjs
+++ b/scripts/qa-legacy-mirror-readiness.mjs
@@ -57,16 +57,16 @@ const removalStages = {
   },
   5: {
     stage: "Legacy table removal",
-    goal: "Drop the legacy mirror tables after all blockers are gone.",
+    goal: "Drop the legacy mirror tables and remaining legacy bridge definitions after all blockers are gone.",
   },
 }
 
 const categories = {
-  active_bridge_migration: {
-    label: "Active bridge migrations",
-    stage: 2,
+  legacy_mirror_compatibility_migration: {
+    label: "Legacy mirror compatibility migrations",
+    stage: 5,
     removalBlocker: true,
-    note: "Drop/supersede graph<->legacy bridge triggers before removing mirrors.",
+    note: "Legacy mirror compatibility migrations remain until the mirror tables are removed.",
   },
   bridge_compatibility_marker: {
     label: "Bridge compatibility markers",
@@ -196,7 +196,7 @@ function classify(file, line = "") {
     file === "supabase/migrations/20260506000042_entity_graph_bridge.sql" ||
     file === "supabase/migrations/20260508000043_graph_primary_composition_writes.sql"
   ) {
-    return "active_bridge_migration"
+    return "legacy_mirror_compatibility_migration"
   }
 
   if (bridgeCompatibilityMarkerFiles.has(file)) {

--- a/supabase/migrations/20260509000046_retire_graph_to_legacy_bridge_writes.sql
+++ b/supabase/migrations/20260509000046_retire_graph_to_legacy_bridge_writes.sql
@@ -1,0 +1,25 @@
+-- Bremen - retire graph-to-legacy composition bridge writes.
+--
+-- Runtime composition writes now target entity_relations directly without
+-- legacy mirror source markers. Keep the installed bridge triggers deploy-order
+-- compatible, but replace their function with a no-op so graph writes no longer
+-- maintain legacy mirror rows.
+--
+-- This migration preserves data, RLS, trigger definitions, and mirror tables.
+
+create or replace function private.sync_entity_relation_source_bridge()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, private
+as $$
+begin
+  if tg_op = 'DELETE' then
+    return old;
+  end if;
+
+  return new;
+end;
+$$;
+
+revoke all on function private.sync_entity_relation_source_bridge() from public;


### PR DESCRIPTION
## Summary
- remove legacy page_sections / section_entities source_table markers from runtime and seed composition writes
- add a review-only migration that replaces the graph-to-legacy source bridge function with a no-op instead of dropping triggers
- tighten QA so source_table marker regressions fail in runtime and seed write paths
- move readiness Stage 2 to zero blockers and classify remaining legacy bridge references as legacy-table-removal work

## Verification
- pnpm run qa:legacy-mirror-readiness
- pnpm run qa:graph-primary-seed-writes
- pnpm run qa:cms-legacy-bridge-boundary
- pnpm run qa:content-graph
- pnpm run qa:cms-db-first-loaders
- pnpm run qa:cms-schema-registry
- pnpm run qa:cms-native-controls
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm run build
- node --check scripts/generate-scraped-content-migration.mjs
- node --check scripts/generate-instagram-feed-migration.mjs
- git diff --cached --check

## Supabase
- Adds migration: supabase/migrations/20260509000046_retire_graph_to_legacy_bridge_writes.sql
- It preserves data, RLS, trigger definitions, and mirror tables.
- It has not been applied to production Supabase in this PR session.
- MCP inspection shows production currently has pending migrations after 20260508000044, including the previous index migration and this new bridge retirement migration.

Closes #117