### PR TITLE
Drop unused schema-id preparation indexes

### DIFF
--- a/supabase/migrations/20260512000064_drop_unused_schema_id_prep_indexes.sql
+++ b/supabase/migrations/20260512000064_drop_unused_schema_id_prep_indexes.sql
@@ -1,0 +1,11 @@
+-- Bremen - drop unused schema-id preparation indexes.
+--
+-- The schema mirror preparation migration added four replacement composite
+-- indexes. Production QA used the from-entity relation indexes, but these two
+-- stayed unused and triggered Supabase advisor INFO findings.
+--
+-- Keep this migration limited to reversible index cleanup. It does not drop
+-- data, tables, columns, constraints, policies, or RLS.
+
+drop index if exists public.entities_schema_id_sort_at_idx;
+drop index if exists public.entity_relations_schema_id_to_slot_sort_idx;


### PR DESCRIPTION
## Summary

- Drops the two schema-id preparation indexes that stayed unused after production QA.
- Keeps the schema-id relation indexes that were actually scanned.
- This is index-only advisor hygiene; no data, columns, tables, policies, or RLS are changed.

## Supabase Impact

Migration already applied to production via guarded MCP after reading the migration from disk: `20260512000064_drop_unused_schema_id_prep_indexes.sql`.

Performance advisor is clean after the migration. Security advisor still reports only the known leaked-password-protection WARN, which requires Supabase Pro.

## Verification

- `pnpm run qa:schema-mirror-removal-readiness`
- `pnpm run qa:schema-semantic-identity`
- `pnpm run qa:content-graph`
- `git diff --check`
- Supabase catalog confirms only used schema-id indexes remain
- Supabase performance advisor: no lints

Closes #151