### PR TITLE
Retire legacy mirror operational dependencies

### DIFF
--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -4,7 +4,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="skeleton"
-      className={cn('bg-accent animate-pulse rounded-md', className)}
+      className={cn('bg-muted/80 animate-pulse rounded-md', className)}
       {...props}
     />
   )

--- a/docs/legacy-mirror-removal-plan.md
+++ b/docs/legacy-mirror-removal-plan.md
@@ -22,13 +22,14 @@ Completed:
 - Routine CMS composition writes target `entity_relations`.
 - Graph-to-legacy mirror writes are retired by replacing the source bridge
   function with a no-op.
+- Legacy mirror audit writes, admin write policies, and legacy-only query
+  indexes are superseded by the Stage 3 operational cleanup migration.
 - Legacy mirror compatibility triggers remain for the legacy tables themselves.
 - Parity QA still compares graph rows against legacy mirror rows.
 
 Remaining blocker classes:
 
 - Legacy mirror compatibility migrations still mention the legacy tables.
-- Audit, index, RLS helper, and schema compatibility migrations still mention the legacy tables.
 - Parity QA still depends on the legacy mirrors as the comparison target.
 
 ## Stage 1: Canonical Graph Identity

--- a/scripts/qa-legacy-mirror-readiness.mjs
+++ b/scripts/qa-legacy-mirror-readiness.mjs
@@ -180,21 +180,15 @@ function classify(file, line = "") {
     return "schema_registry_compatibility"
   }
 
-  if (file === "supabase/migrations/20260505000039_cms_audit_events.sql") {
-    return "active_audit_migration"
-  }
-
   if (
     file === "supabase/migrations/20260430000034_private_rls_helpers.sql" ||
-    file === "supabase/migrations/20260506000041_cms_query_indexes.sql"
-  ) {
-    return "active_index_policy_migration"
-  }
-
-  if (
+    file === "supabase/migrations/20260505000039_cms_audit_events.sql" ||
     file === "supabase/migrations/20260506000040_entity_schema_registry.sql" ||
+    file === "supabase/migrations/20260506000041_cms_query_indexes.sql" ||
     file === "supabase/migrations/20260506000042_entity_graph_bridge.sql" ||
-    file === "supabase/migrations/20260508000043_graph_primary_composition_writes.sql"
+    file === "supabase/migrations/20260508000043_graph_primary_composition_writes.sql" ||
+    file ===
+      "supabase/migrations/20260509000047_retire_legacy_mirror_operational_dependencies.sql"
   ) {
     return "legacy_mirror_compatibility_migration"
   }

--- a/supabase/migrations/20260509000047_retire_legacy_mirror_operational_dependencies.sql
+++ b/supabase/migrations/20260509000047_retire_legacy_mirror_operational_dependencies.sql
@@ -1,0 +1,101 @@
+-- Bremen - retire legacy mirror operational dependencies.
+--
+-- Stage 3 keeps page_sections / section_entities available for transition
+-- parity checks, but stops treating them as active CMS operation targets.
+-- This migration avoids table, trigger, policy, and function drops.
+
+create or replace function private.record_cms_audit_event()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, auth, private
+as $$
+declare
+  before_snapshot jsonb;
+  after_snapshot jsonb;
+  audit_action text;
+  row_id uuid;
+begin
+  if tg_table_name in ('page_sections', 'section_entities') then
+    if tg_op = 'DELETE' then
+      return old;
+    end if;
+
+    return new;
+  end if;
+
+  if tg_op = 'INSERT' then
+    audit_action := 'insert';
+    before_snapshot := null;
+    after_snapshot := to_jsonb(new);
+    row_id := new.id;
+  elsif tg_op = 'UPDATE' then
+    audit_action := 'update';
+    before_snapshot := to_jsonb(old);
+    after_snapshot := to_jsonb(new);
+    row_id := new.id;
+  elsif tg_op = 'DELETE' then
+    audit_action := 'delete';
+    before_snapshot := to_jsonb(old);
+    after_snapshot := null;
+    row_id := old.id;
+  else
+    return null;
+  end if;
+
+  insert into public.cms_audit_events (
+    actor_member_id,
+    action,
+    target_table,
+    target_id,
+    before_data,
+    after_data,
+    changed_keys
+  )
+  values (
+    private.current_member_id(),
+    audit_action,
+    tg_table_name,
+    row_id,
+    before_snapshot,
+    after_snapshot,
+    private.cms_audit_changed_keys(before_snapshot, after_snapshot)
+  );
+
+  if tg_op = 'DELETE' then
+    return old;
+  end if;
+
+  return new;
+end;
+$$;
+
+revoke all on function private.record_cms_audit_event() from public;
+
+alter table public.cms_audit_events
+  drop constraint if exists cms_audit_events_target_table_check;
+
+alter table public.cms_audit_events
+  add constraint cms_audit_events_target_table_check
+  check (
+    target_table in (
+      'pages',
+      'sections',
+      'entities',
+      'entity_schemas',
+      'entity_relations'
+    )
+  ) not valid;
+
+alter policy "page_sections_admin_write"
+  on public.page_sections
+  using (false)
+  with check (false);
+
+alter policy "section_entities_admin_write"
+  on public.section_entities
+  using (false)
+  with check (false);
+
+drop index if exists public.page_sections_section_sort_idx;
+drop index if exists public.section_entities_entity_slot_sort_idx;


### PR DESCRIPTION
## Summary
- add a Stage 3 migration that stops legacy mirror audit writes, locks legacy mirror admin-write policies with false checks, and removes legacy-only query indexes
- update readiness classification so Stage 3 reports zero active audit/policy/index blockers
- document Stage 3 cleanup in the legacy mirror removal plan
- move loading skeletons from red accent pulse to muted theme color

## Verification
- pnpm run qa:legacy-mirror-readiness
- pnpm run qa:content-graph
- pnpm run qa:cms-schema-registry
- pnpm run qa:cms-db-first-loaders
- pnpm run qa:graph-primary-seed-writes
- pnpm run qa:cms-legacy-bridge-boundary
- pnpm run qa:cms-native-controls
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm run build
- node --check scripts/qa-legacy-mirror-readiness.mjs
- git diff --cached --check

## Supabase
- Adds migration: supabase/migrations/20260509000047_retire_legacy_mirror_operational_dependencies.sql
- Migration intentionally does not drop tables, triggers, policies, or functions.
- It uses a no-op branch in the audit function, a NOT VALID audit target check, false admin-write policies for legacy mirrors, and drops two legacy-only indexes.
- Not applied to production Supabase in this PR session.

Closes #119