### PR TITLE
Prepare guarded legacy media table removal

### DIFF
--- a/docs/content-graph.md
+++ b/docs/content-graph.md
@@ -1,16 +1,6 @@
 # Content Graph
 
-The site is currently built around a CMS-friendly graph:
-
-```txt
-pages
-  -> page_sections
-    -> sections
-      -> section_entities
-        -> entities
-```
-
-The target model is a smaller entity graph:
+The site is currently built around a compact entity graph:
 
 ```txt
 entity_schemas
@@ -19,33 +9,32 @@ entity_schemas
       -> entities
 ```
 
-`pages`, `sections`, `page_sections`, and `section_entities` remain in the
-database during the transition. New CMS architecture work should avoid deepening
-those special tables unless the change is explicitly about preserving the
-bridge.
+`pages` and `sections` remain domain tables because they are routable and
+renderer-facing records. Ordered page/section composition is stored in
+`entity_relations`; the legacy `page_sections` and `section_entities` mirror
+tables have been removed.
+
+The older media domain tables `performances`, `videos`, and `photos` are no
+longer runtime content sources. They remain only until the legacy media removal
+runbook proves every row is represented by `entities` and `entity_relations`.
 
 ## Entity Graph Bridge
 
-Migration `20260506000042_entity_graph_bridge.sql` starts the safe transition by
-mirroring page and section records into the generic graph without deleting the
-legacy tables:
+Migration `20260506000042_entity_graph_bridge.sql` started the safe transition
+by mirroring page and section records into the generic graph:
 
 - `pages` rows get shadow `entities` rows with `entity_type = 'page'`.
 - `sections` rows get shadow `entities` rows with `entity_type = 'section'`.
-- `page_sections` rows get shadow `entity_relations` rows from page entity to
+- Page-to-section composition uses `entity_relations` rows from page entity to
   section entity.
-- `section_entities` rows get shadow `entity_relations` rows from section entity
-  to content entity.
+- Section-to-content composition uses `entity_relations` rows from section
+  entity to content entity.
 
 The bridge uses `source_table` and `source_id` columns on `entities` and
-`entity_relations` so each shadow record can be traced back to the legacy row.
-Sync triggers keep the shadow graph updated while the app still writes through
-the current CMS screens.
+`entity_relations` so older mirrored rows can still be traced back to their
+source. New runtime composition writes do not need a legacy `source_id`.
 
-The bridge is now the primary runtime composition path. The legacy composition
-tables remain compatibility mirrors. Do not remove `pages`, `sections`,
-`page_sections`, or `section_entities` until all forms, audits, migrations, and
-generated types have moved to the entity graph.
+The bridge is now the primary runtime composition path.
 
 Current PONIX contract:
 
@@ -58,9 +47,7 @@ Current PONIX contract:
 - Existing mirrored rows may still expose a legacy `source_id`; new runtime
   composition writes use `entity_relations.id` and do not require one.
 - Routine CMS composition writes target `entity_relations` without legacy
-  relation `source_table` markers. The graph-to-legacy source bridge is retired
-  as a no-op migration; legacy tables remain only for transition compatibility
-  until the final destructive removal stage.
+  relation `source_table` markers.
 - Maintenance apply scripts and generated seed migrations that refresh scraped
   or Instagram content should also write section placement through
   `entity_relations`, not directly through `page_sections` or
@@ -72,13 +59,12 @@ Current PONIX contract:
   unpublished section/entity references.
 - Runtime CMS code must not read `page_sections` or `section_entities`.
   Use `pnpm run qa:cms-legacy-bridge-boundary` after CMS loader changes.
-- Use `pnpm run qa:legacy-mirror-readiness` before any legacy mirror removal
-  work. The command classifies every remaining `page_sections` /
-  `section_entities` reference and fails only on unclassified references.
-  Treat reported bridge triggers, audit/RLS/index references, `source_table`
-  markers, and schema registry compatibility entries as the
-  removal blocker list. The staged cleanup sequence lives in
-  `docs/legacy-mirror-removal-plan.md`.
+- Use `pnpm run qa:legacy-mirror-readiness` when touching historical mirror
+  references. The command now reports no active blockers after Stage 5 removal.
+- Use `pnpm run qa:legacy-media-table-readiness` before any
+  `performances`/`videos`/`photos` removal work. It verifies runtime code does
+  not read those tables and that visible legacy media rows are represented in
+  the entity graph.
 - `pnpm run qa:graph-primary-seed-writes` checks that seed apply scripts and
   migration generators do not reintroduce direct legacy composition writes.
 
