### PR TITLE
Align CMS graph docs with retired legacy tables

### DIFF
--- a/docs/agentic-workflow.md
+++ b/docs/agentic-workflow.md
@@ -9,7 +9,7 @@ Start from an issue. If no issue exists, the first agent task is to draft one us
 Agents should classify every task as one or more of:
 
 - `code`: React, Next.js, Tailwind, shadcn/ui, loaders, validation, tests
-- `content`: `pages`, `sections`, `entities`, `section_entities`, `entity_relations`
+- `content`: `pages`, `sections`, `entities`, `entity_relations`
 - `schema`: tables, columns, indexes, functions, triggers, RLS, storage policies
 - `ops`: Vercel, Supabase Auth, SMTP, domains, environment variables
 - `research`: YouTube, Instagram, history PDF, references, visual direction
@@ -134,7 +134,8 @@ For content graph tasks:
 1. Identify page slug and section keys.
 2. Determine whether this is content data, renderer behavior, or schema.
 3. Prefer upserts by stable keys (`pages.slug`, `sections.key`, `entities.slug`).
-4. Link with `section_entities` or `entity_relations`.
+4. Link with `entity_relations`; the legacy `section_entities` mirror table has
+   been removed.
 5. Verify counts with the query in `docs/content-graph.md`.
 
 For schema tasks:

--- a/docs/cms-audit.md
+++ b/docs/cms-audit.md
@@ -4,17 +4,21 @@ PONIX CMS writes are admin-gated, but they still mutate shared content rows.
 The audit layer is intentionally append-only and recovery-focused: it records
 what changed, but it does not add broad rollback controls in the first slice.
 
-## First Slice
+## Current Content Graph Audit Scope
 
-Migration `20260505000039_cms_audit_events.sql` adds
-`public.cms_audit_events` and database triggers on:
+Migration `20260505000039_cms_audit_events.sql` introduced
+`public.cms_audit_events`. After the legacy mirror removal in
+`20260509000048_drop_legacy_mirror_tables.sql`, active CMS content graph audit
+coverage is centered on:
 
 - `pages`
 - `sections`
 - `entities`
-- `page_sections`
-- `section_entities`
 - `entity_relations`
+
+Historical audit rows can still contain `target_table` values for removed
+legacy mirror tables. Treat those as immutable history, not active write
+targets.
 
 Each audit event stores:
 

--- a/docs/cms-prework.md
+++ b/docs/cms-prework.md
@@ -32,7 +32,6 @@ The database already has JSONB fields:
 
 - `sections.props`
 - `entities.data`
-- `section_entities.props`
 - `entity_relations.props`
 
 Those fields are flexible but not enough for a safe CMS. A CMS needs to know which JSON keys are editable, which fields are required, which options are allowed, and which fields are read-only.

--- a/docs/content-graph.md
+++ b/docs/content-graph.md
@@ -29,9 +29,11 @@ by mirroring page and section records into the generic graph:
 - Section-to-content composition uses `entity_relations` rows from section
   entity to content entity.
 
-The bridge uses `source_table` and `source_id` columns on `entities` and
-`entity_relations` so older mirrored rows can still be traced back to their
-source. New runtime composition writes do not need a legacy `source_id`.
+The bridge uses `source_table` and `source_id` columns on page/section shadow
+`entities` so routable domain rows can be resolved into graph nodes.
+`entity_relations` no longer uses legacy mirror source markers after
+`20260511000052_retire_legacy_relation_source_markers.sql`; relation identity
+comes from `schema_key`, `relation_type`, `slot`, and the relation id.
 
 The bridge is now the primary runtime composition path.
 
@@ -43,16 +45,13 @@ Current PONIX contract:
 - CMS relation lists read page/section placement through `entity_relations`
   bridge rows, using relation `schema_key` values as the runtime identity:
   `relation/page-section/v1` and `relation/section-entity/v1`.
-- Existing mirrored rows may still expose a legacy `source_id`; new runtime
-  composition writes use `entity_relations.id` and do not require one.
 - Routine CMS composition writes target `entity_relations` without legacy
   relation `source_table` markers.
 - Maintenance apply scripts and generated seed migrations that refresh scraped
   or Instagram content should also write section placement through
   `entity_relations`, not directly through `page_sections` or
   `section_entities`.
