### PR TITLE
Add password reset flow for member auth

### DIFF
--- a/app/auth/actions.ts
+++ b/app/auth/actions.ts
@@ -21,6 +21,10 @@ const weakPasswordMessage =
 
 const weakSignInPasswordMessage =
   "계정 보호를 위해 비밀번호 변경이 필요합니다. 비밀번호 재설정 후 다시 로그인해 주세요."
+const passwordResetRequestedMessage =
+  "메일함을 확인해 주세요. 계정이 확인되면 비밀번호 재설정 링크가 도착합니다."
+const passwordUpdatedMessage =
+  "비밀번호를 새로 저장했습니다. Sign In으로 다시 들어가 주세요."
 
 function stringField(formData: FormData, key: string) {
   const value = formData.get(key)
@@ -177,6 +181,82 @@ export async function signInAction(formData: FormData) {
   }
 
   redirect(next)
+}
+
+export async function requestPasswordResetAction(formData: FormData) {
+  const email = stringField(formData, "email").toLowerCase()
+
+  if (!email) {
+    redirectWithParams("/forgot-password", {
+      error: "POSTECH 메일을 입력해 주세요.",
+    })
+  }
+
+  if (!isPostechEmail(email)) {
+    redirectWithParams("/forgot-password", {
+      error: "POSTECH 메일(@postech.ac.kr)로만 비밀번호를 재설정할 수 있습니다.",
+    })
+  }
+
+  const headerStore = await headers()
+  const origin = headerStore.get("origin") ?? "http://localhost:3000"
+  const supabase = await createClient()
+  const { error } = await supabase.auth.resetPasswordForEmail(email, {
+    redirectTo: `${origin}/auth/callback?next=/reset-password`,
+  })
+
+  if (error) {
+    redirectWithParams("/forgot-password", {
+      error: "요청을 처리하지 못했습니다. 잠시 후 다시 시도해 주세요.",
+    })
+  }
+
+  redirectWithParams("/forgot-password", {
+    message: passwordResetRequestedMessage,
+  })
+}
+
+export async function updatePasswordAction(formData: FormData) {
+  const password = stringField(formData, "password")
+  const passwordConfirm = stringField(formData, "password_confirm")
+
+  if (password.length < 8) {
+    redirectWithParams("/reset-password", {
+      error: "비밀번호는 8자 이상으로 입력해 주세요.",
+    })
+  }
+
+  if (password !== passwordConfirm) {
+    redirectWithParams("/reset-password", {
+      error: "두 비밀번호가 서로 다릅니다.",
+    })
+  }
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirectWithParams("/forgot-password", {
+      error: "재설정 링크가 만료되었습니다. 다시 요청해 주세요.",
+    })
+  }
+
+  const { error } = await supabase.auth.updateUser({ password })
+
+  if (error) {
+    redirectWithParams("/reset-password", {
+      error: isWeakPasswordError(error)
+        ? weakPasswordMessage
+        : "비밀번호 저장에 실패했습니다. 다시 시도해 주세요.",
+    })
+  }
+
+  await supabase.auth.signOut()
+  redirectWithParams("/login", {
+    message: passwordUpdatedMessage,
+  })
 }
 
 export async function signUpAction(formData: FormData) {

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next"
 import Link from "next/link"
 import { redirect } from "next/navigation"
 
-import { signInAction } from "@/app/auth/actions"
+import { requestPasswordResetAction } from "@/app/auth/actions"
 import { FormSubmitButton } from "@/components/form-submit-button"
 import {
   Card,
@@ -16,11 +16,11 @@ import { Label } from "@/components/ui/label"
 import { createClient } from "@/lib/supabase/server"
 
 export const metadata: Metadata = {
-  title: "Member Room | 브레멘 Bremen",
-  description: "Bremen member room",
+  title: "Reset Password | 브레멘 Bremen",
+  description: "Bremen member password reset",
 }
 
-type LoginPageProps = {
+type ForgotPasswordPageProps = {
   searchParams?: Promise<Record<string, string | string[] | undefined>>
 }
 
@@ -28,11 +28,12 @@ function firstParam(value: string | string[] | undefined) {
   return Array.isArray(value) ? value[0] : value
 }
 
-export default async function LoginPage({ searchParams }: LoginPageProps) {
+export default async function ForgotPasswordPage({
+  searchParams,
+}: ForgotPasswordPageProps) {
   const params = (await searchParams) ?? {}
   const error = firstParam(params.error)
   const message = firstParam(params.message)
-  const next = firstParam(params.next) ?? "/mypage"
 
   const supabase = await createClient()
   const {
@@ -44,71 +45,44 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
   return (
     <main className="relative min-h-[calc(100vh-4rem)] overflow-hidden">
       <div className="pointer-events-none absolute inset-0 -z-10">
-        <div className="absolute left-[-12rem] top-24 h-96 w-96 rounded-full bg-accent/10 blur-3xl" />
-        <div className="absolute right-[-8rem] top-1/3 h-80 w-80 rounded-full bg-muted blur-3xl" />
-        <div className="absolute bottom-16 left-1/3 h-px w-[42rem] -rotate-6 bg-border" />
+        <div className="absolute left-[-10rem] top-24 h-96 w-96 rounded-full bg-accent/10 blur-3xl" />
+        <div className="absolute bottom-10 right-[-8rem] h-80 w-80 rounded-full bg-muted blur-3xl" />
+        <div className="absolute left-1/4 top-1/2 h-px w-[38rem] rotate-[-7deg] bg-border" />
       </div>
 
       <section className="mx-auto grid max-w-6xl grid-cols-1 gap-10 px-6 py-20 md:px-8 md:py-28 lg:grid-cols-12 lg:items-center">
         <div className="lg:col-span-6">
           <p className="caps mb-5">Member access</p>
-          <h1 className="font-serif italic text-[clamp(4rem,14vw,8.5rem)] leading-[0.82] tracking-tight">
-            Member
+          <h1 className="font-serif italic text-[clamp(4rem,13vw,8rem)] leading-[0.82] tracking-tight">
+            Reset
             <br />
-            Room
+            Password
           </h1>
           <p className="mt-6 max-w-xl font-serif-kr text-2xl leading-snug text-muted-foreground md:text-3xl">
-            세션과 근황, 브레멘에서의 현재를 이어서 남겨두세요.
+            POSTECH 메일로 새 비밀번호를 설정할 링크를 받습니다.
           </p>
-
-          <div className="mt-10 grid max-w-xl grid-cols-1 gap-3 sm:grid-cols-3">
-            {["프로필", "활동 상태", "멤버 카드"].map((label) => (
-              <div key={label} className="rounded-md border bg-card/70 p-4 shadow-sm">
-                <p className="caps">{label}</p>
-              </div>
-            ))}
-          </div>
         </div>
 
         <div className="lg:col-span-5 lg:col-start-8">
           <Card className="lift-card gap-0 overflow-hidden rounded-md border bg-card/95 py-0 shadow-xl">
             <CardHeader className="border-b px-6 py-6 md:px-8">
-              <CardTitle className="font-serif italic text-4xl">Sign In</CardTitle>
+              <CardTitle className="font-serif italic text-4xl">
+                Find Your Room
+              </CardTitle>
               <CardDescription>
-                POSTECH 메일로 Member Room에 들어갑니다.
+                가입한 POSTECH 메일을 입력하면 재설정 링크를 보냅니다.
               </CardDescription>
             </CardHeader>
             <CardContent className="px-6 py-6 md:px-8 md:py-8">
-              <form action={signInAction}>
-                <input type="hidden" name="next" value={next} />
+              <form action={requestPasswordResetAction}>
                 <div className="space-y-2">
-                  <Label htmlFor="email">Email</Label>
+                  <Label htmlFor="email">POSTECH Email</Label>
                   <Input
                     id="email"
                     name="email"
                     type="email"
                     autoComplete="email"
                     placeholder="name@postech.ac.kr"
-                    className="h-11 bg-background/70"
-                    required
-                  />
-                </div>
-
-                <div className="mt-5 space-y-2">
-                  <div className="flex items-center justify-between gap-3">
-                    <Label htmlFor="password">Password</Label>
-                    <Link
-                      href="/forgot-password"
-                      className="text-xs font-medium text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
-                    >
-                      Reset password
-                    </Link>
-                  </div>
-                  <Input
-                    id="password"
-                    name="password"
-                    type="password"
-                    autoComplete="current-password"
                     className="h-11 bg-background/70"
                     required
                   />
@@ -128,21 +102,21 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
                 <FormSubmitButton
                   size="lg"
                   className="mt-7 w-full"
-                  pendingLabel="Signing in..."
+                  pendingLabel="Sending link..."
                 >
-                  Sign In
+                  Send Reset Link
                 </FormSubmitButton>
               </form>
 
               <div className="mt-6 rounded-md bg-muted/45 p-4 text-sm leading-relaxed text-muted-foreground">
-                아직 계정이 없으면{" "}
+                비밀번호가 기억났다면{" "}
                 <Link
-                  href="/signup"
+                  href="/login"
                   className="font-medium text-foreground underline-offset-4 hover:underline"
                 >
-                  Sign Up
+                  Sign In
                 </Link>
-                으로 내 이름을 먼저 찾아주세요.
+                으로 돌아가세요.
               </div>
             </CardContent>
           </Card>

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -1,0 +1,131 @@
+import type { Metadata } from "next"
+import { redirect } from "next/navigation"
+
+import { updatePasswordAction } from "@/app/auth/actions"
+import { FormSubmitButton } from "@/components/form-submit-button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { createClient } from "@/lib/supabase/server"
+
+export const metadata: Metadata = {
+  title: "New Password | 브레멘 Bremen",
+  description: "Set a new Bremen member password",
+}
+
+type ResetPasswordPageProps = {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>
+}
+
+function firstParam(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value
+}
+
+export default async function ResetPasswordPage({
+  searchParams,
+}: ResetPasswordPageProps) {
+  const params = (await searchParams) ?? {}
+  const error = firstParam(params.error)
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    const search = new URLSearchParams({
+      error: "재설정 링크가 만료되었습니다. 다시 요청해 주세요.",
+    })
+    redirect(`/forgot-password?${search.toString()}`)
+  }
+
+  return (
+    <main className="relative min-h-[calc(100vh-4rem)] overflow-hidden">
+      <div className="pointer-events-none absolute inset-0 -z-10">
+        <div className="absolute right-[-10rem] top-20 h-96 w-96 rounded-full bg-accent/10 blur-3xl" />
+        <div className="absolute bottom-12 left-[-8rem] h-80 w-80 rounded-full bg-muted blur-3xl" />
+      </div>
+
+      <section className="mx-auto grid max-w-6xl grid-cols-1 gap-10 px-6 py-20 md:px-8 md:py-28 lg:grid-cols-12 lg:items-center">
+        <div className="lg:col-span-6">
+          <p className="caps mb-5">Member access</p>
+          <h1 className="font-serif italic text-[clamp(4rem,13vw,8rem)] leading-[0.82] tracking-tight">
+            New
+            <br />
+            Password
+          </h1>
+          <p className="mt-6 max-w-xl font-serif-kr text-2xl leading-snug text-muted-foreground md:text-3xl">
+            다른 곳에서 쓰지 않은 긴 비밀번호로 Member Room을 지켜주세요.
+          </p>
+        </div>
+
+        <div className="lg:col-span-5 lg:col-start-8">
+          <Card className="lift-card gap-0 overflow-hidden rounded-md border bg-card/95 py-0 shadow-xl">
+            <CardHeader className="border-b px-6 py-6 md:px-8">
+              <CardTitle className="font-serif italic text-4xl">
+                Set Password
+              </CardTitle>
+              <CardDescription>
+                재설정이 끝나면 다시 Sign In으로 들어갑니다.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="px-6 py-6 md:px-8 md:py-8">
+              <form action={updatePasswordAction}>
+                <div className="space-y-2">
+                  <Label htmlFor="password">New Password</Label>
+                  <Input
+                    id="password"
+                    name="password"
+                    type="password"
+                    autoComplete="new-password"
+                    minLength={8}
+                    className="h-11 bg-background/70"
+                    required
+                  />
+                </div>
+
+                <div className="mt-5 space-y-2">
+                  <Label htmlFor="password_confirm">Confirm Password</Label>
+                  <Input
+                    id="password_confirm"
+                    name="password_confirm"
+                    type="password"
+                    autoComplete="new-password"
+                    minLength={8}
+                    className="h-11 bg-background/70"
+                    required
+                  />
+                </div>
+
+                <p className="mt-4 text-xs leading-relaxed text-muted-foreground">
+                  유출된 적 없는 비밀번호를 권장합니다. 같은 비밀번호를 여러
+                  서비스에 반복해서 쓰지 마세요.
+                </p>
+
+                {error && (
+                  <p className="mt-5 rounded-md border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+                    {error}
+                  </p>
+                )}
+
+                <FormSubmitButton
+                  size="lg"
+                  className="mt-7 w-full"
+                  pendingLabel="Saving password..."
+                >
+                  Save New Password
+                </FormSubmitButton>
+              </form>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -108,6 +108,11 @@ Current expected values:
 - Vercel preview wildcard: `https://*-hyeongsoo-kims-projects-3dc1850b.vercel.app/**`
 - Local development callback: `http://localhost:3000/auth/callback`
 
+Password recovery also returns through `/auth/callback` and preserves
+`next=/reset-password`, so the callback URLs above cover signup confirmation and
+password reset. Do not add `/reset-password` directly unless the Auth email
+template or application flow changes to bypass `/auth/callback`.
+
 When adding or changing a domain:
 
 1. Update Supabase Auth Site URL if the canonical production domain changes.


### PR DESCRIPTION
## Summary
- Closes #139
- adds `/forgot-password` for neutral POSTECH email reset requests
- adds `/reset-password` for authenticated recovery sessions to set a new password
- links login to reset password and documents the callback-based recovery redirect

## Validation
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm run build
- git diff --check
- `curl -I http://localhost:3000/login` returns 200
- `curl -I http://localhost:3000/forgot-password` returns 200
- `curl -I http://localhost:3000/reset-password` redirects signed-out users to `/forgot-password`

## Production Note
This PR does not enable leaked password protection. After deployment, confirm Supabase Auth redirect URLs still include `/auth/callback` for production, preview, and local domains, then test one real recovery email before enabling the protection setting.
