### PR TITLE
Add indexes for Supabase FK advisors

### DIFF
--- a/supabase/migrations/20260509000049_add_fk_advisor_indexes.sql
+++ b/supabase/migrations/20260509000049_add_fk_advisor_indexes.sql
@@ -1,0 +1,14 @@
+create index if not exists entity_relations_created_by_member_id_idx
+  on public.entity_relations (created_by_member_id);
+
+create index if not exists members_approved_by_idx
+  on public.members (approved_by);
+
+create index if not exists pages_owner_member_id_idx
+  on public.pages (owner_member_id);
+
+create index if not exists photos_performance_id_idx
+  on public.photos (performance_id);
+
+create index if not exists sections_owner_member_id_idx
+  on public.sections (owner_member_id);


### PR DESCRIPTION
## Summary
- Add non-destructive FK indexes for the five columns reported by Supabase performance advisors.
- Keep this separate from RLS policy consolidation and unused-index cleanup.

## Verification
- `rg` stop-list check on migration SQL
- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run qa:content-graph`
- `git diff --check`

Closes #130