### PR TITLE
Harden password recovery reset guard

### DIFF
--- a/app/auth/actions.ts
+++ b/app/auth/actions.ts
@@ -1,9 +1,14 @@
 "use server"
 
 import { headers } from "next/headers"
+import { cookies } from "next/headers"
 import { revalidatePath, updateTag } from "next/cache"
 import { redirect } from "next/navigation"
 
+import {
+  PASSWORD_RECOVERY_COOKIE,
+  passwordRecoveryExpiredMessage,
+} from "@/lib/auth/password-recovery"
 import { PUBLIC_CONTENT_CACHE_TAG } from "@/lib/data/public-cache"
 import { createClient } from "@/lib/supabase/server"
 import type { Database } from "@/lib/supabase/types"
@@ -219,6 +224,14 @@ export async function requestPasswordResetAction(formData: FormData) {
 export async function updatePasswordAction(formData: FormData) {
   const password = stringField(formData, "password")
   const passwordConfirm = stringField(formData, "password_confirm")
+  const cookieStore = await cookies()
+  const hasRecoveryGuard = cookieStore.get(PASSWORD_RECOVERY_COOKIE)?.value === "1"
+
+  if (!hasRecoveryGuard) {
+    redirectWithParams("/forgot-password", {
+      error: passwordRecoveryExpiredMessage,
+    })
+  }
 
   if (password.length < 8) {
     redirectWithParams("/reset-password", {
@@ -238,8 +251,9 @@ export async function updatePasswordAction(formData: FormData) {
   } = await supabase.auth.getUser()
 
   if (!user) {
+    cookieStore.delete(PASSWORD_RECOVERY_COOKIE)
     redirectWithParams("/forgot-password", {
-      error: "재설정 링크가 만료되었습니다. 다시 요청해 주세요.",
+      error: passwordRecoveryExpiredMessage,
     })
   }
 
@@ -254,6 +268,7 @@ export async function updatePasswordAction(formData: FormData) {
   }
 
   await supabase.auth.signOut()
+  cookieStore.delete(PASSWORD_RECOVERY_COOKIE)
   redirectWithParams("/login", {
     message: passwordUpdatedMessage,
   })

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,5 +1,11 @@
 import { NextResponse, type NextRequest } from "next/server"
 
+import {
+  invalidAuthLinkMessage,
+  PASSWORD_RECOVERY_COOKIE,
+  PASSWORD_RECOVERY_COOKIE_MAX_AGE_SECONDS,
+  passwordRecoveryExpiredMessage,
+} from "@/lib/auth/password-recovery"
 import { createClient } from "@/lib/supabase/server"
 
 function safeNextPath(raw: string | null) {
@@ -7,15 +13,44 @@ function safeNextPath(raw: string | null) {
   return raw
 }
 
+function errorRedirect(requestUrl: URL, next: string) {
+  const fallbackPath = next === "/reset-password" ? "/forgot-password" : "/login"
+  const message =
+    next === "/reset-password"
+      ? passwordRecoveryExpiredMessage
+      : invalidAuthLinkMessage
+  const redirectUrl = new URL(fallbackPath, requestUrl.origin)
+  redirectUrl.searchParams.set("error", message)
+  return NextResponse.redirect(redirectUrl)
+}
+
 export async function GET(request: NextRequest) {
   const requestUrl = new URL(request.url)
   const code = requestUrl.searchParams.get("code")
   const next = safeNextPath(requestUrl.searchParams.get("next"))
 
-  if (code) {
-    const supabase = await createClient()
-    await supabase.auth.exchangeCodeForSession(code)
+  if (!code) {
+    return errorRedirect(requestUrl, next)
   }
 
-  return NextResponse.redirect(new URL(next, requestUrl.origin))
+  const supabase = await createClient()
+  const { error } = await supabase.auth.exchangeCodeForSession(code)
+
+  if (error) {
+    return errorRedirect(requestUrl, next)
+  }
+
+  const response = NextResponse.redirect(new URL(next, requestUrl.origin))
+
+  if (next === "/reset-password") {
+    response.cookies.set(PASSWORD_RECOVERY_COOKIE, "1", {
+      httpOnly: true,
+      maxAge: PASSWORD_RECOVERY_COOKIE_MAX_AGE_SECONDS,
+      path: "/",
+      sameSite: "lax",
+      secure: requestUrl.protocol === "https:",
+    })
+  }
+
+  return response
 }

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next"
+import { cookies } from "next/headers"
 import { redirect } from "next/navigation"
 
 import { updatePasswordAction } from "@/app/auth/actions"
@@ -12,6 +13,10 @@ import {
 } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import {
+  PASSWORD_RECOVERY_COOKIE,
+  passwordRecoveryExpiredMessage,
+} from "@/lib/auth/password-recovery"
 import { createClient } from "@/lib/supabase/server"
 
 export const metadata: Metadata = {
@@ -32,15 +37,17 @@ export default async function ResetPasswordPage({
 }: ResetPasswordPageProps) {
   const params = (await searchParams) ?? {}
   const error = firstParam(params.error)
+  const cookieStore = await cookies()
+  const hasRecoveryGuard = cookieStore.get(PASSWORD_RECOVERY_COOKIE)?.value === "1"
 
   const supabase = await createClient()
   const {
     data: { user },
   } = await supabase.auth.getUser()
 
-  if (!user) {
+  if (!user || !hasRecoveryGuard) {
     const search = new URLSearchParams({
-      error: "재설정 링크가 만료되었습니다. 다시 요청해 주세요.",
+      error: passwordRecoveryExpiredMessage,
     })
     redirect(`/forgot-password?${search.toString()}`)
   }

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -113,6 +113,11 @@ Password recovery also returns through `/auth/callback` and preserves
 password reset. Do not add `/reset-password` directly unless the Auth email
 template or application flow changes to bypass `/auth/callback`.
 
+The app sets a short-lived httpOnly recovery guard cookie only after a successful
+`/auth/callback?next=/reset-password` exchange. `/reset-password` and its server
+action must reject direct access without that guard, even when the user already
+has a normal signed-in session.
+
 When adding or changing a domain:
 
 1. Update Supabase Auth Site URL if the canonical production domain changes.

--- a/lib/auth/password-recovery.ts
+++ b/lib/auth/password-recovery.ts
@@ -1,0 +1,8 @@
+export const PASSWORD_RECOVERY_COOKIE = "bremen-password-recovery"
+export const PASSWORD_RECOVERY_COOKIE_MAX_AGE_SECONDS = 10 * 60
+
+export const passwordRecoveryExpiredMessage =
+  "재설정 링크가 만료되었습니다. 다시 요청해 주세요."
+
+export const invalidAuthLinkMessage =
+  "인증 링크가 올바르지 않거나 만료되었습니다. 다시 시도해 주세요."


### PR DESCRIPTION
## Summary
- Closes #142
- Gates `/reset-password` behind a short-lived httpOnly recovery guard set by `/auth/callback?next=/reset-password`
- Makes missing or invalid callback codes redirect to a clear user-facing error path
- Documents the recovery guard in operations docs

## Validation
- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `pnpm run build`
- `git diff --check`
- `curl -I http://localhost:3000/reset-password` redirects to `/forgot-password`
- `curl -I 'http://localhost:3000/auth/callback?next=/reset-password'` redirects to `/forgot-password`
- `curl -I 'http://localhost:3000/auth/callback?next=/mypage'` redirects to `/login`
- `curl -I 'http://localhost:3000/auth/callback?next=/reset-password&code=definitely-invalid'` redirects to `/forgot-password`
- `curl -I http://localhost:3000/forgot-password` returns 200

## Production Note
This does not change Supabase configuration. Leaked password protection remains blocked by the current Free plan; see #141.
