### PR TITLE
Prepare schema mirror removal preflight

### DIFF
--- a/docs/content-graph.md
+++ b/docs/content-graph.md
@@ -167,6 +167,14 @@ independent authoring field.
 Do not remove the text `schema_key` fields until all loaders, CMS forms,
 migrations, and production data have moved to schema IDs.
 
+Issue #149 tracks the removal preparation for those compatibility mirrors.
+`entity_schemas.schema_key` is not legacy; it remains the stable, human-readable
+registry key. The fields under review are only the duplicated content-row mirror
+columns: `entities.schema_key`, `entities.entity_type`,
+`entity_relations.schema_key`, and `sections.schema_key`. Run
+`pnpm run qa:schema-mirror-removal-readiness` after touching CMS loaders,
+seed/apply scripts, or graph migrations.
+
 Renderer implementations remain in React code. Database schemas may name a
 `renderer_key`, but they must not define executable UI behavior.
 
@@ -176,7 +184,8 @@ Use `sections` columns for section identity:
 
 - `key`
 - `section_type`
-- `schema_key`
+- `schema_id` (canonical schema reference)
+- `schema_key` (compatibility mirror until the final drop migration)
 - `eyebrow`
 - `title`
 - `subtitle`
@@ -194,9 +203,10 @@ Use `sections.props` for renderer-level copy and behavior:
 
 Use `entities` columns for shared display identity:
 