-- Code that mutates page or section composition must pass the graph relation id,
-  not the legacy `source_id`.
+- Code that mutates page or section composition must pass the graph relation id.
 - `pnpm run qa:content-graph` checks graph-only page composition integrity:
   page shadow cardinality, section ordering, relation contracts, and missing or
   unpublished section/entity references.
@@ -206,7 +205,8 @@ Use `entities.data` for entity-specific structured data:
 - activity metadata: schedule, variant, tilt
 - history metadata: year, display order
 
-Use `section_entities.props` only for relationship-specific display choices, such as a caption for a featured entity in one section.
+Use `entity_relations.props` only for relationship-specific display choices,
+such as a caption for a featured entity in one section.
 
 ## Image Policy
 
@@ -276,25 +276,30 @@ values (
 ### Link an Entity to a Section
 
 ```sql
-insert into public.section_entities (
-  section_id,
-  entity_id,
+insert into public.entity_relations (
+  from_entity_id,
+  to_entity_id,
+  schema_key,
   relation_type,
   slot,
   sort_order,
   props
 )
 select
-  section_ref.id,
+  section_shadow.id,
   entity_ref.id,
+  'relation/section-entity/v1',
   'item',
   'default',
   120,
   '{}'::jsonb
 from public.sections section_ref
+join public.entities section_shadow
+  on section_shadow.source_table = 'sections'
+ and section_shadow.source_id = section_ref.id
 join public.entities entity_ref on entity_ref.slug = 'history-2026-new-season'
 where section_ref.key = 'history-timeline'
-on conflict (section_id, entity_id, relation_type, slot) do update
+on conflict (from_entity_id, to_entity_id, relation_type, slot) do update
 set sort_order = excluded.sort_order,
     props = excluded.props,
     updated_at = now();
@@ -303,13 +308,21 @@ set sort_order = excluded.sort_order,
 ### Reorder a Section
 
 ```sql
-update public.page_sections page_section
+update public.entity_relations page_section_relation
 set sort_order = 30
-from public.pages page_ref, public.sections section_ref
-where page_section.page_id = page_ref.id
-  and page_section.section_id = section_ref.id
-  and page_ref.slug = 'home'
-  and section_ref.key = 'home-activities';
+from public.pages page_ref
+join public.entities page_shadow
+  on page_shadow.source_table = 'pages'
+ and page_shadow.source_id = page_ref.id
+join public.sections section_ref on section_ref.key = 'home-activities'
+join public.entities section_shadow
+  on section_shadow.source_table = 'sections'
+ and section_shadow.source_id = section_ref.id
+where page_section_relation.from_entity_id = page_shadow.id
+  and page_section_relation.to_entity_id = section_shadow.id
+  and page_section_relation.schema_key = 'relation/page-section/v1'
+  and page_section_relation.slot = 'sections'
+  and page_ref.slug = 'home';
 ```
 
 ## Required Content Checks
@@ -326,14 +339,33 @@ After changing content graph data, verify:
 Useful query:
 
 ```sql
-select p.slug, ps.sort_order, s.key, s.section_type, count(se.id) as entity_count
+select
+  p.slug,
+  page_section_relation.sort_order,
+  s.key,
+  s.section_type,
+  count(content_entity.id) as entity_count
 from public.pages p
-join public.page_sections ps on ps.page_id = p.id
-join public.sections s on s.id = ps.section_id
-left join public.section_entities se on se.section_id = s.id
+join public.entities page_shadow
+  on page_shadow.source_table = 'pages'
+ and page_shadow.source_id = p.id
+join public.entity_relations page_section_relation
+  on page_section_relation.from_entity_id = page_shadow.id
+ and page_section_relation.schema_key = 'relation/page-section/v1'
+ and page_section_relation.slot = 'sections'
+join public.entities section_shadow
+  on section_shadow.id = page_section_relation.to_entity_id
+ and section_shadow.source_table = 'sections'
+join public.sections s on s.id = section_shadow.source_id
+left join public.entity_relations section_item_relation
+  on section_item_relation.from_entity_id = section_shadow.id
+ and section_item_relation.schema_key = 'relation/section-entity/v1'
+left join public.entities content_entity
+  on content_entity.id = section_item_relation.to_entity_id
+ and content_entity.published = true
 where p.slug in ('home', 'site', 'performances', 'videos', 'photos', 'history')
   and p.published = true
   and s.published = true
-group by p.slug, ps.sort_order, s.key, s.section_type
-order by p.slug, ps.sort_order;
+group by p.slug, page_section_relation.sort_order, s.key, s.section_type
+order by p.slug, page_section_relation.sort_order;
 ```

--- a/docs/legacy-mirror-removal-plan.md
+++ b/docs/legacy-mirror-removal-plan.md
@@ -1,15 +1,18 @@
 # Legacy Mirror Removal Plan
 
-This document stages the removal of the legacy composition mirror tables:
+Status: complete as of the Stage 5 migration
+`20260509000048_drop_legacy_mirror_tables.sql`. This document remains as the
+decision record for how the removal was staged.
+
+This document staged the removal of the legacy composition mirror tables:
 
 - `page_sections`
 - `section_entities`
 
-The current production-safe state is graph-primary runtime composition with
-legacy mirrors kept only for compatibility and their own transition triggers.
-Do not drop the legacy tables until every pre-Stage-5 blocker reported by
-`pnpm run qa:legacy-mirror-stage5-preflight` is clear and a maintainer has
-explicitly approved the destructive migration.
+The current production state is graph-primary runtime composition with the
+legacy mirrors removed. Do not reintroduce these tables; use
+`entity_relations` for ordered page-to-section and section-to-entity
+composition.
 
 ## Current State
 
@@ -27,11 +30,10 @@ Completed:
   indexes are superseded by the Stage 3 operational cleanup migration.
 - Content graph QA validates graph-internal page composition integrity without
   reading the legacy mirrors.
-- Legacy mirror compatibility triggers remain for the legacy tables themselves.
+- Legacy mirror compatibility triggers and tables were removed in Stage 5.
 
-Remaining blocker classes:
-
-- Legacy mirror compatibility migrations still mention the legacy tables.
+Remaining blocker classes: none for active runtime/CMS code. Historical
+migrations and guard self-tests still mention the removed table names by design.
 
 ## Stage 1: Canonical Graph Identity
 
@@ -140,6 +142,8 @@ contracts, ordering, and missing or unpublished targets directly from the graph.
 
 Goal: remove `page_sections` and `section_entities`.
 
+Status: complete.
+
 Preconditions:
 
 - Stages 1-4 are complete.
@@ -163,6 +167,12 @@ Exit checks:
 - No runtime, QA, migration, docs, or generated-code path expects live legacy
   mirror tables.
 - Production pages and PONIX CMS composition editing still pass smoke tests.
+
+Current verification commands:
+
+- `pnpm run qa:legacy-mirror-readiness`
+- `pnpm run qa:cms-legacy-bridge-boundary`
+- `pnpm run qa:graph-primary-seed-writes`
 
 ## Guardrails
 

--- a/docs/legacy-mirror-stage-5-runbook.md
+++ b/docs/legacy-mirror-stage-5-runbook.md
@@ -1,16 +1,40 @@
 # Legacy Mirror Stage 5 Runbook
 
-Stage 5 removes the legacy composition mirror tables:
+Status: completed. Stage 5 removed the legacy composition mirror tables through
+`20260509000048_drop_legacy_mirror_tables.sql`.
+
+The removed tables were:
 
 - `public.page_sections`
 - `public.section_entities`
 
-This is destructive. Do not apply the migration until a maintainer explicitly
-approves the production write after reviewing the preflight output.
+This runbook is retained as a historical safety record and rollback reference.
+Do not use it as an instruction to recreate the legacy mirrors during normal
+CMS work.
 
 ## Current Production Snapshot
 
-Captured on 2026-05-09 with Supabase MCP read-only queries:
+Captured on 2026-05-11 with `pnpm run qa:legacy-media-table-readiness`,
+`pnpm run qa:legacy-mirror-readiness`, and Supabase MCP `list_tables`:
+
+- `public.page_sections`: removed.
+- `public.section_entities`: removed.
+- `public.performances`: removed.
+- `public.videos`: removed.
+- `public.photos`: removed.
+- Active public tables: `members`, `entities`, `entity_relations`, `pages`,
+  `sections`, `cms_audit_events`, `entity_schemas`.
+- Entity graph media summary: 33 performance entities, 215 video entities, 31
+  photo entities.
+- `qa:legacy-mirror-readiness` reports zero active blocker references.
+- Follow-up migration `20260511000052_retire_legacy_relation_source_markers.sql`
+  retires inert `entity_relations.source_table/source_id` markers that pointed
+  to the removed mirror rows.
+
+## Historical Pre-Drop Snapshot
+
+Captured on 2026-05-09 with Supabase MCP read-only queries before the
+destructive migration:
 
 - `page_sections`: 16 rows.
 - `section_entities`: 400 rows.
@@ -20,12 +44,13 @@ Captured on 2026-05-09 with Supabase MCP read-only queries:
 - Historical `cms_audit_events.target_table = 'section_entities'`: 35 rows.
 - No public/private views reference the legacy mirrors.
 
-The graph rows are the canonical runtime source. The legacy row counts are kept
-here only to make the destructive boundary explicit.
+The graph rows were already the canonical runtime source. The legacy row counts
+are kept here only to make the destructive boundary explicit.
 
-## Local Preflight
+## Historical Local Preflight
 
-Run these before writing or applying the destructive migration:
+These checks were required before writing or applying the destructive
+migration:
 
 ```bash
 pnpm run qa:legacy-mirror-stage5-preflight
@@ -45,9 +70,9 @@ pnpm run build
 At this point, the expected remaining static references are historical
 migrations, docs, static guard self-tests, and Stage 5 compatibility migrations.
 
-## Supabase MCP Preflight
+## Historical Supabase MCP Preflight
 
-Run these as read-only checks immediately before approval/application:
+These read-only checks were required immediately before approval/application:
 
 ```sql
 select table_name, table_type
@@ -109,13 +134,13 @@ group by target_table
 order by target_table;
 ```
 
-Expected function references before the destructive migration:
+Expected function references before the destructive migration were:
 
 - `private.record_cms_audit_event()`
 - `private.sync_page_section_relation_bridge()`
 - `private.sync_section_entity_relation_bridge()`
 
-Expected legacy table triggers before the destructive migration:
+Expected legacy table triggers before the destructive migration were:
 
 - `page_sections_cms_audit`
 - `page_sections_entity_relation_bridge`
@@ -124,18 +149,19 @@ Expected legacy table triggers before the destructive migration:
 - `section_entities_entity_relation_bridge`
 - `section_entities_set_updated_at`
 
-Expected entity relation bridge triggers before cleanup:
+Expected entity relation bridge triggers before cleanup were:
 
 - `entity_relations_source_bridge_insert`
 - `entity_relations_source_bridge_update`
 - `entity_relations_source_bridge_delete`
 
-## Migration Shape
+## Applied Migration Shape
 
-The reviewed migration should avoid `cascade` unless a fresh catalog preflight
-proves an unexpected dependency must be removed deliberately.
+The reviewed migration avoided `cascade`; if a future migration fails because of
+an unexpected dependency, stop and inspect the dependency instead of broadening
+the destructive operation.
 
-Recommended order:
+Applied order:
 
 1. Drop the no-op `entity_relations_source_bridge_*` triggers.
 2. Drop legacy table triggers explicitly.
@@ -154,10 +180,7 @@ Reviewed draft migration:
 
 - `supabase/migrations/20260509000048_drop_legacy_mirror_tables.sql`
 
-Do not apply this migration to production until the maintainer gives explicit
-production-write approval in the active session. The migration is intentionally
-plain `drop table if exists` without `cascade`; if it fails, stop and inspect
-the dependency instead of broadening the destructive operation.
+The migration is intentionally plain `drop table if exists` without `cascade`.
 
 ## Rollback Plan
 

--- a/scripts/qa-legacy-mirror-readiness.mjs
+++ b/scripts/qa-legacy-mirror-readiness.mjs
@@ -84,6 +84,12 @@ const categories = {
     removalBlocker: false,
     note: "The reviewed Stage 5 migration intentionally names the legacy mirrors it removes.",
   },
+  legacy_relation_source_retirement_migration: {
+    label: "Legacy relation source marker retirement migration",
+    stage: null,
+    removalBlocker: false,
+    note: "The follow-up cleanup migration intentionally names retired source_table marker values.",
+  },
   bridge_compatibility_marker: {
     label: "Bridge compatibility markers",
     stage: 2,
@@ -209,6 +215,13 @@ function classify(file, line = "") {
     return "legacy_mirror_removal_migration"
   }
 
+  if (
+    file ===
+    "supabase/migrations/20260511000052_retire_legacy_relation_source_markers.sql"
+  ) {
+    return "legacy_relation_source_retirement_migration"
+  }
+
   if (bridgeCompatibilityMarkerFiles.has(file)) {
     if (
       /\.eq\(\s*["'`]source_table["'`]/.test(line) ||
@@ -257,6 +270,7 @@ function runSelfTest() {
     classify("scripts/generate-instagram-feed-migration.mjs", "'section_entities'"),
     classify("supabase/migrations/20260430000034_private_rls_helpers.sql", "section_entities"),
     classify("supabase/migrations/20260509000048_drop_legacy_mirror_tables.sql", "drop table public.section_entities"),
+    classify("supabase/migrations/20260511000052_retire_legacy_relation_source_markers.sql", "source_table in ('page_sections', 'section_entities')"),
     classify("supabase/migrations/20260429000009_scraped_content_seed.sql", "page_sections"),
     classify("docs/content-graph.md", "`section_entities`"),
   ]

--- a/supabase/migrations/20260511000052_retire_legacy_relation_source_markers.sql
+++ b/supabase/migrations/20260511000052_retire_legacy_relation_source_markers.sql
@@ -1,0 +1,36 @@
+-- Bremen - retire legacy relation source markers.
+--
+-- Stage 5 removed public.page_sections and public.section_entities. The
+-- canonical runtime composition source is public.entity_relations, and new
+-- writes already identify relation purpose through schema_key/relation_type.
+--
+-- These source markers only pointed back to removed mirror rows, so keeping
+-- them makes the CMS model look more legacy-backed than it is.
+
+update public.entity_relations
+set source_table = null,
+    source_id = null
+where source_table in ('page_sections', 'section_entities');
+
+drop index if exists public.entity_relations_source_ref_idx;
+
+alter table public.entity_relations
+  drop constraint if exists entity_relations_source_table_check;
+
+alter table public.entity_relations
+  add constraint entity_relations_source_table_retired_check
+  check (source_table is null and source_id is null);
+
+alter table public.entity_schemas
+  drop constraint if exists entity_schemas_table_name_check;
+
+alter table public.entity_schemas
+  add constraint entity_schemas_table_name_check
+  check (
+    table_name in (
+      'pages',
+      'sections',
+      'entities',
+      'entity_relations'
+    )
+  );


### PR DESCRIPTION
## Summary
- Closes #145
- Updates content graph and agent workflow docs so contributors use `entity_relations` instead of removed mirror tables
- Marks legacy mirror Stage 5 docs as completed/current-state historical records
- Adds `20260511000052_retire_legacy_relation_source_markers.sql` to clear inert `entity_relations.source_table/source_id` markers and tighten registry table targets
- Updates the legacy readiness classifier so this follow-up cleanup migration is intentional, not an active blocker

## Supabase Impact
- Adds a migration file for review.
- Does not apply the migration to production in this PR.
- Production application remains approval-gated.

## Validation
- Supabase MCP `list_tables` confirms active public tables are `members`, `entities`, `entity_relations`, `pages`, `sections`, `cms_audit_events`, `entity_schemas`
- Supabase MCP graph composition select query succeeds against `entity_relations`
- `pnpm run qa:legacy-media-table-readiness`
- `pnpm run qa:legacy-mirror-readiness`
- `pnpm run qa:cms-legacy-bridge-boundary`
- `pnpm run qa:graph-primary-seed-writes`
- `pnpm run qa:content-graph`
- `pnpm run qa:cms-schema-registry -- --strict`
- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `pnpm run build`
- `git diff --check`

## Not Applied
- `supabase/migrations/20260511000052_retire_legacy_relation_source_markers.sql` has not been applied to production.
