### PR TITLE
Sync Supabase types after legacy mirror drop

### DIFF
--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -338,51 +338,6 @@ export type Database = {
           },
         ]
       }
-      page_sections: {
-        Row: {
-          created_at: string
-          id: string
-          page_id: string
-          props: Json
-          section_id: string
-          sort_order: number
-          updated_at: string
-        }
-        Insert: {
-          created_at?: string
-          id?: string
-          page_id: string
-          props?: Json
-          section_id: string
-          sort_order?: number
-          updated_at?: string
-        }
-        Update: {
-          created_at?: string
-          id?: string
-          page_id?: string
-          props?: Json
-          section_id?: string
-          sort_order?: number
-          updated_at?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "page_sections_page_id_fkey"
-            columns: ["page_id"]
-            isOneToOne: false
-            referencedRelation: "pages"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "page_sections_section_id_fkey"
-            columns: ["section_id"]
-            isOneToOne: false
-            referencedRelation: "sections"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
       pages: {
         Row: {
           created_at: string
@@ -524,57 +479,6 @@ export type Database = {
             columns: ["performance_id"]
             isOneToOne: false
             referencedRelation: "performances"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      section_entities: {
-        Row: {
-          created_at: string
-          entity_id: string
-          id: string
-          props: Json
-          relation_type: string
-          section_id: string
-          slot: string
-          sort_order: number
-          updated_at: string
-        }
-        Insert: {
-          created_at?: string
-          entity_id: string
-          id?: string
-          props?: Json
-          relation_type?: string
-          section_id: string
-          slot?: string
-          sort_order?: number
-          updated_at?: string
-        }
-        Update: {
-          created_at?: string
-          entity_id?: string
-          id?: string
-          props?: Json
-          relation_type?: string
-          section_id?: string
-          slot?: string
-          sort_order?: number
-          updated_at?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "section_entities_entity_id_fkey"
-            columns: ["entity_id"]
-            isOneToOne: false
-            referencedRelation: "entities"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "section_entities_section_id_fkey"
-            columns: ["section_id"]
-            isOneToOne: false
-            referencedRelation: "sections"
             referencedColumns: ["id"]
           },
         ]

--- a/scripts/qa-legacy-mirror-readiness.mjs
+++ b/scripts/qa-legacy-mirror-readiness.mjs
@@ -40,6 +40,9 @@ const bridgeCompatibilityMarkerFiles = new Set([
   "scripts/generate-instagram-feed-migration.mjs",
   "scripts/generate-scraped-content-migration.mjs",
 ])
+const stage5RemovalMigration =
+  "supabase/migrations/20260509000048_drop_legacy_mirror_tables.sql"
+const stage5RemovalCommitted = existsSync(path.join(repoRoot, stage5RemovalMigration))
 
 const removalStages = {
   1: {
@@ -66,10 +69,14 @@ const removalStages = {
 
 const categories = {
   legacy_mirror_compatibility_migration: {
-    label: "Legacy mirror compatibility migrations",
-    stage: 5,
-    removalBlocker: true,
-    note: "Legacy mirror compatibility migrations remain until the mirror tables are removed.",
+    label: stage5RemovalCommitted
+      ? "Legacy mirror compatibility migration history"
+      : "Legacy mirror compatibility migrations",
+    stage: stage5RemovalCommitted ? null : 5,
+    removalBlocker: !stage5RemovalCommitted,
+    note: stage5RemovalCommitted
+      ? "Compatibility migration references are retained so fresh database replays still work."
+      : "Legacy mirror compatibility migrations remain until the mirror tables are removed.",
   },
   legacy_mirror_removal_migration: {
     label: "Legacy mirror removal migration",
@@ -198,7 +205,7 @@ function classify(file, line = "") {
     return "legacy_mirror_compatibility_migration"
   }
 
-  if (file === "supabase/migrations/20260509000048_drop_legacy_mirror_tables.sql") {
+  if (file === stage5RemovalMigration) {
     return "legacy_mirror_removal_migration"
   }
 
@@ -317,8 +324,16 @@ const blockerRows = Object.entries(categories)
     nextStep: metadata.note,
   }))
 
-console.log("\nRemoval blockers to clear before dropping legacy mirrors")
-console.table(blockerRows)
+console.log(
+  stage5RemovalCommitted
+    ? "\nActive legacy mirror blockers after Stage 5 removal"
+    : "\nRemoval blockers to clear before dropping legacy mirrors",
+)
+if (blockerRows.length) {
+  console.table(blockerRows)
+} else {
+  console.log("No active blocker categories remain.")
+}
 
 if (failBeforeStage !== null) {
   if (!Number.isInteger(failBeforeStage) || failBeforeStage < 1) {


### PR DESCRIPTION
## Summary
- Remove dropped `page_sections` and `section_entities` table types from generated Supabase types.
- Update the legacy mirror readiness guard so Stage 5 compatibility migrations are treated as replay history after the drop migration exists.

## Verification
- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run qa:content-graph`
- `pnpm run qa:cms-schema-registry`
- `pnpm run qa:cms-db-first-loaders`
- `pnpm run qa:graph-primary-seed-writes`
- `pnpm run qa:cms-legacy-bridge-boundary`
- `pnpm run qa:cms-native-controls`
- `pnpm run qa:legacy-mirror-readiness`
- `pnpm run qa:legacy-mirror-stage5-preflight`

Closes #128