-- `entity_type` (compatibility cache; prefer `entity_schemas.semantic_kind` for
+- `schema_id` (canonical schema reference)
+- `entity_type` (compatibility mirror; prefer `entity_schemas.semantic_kind` for
   new CMS/runtime logic; not exposed as a CMS editor field)
-- `schema_key`
+- `schema_key` (compatibility mirror)
 - `slug`
 - `title`
 - `subtitle`

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "qa:legacy-media-table-readiness": "node scripts/qa-legacy-media-table-readiness.mjs",
     "qa:legacy-mirror-readiness": "node scripts/qa-legacy-mirror-readiness.mjs",
     "qa:legacy-mirror-stage5-preflight": "node scripts/qa-legacy-mirror-readiness.mjs --fail-before-stage 5",
+    "qa:schema-mirror-removal-readiness": "node scripts/qa-schema-mirror-removal-readiness.mjs",
     "qa:schema-semantic-identity": "node scripts/qa-schema-semantic-identity.mjs"
   },
   "dependencies": {

--- a/scripts/qa-schema-mirror-removal-readiness.mjs
+++ b/scripts/qa-schema-mirror-removal-readiness.mjs
@@ -1,0 +1,235 @@
+#!/usr/bin/env node
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs"
+import path from "node:path"
+
+const repoRoot = process.cwd()
+const scanRoots = ["app", "components", "lib", "scripts"]
+const codeExtensions = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs"])
+const ignoredFiles = new Set([
+  "lib/supabase/types.ts",
+  "scripts/qa-schema-mirror-removal-readiness.mjs",
+  "scripts/qa-schema-semantic-identity.mjs",
+  "scripts/qa-cms-schema-registry.mjs",
+  "scripts/qa-cms-db-first-loaders.mjs",
+  "scripts/qa-content-graph-integrity.mjs",
+  "scripts/qa-graph-primary-seed-writes.mjs",
+  "scripts/qa-legacy-media-table-readiness.mjs",
+])
+const allowedSchemaRegistryFiles = new Set([
+  "lib/cms/schema-registry.ts",
+  "lib/cms/schema-registry.server.ts",
+])
+const contentMirrorColumns = {
+  entities: ["schema_key", "entity_type"],
+  sections: ["schema_key"],
+  entity_relations: ["schema_key"],
+}
+
+function repoRelative(filePath) {
+  return path.relative(repoRoot, filePath).split(path.sep).join("/")
+}
+
+function listFiles(dir) {
+  if (!existsSync(dir)) return []
+
+  return readdirSync(dir).flatMap((entry) => {
+    const absolute = path.join(dir, entry)
+    const stat = statSync(absolute)
+
+    if (stat.isDirectory()) {
+      if (entry === "node_modules" || entry === ".next") return []
+      return listFiles(absolute)
+    }
+
+    const relative = repoRelative(absolute)
+    if (ignoredFiles.has(relative)) return []
+
+    return codeExtensions.has(path.extname(entry)) ? [absolute] : []
+  })
+}
+
+function lineNumberForOffset(source, offset) {
+  return source.slice(0, offset).split(/\r?\n/).length
+}
+
+function compact(value) {
+  return value.replace(/\s+/g, " ").trim().slice(0, 180)
+}
+
+function findSupabaseContentMirrorQueries(file, source) {
+  const violations = []
+  const tablePattern = /\.from\(\s*["'`](entities|sections|entity_relations)["'`]\s*\)/g
+  let match
+
+  while ((match = tablePattern.exec(source))) {
+    const tableName = match[1]
+    const blockStart = match.index
+    const nextTable = source.slice(tablePattern.lastIndex).search(/\.from\(\s*["'`]/)
+    const blockEnd =
+      nextTable === -1
+        ? Math.min(source.length, blockStart + 1600)
+        : tablePattern.lastIndex + nextTable
+    const block = source.slice(blockStart, blockEnd)
+
+    for (const column of contentMirrorColumns[tableName]) {
+      const columnPattern = new RegExp(
+        String.raw`(?:\.select\(|\.eq\(|\.neq\(|\.in\(|\.order\(|\.or\()[\s\S]{0,420}["'\`]${column}["'\`]`,
+      )
+
+      if (!columnPattern.test(block)) continue
+
+      violations.push({
+        file,
+        line: lineNumberForOffset(source, blockStart),
+        table: tableName,
+        column,
+        reason: "Supabase query references a content-row mirror column",
+        text: compact(block),
+      })
+    }
+  }
+
+  return violations
+}
+
+function findObjectMirrorAccess(file, source) {
+  const violations = []
+  const accessPatterns = [
+    {
+      pattern: /\b(entity|row|data|item|relatedEntity|fromEntity|toEntity)\.entity_type\b/g,
+      column: "entity_type",
+    },
+    {
+      pattern: /\b(entity|row|data|item|relation|section)\.schema_key\b/g,
+      column: "schema_key",
+    },
+  ]
+
+  for (const { pattern, column } of accessPatterns) {
+    let match
+    while ((match = pattern.exec(source))) {
+      violations.push({
+        file,
+        line: lineNumberForOffset(source, match.index),
+        table: "content-row",
+        column,
+        reason: "Runtime object access reads a mirror column directly",
+        text: compact(source.split(/\r?\n/)[lineNumberForOffset(source, match.index) - 1] ?? ""),
+      })
+    }
+  }
+
+  return violations
+}
+
+function findRawSqlContentMirrorReferences(file, source) {
+  if (!file.startsWith("scripts/")) return []
+
+  const violations = []
+  const patterns = [
+    {
+      pattern:
+        /\b(?:from|join|update|into)\s+public\.entities\b[\s\S]{0,500}\b(?:schema_key|entity_type)\b/gi,
+      table: "entities",
+    },
+    {
+      pattern:
+        /\b(?:from|join|update|into)\s+public\.sections\b[\s\S]{0,500}\bschema_key\b/gi,
+      table: "sections",
+    },
+    {
+      pattern:
+        /\b(?:from|join|update|into)\s+public\.entity_relations\b[\s\S]{0,500}\bschema_key\b/gi,
+      table: "entity_relations",
+    },
+  ]
+
+  for (const { pattern, table } of patterns) {
+    let match
+    while ((match = pattern.exec(source))) {
+      const text = match[0]
+      if (/public\.entity_schemas\b/i.test(text)) continue
+
+      violations.push({
+        file,
+        line: lineNumberForOffset(source, match.index),
+        table,
+        column: "schema_key/entity_type",
+        reason: "Generated SQL references content-row mirror identity",
+        text: compact(text),
+      })
+    }
+  }
+
+  return violations
+}
+
+function findForbiddenReferences(filePath) {
+  const file = repoRelative(filePath)
+  const source = readFileSync(filePath, "utf8")
+
+  if (allowedSchemaRegistryFiles.has(file)) return []
+
+  return [
+    ...findSupabaseContentMirrorQueries(file, source),
+    ...findObjectMirrorAccess(file, source),
+    ...findRawSqlContentMirrorReferences(file, source),
+  ]
+}
+
+function runSelfTest() {
+  const blockedSelect = findSupabaseContentMirrorQueries(
+    "app/example.ts",
+    `supabase.from("entities").select("id, schema_key, entity_type").eq("entity_type", "video")`,
+  )
+  const blockedObject = findObjectMirrorAccess(
+    "lib/example.ts",
+    "const kind = entity.entity_type\nconst key = section.schema_key",
+  )
+  const blockedSql = findRawSqlContentMirrorReferences(
+    "scripts/example.mjs",
+    "update public.entities set schema_key = 'video/default/v1' where id = target_id",
+  )
+  const allowedRegistry = findSupabaseContentMirrorQueries(
+    "lib/example.ts",
+    `supabase.from("entity_schemas").select("id, schema_key").eq("schema_key", key)`,
+  )
+
+  if (!blockedSelect.length || !blockedObject.length || !blockedSql.length) {
+    throw new Error("Self-test failed: mirror-column dependency was not detected.")
+  }
+
+  if (allowedRegistry.length) {
+    throw new Error("Self-test failed: entity_schemas.schema_key was rejected.")
+  }
+}
+
+runSelfTest()
+
+const files = scanRoots.flatMap((root) => listFiles(path.join(repoRoot, root)))
+const violations = files.flatMap(findForbiddenReferences)
+
+console.log("Schema mirror removal readiness guard")
+console.table([
+  {
+    scannedFiles: files.length,
+    ignoredFiles: ignoredFiles.size,
+    violations: violations.length,
+    selfTest: "ok",
+  },
+])
+
+if (violations.length > 0) {
+  console.error("\nContent-row mirror dependencies found:")
+  console.table(violations)
+  console.error(
+    [
+      "Use schema_id plus entity_schemas registry metadata instead of",
+      "entities.schema_key/entities.entity_type/sections.schema_key/",
+      "entity_relations.schema_key. entity_schemas.schema_key remains allowed",
+      "as the human-readable registry key.",
+    ].join(" "),
+  )
+  process.exit(1)
+}

--- a/supabase/migrations/20260511000063_prepare_schema_mirror_removal.sql
+++ b/supabase/migrations/20260511000063_prepare_schema_mirror_removal.sql
@@ -1,0 +1,120 @@
+-- Bremen - prepare content-row schema mirror removal.
+--
+-- This migration is intentionally non-destructive:
+-- - add schema_id composite indexes that match current runtime query shapes
+-- - retire remaining page shadow bridge DML reads/writes of entities.schema_key
+--   and entities.entity_type
+-- - drop superseded schema_key/entity_type indexes only after schema_id
+--   replacements exist
+--
+-- It does not drop compatibility columns. That final step needs a separate
+-- reviewed destructive migration after readiness QA and maintainer approval.
+
+create index if not exists entities_schema_id_sort_at_idx
+  on public.entities(schema_id, sort_at desc);
+
+create index if not exists entity_relations_schema_id_from_sort_idx
+  on public.entity_relations(schema_id, from_entity_id, sort_order);
+
+create index if not exists entity_relations_schema_id_from_slot_sort_idx
+  on public.entity_relations(schema_id, from_entity_id, slot, sort_order);
+
+create index if not exists entity_relations_schema_id_to_slot_sort_idx
+  on public.entity_relations(schema_id, to_entity_id, slot, sort_order);
+
+create or replace function private.sync_page_entity_bridge()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, private
+as $$
+declare
+  page_schema_id uuid;
+begin
+  select id into page_schema_id
+  from public.entity_schemas
+  where schema_key = 'page/default/v1'
+    and kind = 'page'
+    and active = true;
+
+  if page_schema_id is null then
+    raise exception 'Missing active page schema page/default/v1';
+  end if;
+
+  if tg_op = 'DELETE' then
+    delete from public.entities
+    where schema_id = page_schema_id
+      and slug = 'page:' || old.slug;
+    return old;
+  end if;
+
+  if tg_op = 'UPDATE' then
+    update public.entities entity_ref
+    set schema_id = page_schema_id,
+        slug = 'page:' || new.slug,
+        title = new.title,
+        subtitle = new.subtitle,
+        summary = new.description,
+        published = new.published,
+        sort_at = new.updated_at,
+        data = jsonb_build_object(
+          'slug', new.slug,
+          'props', new.props
+        ),
+        updated_at = now()
+    where entity_ref.schema_id = page_schema_id
+      and entity_ref.slug = 'page:' || old.slug;
+
+    if found then
+      return new;
+    end if;
+  end if;
+
+  insert into public.entities (
+    schema_id,
+    slug,
+    title,
+    subtitle,
+    summary,
+    published,
+    sort_at,
+    data,
+    created_at,
+    updated_at
+  )
+  values (
+    page_schema_id,
+    'page:' || new.slug,
+    new.title,
+    new.subtitle,
+    new.description,
+    new.published,
+    new.updated_at,
+    jsonb_build_object(
+      'slug', new.slug,
+      'props', new.props
+    ),
+    new.created_at,
+    new.updated_at
+  )
+  on conflict (slug) do update
+  set schema_id = excluded.schema_id,
+      title = excluded.title,
+      subtitle = excluded.subtitle,
+      summary = excluded.summary,
+      published = excluded.published,
+      sort_at = excluded.sort_at,
+      data = excluded.data,
+      updated_at = excluded.updated_at;
+
+  return new;
+end;
+$$;
+
+revoke all on function private.sync_page_entity_bridge() from public;
+
+drop index if exists public.entities_schema_sort_at_idx;
+drop index if exists public.entities_type_idx;
+drop index if exists public.entity_relations_schema_from_sort_idx;
+drop index if exists public.entity_relations_schema_from_slot_sort_idx;
+drop index if exists public.entity_relations_schema_to_slot_sort_idx;


### PR DESCRIPTION
## Summary

- Adds `qa:schema-mirror-removal-readiness` to block direct runtime/script dependencies on content-row mirror identity columns.
- Adds a non-destructive migration that creates schema_id composite indexes and rewrites the page shadow bridge to use `schema_id` instead of content-row `schema_key`/`entity_type`.
- Updates content graph docs to separate `entity_schemas.schema_key` as the stable registry key from legacy content-row mirrors.

## Supabase Impact

Migration included but not applied in this PR run: `20260511000063_prepare_schema_mirror_removal.sql`. It adds indexes, replaces one trigger function, and drops superseded indexes. It does not drop any columns or data. Production application still needs maintainer approval.

## Verification

- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run qa:schema-mirror-removal-readiness`
- `pnpm run qa:cms-db-first-loaders`
- `pnpm run qa:schema-semantic-identity`
- `pnpm run qa:content-graph`
- `pnpm run qa:graph-primary-seed-writes`
- `pnpm run qa:legacy-media-table-readiness`
- `git diff --check`

Closes #149