### PR TITLE
Make auth callback HEAD side-effect free

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -54,3 +54,12 @@ export async function GET(request: NextRequest) {
 
   return response
 }
+
+export function HEAD(request: NextRequest) {
+  const requestUrl = new URL(request.url)
+  const next = safeNextPath(requestUrl.searchParams.get("next"))
+
+  // Do not exchange recovery codes for HEAD requests. Link scanners and curl -I
+  // should not consume a one-time auth code before the member opens the link.
+  return errorRedirect(requestUrl, next)
+}


### PR DESCRIPTION
## Summary
- Closes #142
- Adds side-effect-free `HEAD` handling for `/auth/callback`
- Keeps browser `GET` as the only path that may exchange Supabase one-time recovery codes
- Makes `curl -I` and link-scanner probes fall back to the same safe error destinations

## Validation
- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `pnpm run build`
- `git diff --check`
- Local `HEAD /auth/callback?next=/reset-password` redirects to `/forgot-password`
- Local `HEAD /auth/callback?next=/mypage` redirects to `/login`
- Local `GET /auth/callback?next=/reset-password&code=definitely-invalid` redirects to `/forgot-password`
- Local `HEAD /reset-password` redirects to `/forgot-password`

## Note
This intentionally does not exchange codes for `HEAD` requests. Some scanners probe email links before users open them, and those probes should not consume recovery credentials.
