### PR TITLE
Draft legacy mirror table removal migration

### DIFF
--- a/docs/legacy-mirror-stage-5-runbook.md
+++ b/docs/legacy-mirror-stage-5-runbook.md
@@ -150,6 +150,15 @@ Recommended order:
 7. Regenerate `lib/supabase/types.ts`.
 8. Run Supabase security and performance advisors.
 
+Reviewed draft migration:
+
+- `supabase/migrations/20260509000048_drop_legacy_mirror_tables.sql`
+
+Do not apply this migration to production until the maintainer gives explicit
+production-write approval in the active session. The migration is intentionally
+plain `drop table if exists` without `cascade`; if it fails, stop and inspect
+the dependency instead of broadening the destructive operation.
+
 ## Rollback Plan
 
 Preferred rollback is Supabase point-in-time recovery if the destructive

--- a/scripts/qa-legacy-mirror-readiness.mjs
+++ b/scripts/qa-legacy-mirror-readiness.mjs
@@ -71,6 +71,12 @@ const categories = {
     removalBlocker: true,
     note: "Legacy mirror compatibility migrations remain until the mirror tables are removed.",
   },
+  legacy_mirror_removal_migration: {
+    label: "Legacy mirror removal migration",
+    stage: null,
+    removalBlocker: false,
+    note: "The reviewed Stage 5 migration intentionally names the legacy mirrors it removes.",
+  },
   bridge_compatibility_marker: {
     label: "Bridge compatibility markers",
     stage: 2,
@@ -192,6 +198,10 @@ function classify(file, line = "") {
     return "legacy_mirror_compatibility_migration"
   }
 
+  if (file === "supabase/migrations/20260509000048_drop_legacy_mirror_tables.sql") {
+    return "legacy_mirror_removal_migration"
+  }
+
   if (bridgeCompatibilityMarkerFiles.has(file)) {
     if (
       /\.eq\(\s*["'`]source_table["'`]/.test(line) ||
@@ -239,6 +249,7 @@ function runSelfTest() {
     classify("lib/cms/content.ts", '.eq("source_table", "page_sections")'),
     classify("scripts/generate-instagram-feed-migration.mjs", "'section_entities'"),
     classify("supabase/migrations/20260430000034_private_rls_helpers.sql", "section_entities"),
+    classify("supabase/migrations/20260509000048_drop_legacy_mirror_tables.sql", "drop table public.section_entities"),
     classify("supabase/migrations/20260429000009_scraped_content_seed.sql", "page_sections"),
     classify("docs/content-graph.md", "`section_entities`"),
   ]

--- a/supabase/migrations/20260509000048_drop_legacy_mirror_tables.sql
+++ b/supabase/migrations/20260509000048_drop_legacy_mirror_tables.sql
@@ -1,0 +1,93 @@
+-- Bremen - drop legacy composition mirror tables.
+--
+-- DESTRUCTIVE: apply only after Stage 5 approval and a fresh
+-- qa:legacy-mirror-stage5-preflight + Supabase catalog preflight.
+-- The canonical runtime composition source is public.entity_relations.
+-- Historical cms_audit_events rows are preserved as text audit history.
+
+drop trigger if exists entity_relations_source_bridge_insert on public.entity_relations;
+drop trigger if exists entity_relations_source_bridge_update on public.entity_relations;
+drop trigger if exists entity_relations_source_bridge_delete on public.entity_relations;
+
+do $$
+begin
+  if to_regclass('public.page_sections') is not null then
+    execute 'drop trigger if exists page_sections_cms_audit on public.page_sections';
+    execute 'drop trigger if exists page_sections_entity_relation_bridge on public.page_sections';
+    execute 'drop trigger if exists page_sections_set_updated_at on public.page_sections';
+  end if;
+
+  if to_regclass('public.section_entities') is not null then
+    execute 'drop trigger if exists section_entities_cms_audit on public.section_entities';
+    execute 'drop trigger if exists section_entities_entity_relation_bridge on public.section_entities';
+    execute 'drop trigger if exists section_entities_set_updated_at on public.section_entities';
+  end if;
+end;
+$$;
+
+drop function if exists private.sync_entity_relation_source_bridge();
+drop function if exists private.sync_page_section_relation_bridge();
+drop function if exists private.sync_section_entity_relation_bridge();
+
+create or replace function private.record_cms_audit_event()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, auth, private
+as $$
+declare
+  before_snapshot jsonb;
+  after_snapshot jsonb;
+  audit_action text;
+  row_id uuid;
+begin
+  if tg_op = 'INSERT' then
+    audit_action := 'insert';
+    before_snapshot := null;
+    after_snapshot := to_jsonb(new);
+    row_id := new.id;
+  elsif tg_op = 'UPDATE' then
+    audit_action := 'update';
+    before_snapshot := to_jsonb(old);
+    after_snapshot := to_jsonb(new);
+    row_id := new.id;
+  elsif tg_op = 'DELETE' then
+    audit_action := 'delete';
+    before_snapshot := to_jsonb(old);
+    after_snapshot := null;
+    row_id := old.id;
+  else
+    return null;
+  end if;
+
+  insert into public.cms_audit_events (
+    actor_member_id,
+    action,
+    target_table,
+    target_id,
+    before_data,
+    after_data,
+    changed_keys
+  )
+  values (
+    private.current_member_id(),
+    audit_action,
+    tg_table_name,
+    row_id,
+    before_snapshot,
+    after_snapshot,
+    private.cms_audit_changed_keys(before_snapshot, after_snapshot)
+  );
+
+  if tg_op = 'DELETE' then
+    return old;
+  end if;
+
+  return new;
+end;
+$$;
+
+revoke all on function private.record_cms_audit_event() from public;
+
+drop table if exists public.section_entities;
+drop table if exists public.page_sections;


### PR DESCRIPTION
## Summary
- Add the reviewed Stage 5 migration draft to remove page_sections and section_entities.
- Drop obsolete bridge triggers/functions before dropping the tables.
- Keep graph rows and historical cms_audit_events intact.
- Classify the removal migration so readiness does not treat the reviewed drop artifact as an unclassified legacy reference.

## Safety notes
- This PR does not apply the migration to production.
- The migration intentionally avoids CASCADE.
- Production apply still requires fresh qa:legacy-mirror-stage5-preflight, Supabase catalog preflight, reading SQL from disk, and explicit maintainer approval.

## Verification
- rg stop-list check for cascade/truncate/delete/RLS/storage
- pnpm run qa:legacy-mirror-stage5-preflight
- pnpm run qa:legacy-mirror-readiness
- node --check scripts/qa-legacy-mirror-readiness.mjs
- pnpm run qa:content-graph
- pnpm run qa:cms-schema-registry
- pnpm run qa:cms-db-first-loaders
- pnpm run qa:graph-primary-seed-writes
- pnpm run qa:cms-legacy-bridge-boundary
- pnpm run qa:cms-native-controls
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm run build
- git diff --check
- git diff --cached --check

Closes #126