@@ -89,11 +75,10 @@ Current PONIX contract:
 | `entity_schemas` | DB-backed schema registry for page, section, entity, and relation records. This is the long-term source for CMS form metadata and validation. |
 | `pages` | Routable page records such as `home`, `performances`, `videos`, `photos`, `history`, and `site`. |
 | `sections` | Renderer blocks with `section_type`, copy, and renderer props. |
-| `page_sections` | Ordered section placement on pages. |
 | `entities` | Reusable content units such as videos, photos, stats, posts, history milestones, activities, nav items, and social links. |
-| `section_entities` | Ordered links between a section and the entities displayed in that section. |
-| `entity_relations` | Domain relations such as performance to recording, performance to photo, performance to post. |
+| `entity_relations` | Ordered page-to-section, section-to-entity, and domain relations such as performance to recording/photo/post. |
 | `members` | Domain-specific member/auth/profile table. This intentionally remains separate from generic entities. |
+| `performances`, `videos`, `photos` | Legacy media domain tables. Runtime content has moved to `entities`; remove these only through the guarded legacy media table workflow. |
 
 ## Renderer Contract
 
@@ -132,7 +117,6 @@ Use the registry contract for:
 
 - `sections.props`
 - `entities.data`
-- `section_entities.props`
 - `entity_relations.props`
 
 Each registry entry defines the schema key, field source, field type,

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "qa:cms-legacy-bridge-boundary": "node scripts/qa-cms-legacy-bridge-boundary.mjs",
     "qa:cms-native-controls": "node scripts/qa-cms-native-controls.mjs",
     "qa:graph-primary-seed-writes": "node scripts/qa-graph-primary-seed-writes.mjs",
+    "qa:legacy-media-table-readiness": "node scripts/qa-legacy-media-table-readiness.mjs",
     "qa:legacy-mirror-readiness": "node scripts/qa-legacy-mirror-readiness.mjs",
     "qa:legacy-mirror-stage5-preflight": "node scripts/qa-legacy-mirror-readiness.mjs --fail-before-stage 5"
   },

--- a/scripts/qa-legacy-media-table-readiness.mjs
+++ b/scripts/qa-legacy-media-table-readiness.mjs
@@ -1,0 +1,326 @@
+#!/usr/bin/env node
+
+import { createClient } from "@supabase/supabase-js"
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+} from "node:fs"
+import path from "node:path"
+
+const repoRoot = process.cwd()
+const envPath = process.argv.includes("--env")
+  ? process.argv[process.argv.indexOf("--env") + 1]
+  : ".env.local"
+const runtimeScanRoots = ["app", "lib"]
+const ignoredFiles = new Set(["lib/supabase/types.ts"])
+const codeExtensions = new Set([".mjs", ".ts", ".tsx", ".js", ".jsx"])
+const legacyTables = ["performances", "videos", "photos"]
+const runtimeLegacyReadPattern =
+  /\.from\(\s*["'`](performances|videos|photos)["'`]\s*\)/g
+const legacyMediaRemovalMigration =
+  "supabase/migrations/20260509000050_drop_legacy_media_tables.sql"
+
+function loadEnv(filePath) {
+  let text = ""
+  try {
+    text = readFileSync(filePath, "utf8")
+  } catch {
+    return
+  }
+
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith("#")) continue
+
+    const index = trimmed.indexOf("=")
+    if (index === -1) continue
+
+    const key = trimmed.slice(0, index).trim()
+    const rawValue = trimmed.slice(index + 1).trim()
+    process.env[key] ??= rawValue.replace(/^['"]|['"]$/g, "")
+  }
+}
+
+function repoRelative(filePath) {
+  return path.relative(repoRoot, filePath).split(path.sep).join("/")
+}
+
+function listFiles(dir) {
+  if (!existsSync(dir)) return []
+
+  return readdirSync(dir).flatMap((entry) => {
+    const absolute = path.join(dir, entry)
+    const relative = repoRelative(absolute)
+    const stat = statSync(absolute)
+
+    if (stat.isDirectory()) {
+      if (entry === "node_modules" || entry === ".next") return []
+      return listFiles(absolute)
+    }
+
+    if (ignoredFiles.has(relative)) return []
+    return codeExtensions.has(path.extname(entry)) ? [absolute] : []
+  })
+}
+
+function findRuntimeLegacyReads() {
+  const files = runtimeScanRoots.flatMap((root) =>
+    listFiles(path.join(repoRoot, root)),
+  )
+  const violations = []
+
+  for (const filePath of files) {
+    const file = repoRelative(filePath)
+    const source = readFileSync(filePath, "utf8")
+    source.split(/\r?\n/).forEach((line, index) => {
+      runtimeLegacyReadPattern.lastIndex = 0
+      const match = runtimeLegacyReadPattern.exec(line)
+      if (!match) return
+
+      violations.push({
+        file,
+        line: index + 1,
+        table: match[1],
+        text: line.trim(),
+      })
+    })
+  }
+
+  return {
+    scannedFiles: files.length,
+    violations,
+  }
+}
+
+function requireOk(result, label) {
+  if (result.error) {
+    throw new Error(`${label}: ${result.error.message}`)
+  }
+
+  return result.data ?? []
+}
+
+function dataValue(entity, key) {
+  const data = entity.data
+  if (!data || typeof data !== "object" || Array.isArray(data)) return null
+  const value = data[key]
+  return typeof value === "string" && value ? value : null
+}
+
+function indexBy(values, key) {
+  const index = new Map()
+  for (const value of values) {
+    const id = key(value)
+    if (!id) continue
+    const existing = index.get(id) ?? []
+    existing.push(value)
+    index.set(id, existing)
+  }
+  return index
+}
+
+async function loadLegacyRows(supabase) {
+  const [performances, videos, photos] = await Promise.all([
+    supabase
+      .from("performances")
+      .select("id, slug, title, event_date, published")
+      .order("slug", { ascending: true }),
+    supabase
+      .from("videos")
+      .select("id, youtube_id, title, performance_id, published")
+      .order("youtube_id", { ascending: true }),
+    supabase
+      .from("photos")
+      .select("id, storage_path, title, performance_id, published")
+      .order("storage_path", { ascending: true }),
+  ])
+
+  return {
+    performances: requireOk(performances, "legacy performances"),
+    videos: requireOk(videos, "legacy videos"),
+    photos: requireOk(photos, "legacy photos"),
+  }
+}
+
+async function loadGraphMediaEntities(supabase, legacyRows) {
+  const [performances, videos, photos] = await Promise.all([
+    supabase
+      .from("entities")
+      .select("id, entity_type, slug, title, published")
+      .eq("entity_type", "performance"),
+    supabase
+      .from("entities")
+      .select("id, entity_type, slug, title, data, published")
+      .eq("entity_type", "video"),
+    supabase
+      .from("entities")
+      .select(
+        legacyRows.photos.length
+          ? "id, entity_type, slug, title, data, published"
+          : "id, entity_type, slug, title, published",
+      )
+      .eq("entity_type", "photo"),
+  ])
+
+  return {
+    performances: requireOk(performances, "performance entities"),
+    videos: requireOk(videos, "video entities"),
+    photos: requireOk(photos, "photo entities"),
+  }
+}
+
+function compareLegacyMedia({ legacyRows, entities }) {
+  const performanceEntitiesBySlug = indexBy(
+    entities.performances,
+    (entity) => entity.slug,
+  )
+  const videoEntitiesByYoutubeId = indexBy(entities.videos, (entity) =>
+    dataValue(entity, "youtube_id"),
+  )
+  const photoEntitiesByStoragePath = indexBy(entities.photos, (entity) =>
+    dataValue(entity, "storage_path"),
+  )
+
+  const missingPerformances = legacyRows.performances.filter(
+    (row) => !performanceEntitiesBySlug.has(row.slug),
+  )
+  const missingVideos = legacyRows.videos.filter(
+    (row) => !videoEntitiesByYoutubeId.has(row.youtube_id),
+  )
+  const missingPhotos = legacyRows.photos.filter(
+    (row) => !photoEntitiesByStoragePath.has(row.storage_path),
+  )
+
+  return [
+    {
+      table: "performances",
+      legacyRows: legacyRows.performances.length,
+      entityRows: entities.performances.length,
+      matchedLegacyRows: legacyRows.performances.length - missingPerformances.length,
+      missingLegacyRows: missingPerformances.length,
+      key: "slug",
+    },
+    {
+      table: "videos",
+      legacyRows: legacyRows.videos.length,
+      entityRows: entities.videos.length,
+      matchedLegacyRows: legacyRows.videos.length - missingVideos.length,
+      missingLegacyRows: missingVideos.length,
+      key: "youtube_id",
+    },
+    {
+      table: "photos",
+      legacyRows: legacyRows.photos.length,
+      entityRows: entities.photos.length,
+      matchedLegacyRows: legacyRows.photos.length - missingPhotos.length,
+      missingLegacyRows: missingPhotos.length,
+      key: "storage_path",
+    },
+  ]
+}
+
+function inspectRemovalMigration() {
+  const migrationPath = path.join(repoRoot, legacyMediaRemovalMigration)
+  if (!existsSync(migrationPath)) {
+    return {
+      exists: false,
+      dropTableCount: 0,
+      hasCascade: false,
+      hasBroadDeleteOrUpdate: false,
+    }
+  }
+
+  const sql = readFileSync(migrationPath, "utf8")
+  const droppedTables = legacyTables.filter((table) =>
+    new RegExp(`drop\\s+table\\s+if\\s+exists\\s+public\\.${table}\\b`, "i").test(sql),
+  )
+
+  return {
+    exists: true,
+    dropTableCount: droppedTables.length,
+    hasCascade: /\bcascade\b/i.test(sql),
+    hasBroadDeleteOrUpdate: /\b(delete\s+from|update\s+\S+\s+set)\b/i.test(sql),
+  }
+}
+
+async function main() {
+  loadEnv(envPath)
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new Error("NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY are required")
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+    auth: { persistSession: false },
+  })
+  const legacyRows = await loadLegacyRows(supabase)
+  const entities = await loadGraphMediaEntities(supabase, legacyRows)
+  const parityRows = compareLegacyMedia({ legacyRows, entities })
+  const runtimeScan = findRuntimeLegacyReads()
+  const migration = inspectRemovalMigration()
+
+  console.log("Legacy media table removal readiness")
+  console.table([
+    {
+      runtimeScannedFiles: runtimeScan.scannedFiles,
+      runtimeViolations: runtimeScan.violations.length,
+      parityFailures: parityRows.reduce(
+        (total, row) => total + row.missingLegacyRows,
+        0,
+      ),
+      migrationExists: migration.exists,
+      migrationDropTables: migration.dropTableCount,
+      migrationHasCascade: migration.hasCascade,
+      migrationHasBroadDeleteOrUpdate: migration.hasBroadDeleteOrUpdate,
+      selfTest: "ok",
+    },
+  ])
+
+  console.log("\nLegacy row parity against entity graph")
+  console.table(parityRows)
+
+  if (runtimeScan.violations.length) {
+    console.error("\nRuntime legacy media table reads:")
+    for (const violation of runtimeScan.violations) {
+      console.error(
+        `- ${violation.file}:${violation.line}: ${violation.text}`,
+      )
+    }
+  }
+
+  const migrationIssues = []
+  if (migration.exists && migration.dropTableCount !== legacyTables.length) {
+    migrationIssues.push("drop migration does not drop all legacy media tables")
+  }
+  if (migration.hasCascade) {
+    migrationIssues.push("drop migration must not use cascade")
+  }
+  if (migration.hasBroadDeleteOrUpdate) {
+    migrationIssues.push("drop migration must not contain broad delete/update")
+  }
+
+  if (migrationIssues.length) {
+    console.error("\nMigration safety issues:")
+    for (const issue of migrationIssues) {
+      console.error(`- ${issue}`)
+    }
+  }
+
+  const parityFailures = parityRows.filter((row) => row.missingLegacyRows > 0)
+  if (
+    runtimeScan.violations.length ||
+    parityFailures.length ||
+    migrationIssues.length
+  ) {
+    process.exitCode = 1
+  }
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/supabase/migrations/20260509000050_drop_legacy_media_tables.sql
+++ b/supabase/migrations/20260509000050_drop_legacy_media_tables.sql
@@ -1,0 +1,14 @@
+-- Bremen - drop legacy media domain tables.
+--
+-- DESTRUCTIVE: apply only after a fresh qa:legacy-media-table-readiness run,
+-- Supabase catalog preflight, and explicit production approval.
+-- Canonical media/archive content now lives in public.entities and
+-- public.entity_relations.
+
+drop table if exists public.photos;
+drop table if exists public.videos;
+drop table if exists public.performances;
+
+drop type if exists public.photo_aspect;
+drop type if exists public.photo_category;
+drop type if exists public.performance_type;


### PR DESCRIPTION
## Summary
- Add `qa:legacy-media-table-readiness` to prove runtime code no longer reads `performances`, `videos`, or `photos`, and that visible legacy rows are represented in `entities`.
- Draft the destructive drop migration for legacy media tables and enum types without cascade.
- Update content graph docs to reflect the current post-mirror-removal architecture.

## Verification
- `pnpm run qa:legacy-media-table-readiness`
- `pnpm run qa:content-graph`
- `pnpm run qa:cms-schema-registry`
- `pnpm run qa:legacy-mirror-readiness`
- `pnpm run qa:cms-db-first-loaders`
- `pnpm run qa:graph-primary-seed-writes`
- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `pnpm run build`
- `node --check scripts/qa-legacy-media-table-readiness.mjs`
- `git diff --check`

## Production note
Do not apply `20260509000050_drop_legacy_media_tables.sql` until a maintainer explicitly approves the destructive production write after fresh QA and catalog preflight.

Closes #132