### PR TITLE
Drop content-row schema mirror columns

### DIFF
--- a/app/ponix/entities/actions.ts
+++ b/app/ponix/entities/actions.ts
@@ -22,9 +22,6 @@ import type { Database, Json } from "@/lib/supabase/types"
 type EntityUpdate = Database["public"]["Tables"]["entities"]["Update"]
 type EntityInsert = Database["public"]["Tables"]["entities"]["Insert"]
 type EntityRow = Database["public"]["Tables"]["entities"]["Row"]
-type SchemaDerivedEntityInsert = Omit<EntityInsert, "entity_type" | "schema_key"> & {
-  schema_id: string
-}
 
 type ActionResult =
   | {
@@ -415,7 +412,7 @@ export async function createCmsEntityAction(formData: FormData) {
 
   const fields = editableEntityFieldsForSchema(schema)
   const data: CmsJsonObject = {}
-  const insert: SchemaDerivedEntityInsert = {
+  const insert: EntityInsert = {
     data,
     owner_member_id: admin.id,
     published: false,
@@ -470,8 +467,8 @@ export async function createCmsEntityAction(formData: FormData) {
   const supabase = await createClient()
   const { data: created, error: insertError } = await supabase
     .from("entities")
-    // The DB trigger derives `entity_type` and `schema_key` from `schema_id`.
-    .insert(insert as EntityInsert)
+    // The DB trigger validates schema_id against the registered schema kind.
+    .insert(insert)
     .select("*")
     .single()
 

--- a/docs/content-graph.md
+++ b/docs/content-graph.md
@@ -146,32 +146,24 @@ entity_schemas
 
 entities
 - shared identity and display columns
-- required schema_id, with schema_key kept as a compatibility mirror
+- required schema_id
 - flexible data jsonb
 
 entity_relations
 - ordered links between entities
-- required schema_id, with schema_key kept as a compatibility mirror
+- required schema_id
 - slot, relation_type, sort_order
 - relation props as relation-specific data
 ```
 
-For now, `entities.schema_key` and `entity_relations.schema_key` remain public
-compatibility keys. The canonical DB reference is now `schema_id`, and the
-schema registry trigger keeps `schema_id` and `schema_key` synchronized.
-`entity_schemas.semantic_kind` is the broad identity that should replace new
-direct branching on `entities.entity_type`. The DB schema resolver now also
-syncs `entities.entity_type` from `entity_schemas.semantic_kind`, so
-`entity_type` should be treated as a compatibility mirror rather than an
-independent authoring field.
-Do not remove the text `schema_key` fields until all loaders, CMS forms,
-migrations, and production data have moved to schema IDs.
-
-Issue #149 tracks the removal preparation for those compatibility mirrors.
 `entity_schemas.schema_key` is not legacy; it remains the stable, human-readable
-registry key. The fields under review are only the duplicated content-row mirror
-columns: `entities.schema_key`, `entities.entity_type`,
-`entity_relations.schema_key`, and `sections.schema_key`. Run
+registry key. Content rows use `schema_id` as the canonical DB reference, and
+runtime/CMS code derives semantic labels from `entity_schemas.semantic_kind`
+instead of content-row mirrors.
+
+Issue #153 removed the duplicated content-row mirror columns:
+`entities.schema_key`, `entities.entity_type`, `entity_relations.schema_key`,
+and `sections.schema_key`. Run
 `pnpm run qa:schema-mirror-removal-readiness` after touching CMS loaders,
 seed/apply scripts, or graph migrations.
 
@@ -184,8 +176,7 @@ Use `sections` columns for section identity:
 
 - `key`
 - `section_type`
-- `schema_id` (canonical schema reference)
-- `schema_key` (compatibility mirror until the final drop migration)
+- `schema_id`
 - `eyebrow`
 - `title`
 - `subtitle`
@@ -203,10 +194,7 @@ Use `sections.props` for renderer-level copy and behavior:
 
 Use `entities` columns for shared display identity:
 
-- `schema_id` (canonical schema reference)
-- `entity_type` (compatibility mirror; prefer `entity_schemas.semantic_kind` for
-  new CMS/runtime logic; not exposed as a CMS editor field)
-- `schema_key` (compatibility mirror)
+- `schema_id`
 - `slug`
 - `title`
 - `subtitle`

--- a/docs/supabase-setup.md
+++ b/docs/supabase-setup.md
@@ -171,10 +171,10 @@ Safe pattern:
 
 1. Add or update a versioned `schema_key`, such as `video/youtube/v1`.
 2. Keep existing schema keys active until all rows and renderers have migrated.
-3. Keep text `schema_key` compatibility columns until all persisted rows and
-   historical maintenance paths have a schema-id-only path. PONIX create forms
-   should submit `schema_id`; server code may still display stable schema keys
-   for human-readable routing and diagnostics.
+3. PONIX create forms should submit `schema_id`. Server code may still display
+   `entity_schemas.schema_key` for human-readable routing and diagnostics, but
+   content rows no longer carry duplicated `schema_key` or `entity_type`
+   mirrors.
 4. Keep renderer code reviewed in the app. DB rows may store a `renderer_key`,
    but must not define executable React behavior.
 5. Apply production schema registry migrations only after review.

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -70,12 +70,10 @@ export type Database = {
         Row: {
           created_at: string
           data: Json
-          entity_type: string
           id: string
           owner_member_id: string | null
           published: boolean
           schema_id: string
-          schema_key: string
           slug: string | null
           sort_at: string
           subtitle: string | null
@@ -87,12 +85,10 @@ export type Database = {
         Insert: {
           created_at?: string
           data?: Json
-          entity_type: string
           id?: string
           owner_member_id?: string | null
           published?: boolean
           schema_id: string
-          schema_key?: string
           slug?: string | null
           sort_at?: string
           subtitle?: string | null
@@ -104,12 +100,10 @@ export type Database = {
         Update: {
           created_at?: string
           data?: Json
-          entity_type?: string
           id?: string
           owner_member_id?: string | null
           published?: boolean
           schema_id?: string
-          schema_key?: string
           slug?: string | null
           sort_at?: string
           subtitle?: string | null
@@ -144,7 +138,6 @@ export type Database = {
           props: Json
           relation_type: string
           schema_id: string
-          schema_key: string
           slot: string
           sort_order: number
           to_entity_id: string
@@ -158,7 +151,6 @@ export type Database = {
           props?: Json
           relation_type: string
           schema_id: string
-          schema_key?: string
           slot?: string
           sort_order?: number
           to_entity_id: string
@@ -172,7 +164,6 @@ export type Database = {
           props?: Json
           relation_type?: string
           schema_id?: string
-          schema_key?: string
           slot?: string
           sort_order?: number
           to_entity_id?: string
@@ -388,7 +379,6 @@ export type Database = {
           props: Json
           published: boolean
           schema_id: string
-          schema_key: string
           section_type: string
           subtitle: string | null
           title: string | null
@@ -403,7 +393,6 @@ export type Database = {
           props?: Json
           published?: boolean
           schema_id: string
-          schema_key?: string
           section_type: string
           subtitle?: string | null
           title?: string | null
@@ -418,7 +407,6 @@ export type Database = {
           props?: Json
           published?: boolean
           schema_id?: string
-          schema_key?: string
           section_type?: string
           subtitle?: string | null
           title?: string | null

--- a/scripts/qa-content-graph-integrity.mjs
+++ b/scripts/qa-content-graph-integrity.mjs
@@ -354,7 +354,6 @@ async function checkPageComposition(supabase, page, schemas) {
               to_entity_id,
               toEntity:entities!entity_relations_to_entity_id_fkey(
                 id,
-                schema_key,
                 schema_id,
                 slug,
                 title,

--- a/scripts/qa-schema-semantic-identity.mjs
+++ b/scripts/qa-schema-semantic-identity.mjs
@@ -67,20 +67,19 @@ async function main() {
   const entities = requireOk(
     await supabase
       .from("entities")
-      .select("id, schema_id, schema_key, entity_type, slug, title")
-      .order("schema_key", { ascending: true }),
+      .select("id, schema_id, slug, title")
+      .order("title", { ascending: true }),
     "entities semantic identity",
   )
   const sections = requireOk(
     await supabase
       .from("sections")
-      .select("id, schema_id, schema_key, key, title")
+      .select("id, schema_id, key, title")
       .order("key", { ascending: true }),
     "sections schema identity",
   )
 
   const schemaById = new Map(schemas.map((schema) => [schema.id, schema]))
-  const schemaByKey = new Map(schemas.map((schema) => [schema.schema_key, schema]))
   const failures = []
 
   for (const schema of schemas) {
@@ -94,47 +93,42 @@ async function main() {
   }
 
   for (const entity of entities) {
-    const schema =
-      (entity.schema_id ? schemaById.get(entity.schema_id) : null) ??
-      schemaByKey.get(entity.schema_key)
+    const schema = entity.schema_id ? schemaById.get(entity.schema_id) : null
 
     if (!schema) {
       failures.push(
         issue("Entity cannot resolve an active schema", {
           entityId: entity.id,
           schemaId: entity.schema_id,
-          schemaKey: entity.schema_key,
-          entityType: entity.entity_type,
+          slug: entity.slug,
+          title: entity.title,
         }),
       )
       continue
     }
 
-    if (entity.entity_type !== schema.semantic_kind) {
+    if (!["entity", "page", "section"].includes(schema.kind)) {
       failures.push(
-        issue("Entity type differs from schema semantic_kind", {
+        issue("Entity schema has unsupported kind", {
           entityId: entity.id,
           slug: entity.slug,
           title: entity.title,
-          schemaKey: entity.schema_key,
-          entityType: entity.entity_type,
-          semanticKind: schema.semantic_kind,
+          schemaId: entity.schema_id,
+          schemaKey: schema.schema_key,
+          schemaKind: schema.kind,
         }),
       )
     }
   }
 
   for (const section of sections) {
-    const schema =
-      (section.schema_id ? schemaById.get(section.schema_id) : null) ??
-      schemaByKey.get(section.schema_key)
+    const schema = section.schema_id ? schemaById.get(section.schema_id) : null
 
     if (!schema) {
       failures.push(
         issue("Section cannot resolve an active schema", {
           sectionId: section.id,
           schemaId: section.schema_id,
-          schemaKey: section.schema_key,
           key: section.key,
         }),
       )
@@ -146,21 +140,9 @@ async function main() {
         issue("Section schema has non-section kind", {
           sectionId: section.id,
           schemaId: section.schema_id,
-          schemaKey: section.schema_key,
+          schemaKey: schema.schema_key,
           key: section.key,
           schemaKind: schema.kind,
-        }),
-      )
-    }
-
-    if (section.schema_key !== schema.schema_key) {
-      failures.push(
-        issue("Section schema_key differs from schema_id target", {
-          sectionId: section.id,
-          schemaId: section.schema_id,
-          schemaKey: section.schema_key,
-          resolvedSchemaKey: schema.schema_key,
-          key: section.key,
         }),
       )
     }

--- a/supabase/migrations/20260512000065_drop_content_schema_mirror_columns.sql
+++ b/supabase/migrations/20260512000065_drop_content_schema_mirror_columns.sql
@@ -1,0 +1,92 @@
+-- Bremen - drop content-row schema mirror columns.
+--
+-- DESTRUCTIVE: this drops duplicated compatibility columns from content rows:
+-- - public.entities.schema_key
+-- - public.entities.entity_type
+-- - public.entity_relations.schema_key
+-- - public.sections.schema_key
+--
+-- Keep public.entity_schemas.schema_key. It remains the stable, human-readable
+-- registry key used to resolve schema ids and CMS metadata.
+
+create or replace function private.resolve_content_schema_id()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, private
+as $$
+declare
+  expected_kinds text[];
+  resolved_schema record;
+begin
+  if tg_table_name = 'entities' then
+    expected_kinds := array['entity', 'page', 'section'];
+  elsif tg_table_name = 'entity_relations' then
+    expected_kinds := array['relation'];
+  elsif tg_table_name = 'sections' then
+    expected_kinds := array['section'];
+  else
+    raise exception 'resolve_content_schema_id is not configured for table %', tg_table_name;
+  end if;
+
+  if new.schema_id is null then
+    raise exception 'schema_id is required for %', tg_table_name;
+  end if;
+
+  select id, schema_key, kind, active
+  into resolved_schema
+  from public.entity_schemas
+  where id = new.schema_id;
+
+  if not found then
+    raise exception 'Unknown schema id %', new.schema_id;
+  end if;
+
+  if not (resolved_schema.kind = any(expected_kinds)) then
+    raise exception 'Schema % has kind %, expected one of %',
+      resolved_schema.schema_key,
+      resolved_schema.kind,
+      array_to_string(expected_kinds, ', ');
+  end if;
+
+  if resolved_schema.active is not true then
+    raise exception 'Schema % is not active', resolved_schema.schema_key;
+  end if;
+
+  return new;
+end;
+$$;
+
+revoke all on function private.resolve_content_schema_id() from public;
+
+drop trigger if exists entities_resolve_schema_id on public.entities;
+create trigger entities_resolve_schema_id
+  before insert or update of schema_id on public.entities
+  for each row
+  execute function private.resolve_content_schema_id();
+
+drop trigger if exists entity_relations_resolve_schema_id on public.entity_relations;
+create trigger entity_relations_resolve_schema_id
+  before insert or update of schema_id on public.entity_relations
+  for each row
+  execute function private.resolve_content_schema_id();
+
+drop trigger if exists sections_resolve_schema_id on public.sections;
+create trigger sections_resolve_schema_id
+  before insert or update of schema_id on public.sections
+  for each row
+  execute function private.resolve_content_schema_id();
+
+alter table public.entities
+  drop constraint if exists entities_entity_type_check,
+  drop constraint if exists entities_schema_key_check,
+  drop column if exists entity_type,
+  drop column if exists schema_key;
+
+alter table public.entity_relations
+  drop constraint if exists entity_relations_schema_key_check,
+  drop column if exists schema_key;
+
+alter table public.sections
+  drop constraint if exists sections_schema_key_check,
+  drop column if exists schema_key;


### PR DESCRIPTION
Fixes #153\n\n## Summary\n- Drop duplicated content-row schema mirrors from entities, entity_relations, and sections.\n- Keep entity_schemas.schema_key as the stable registry key and validate content rows through schema_id.\n- Update Supabase generated types, PONIX entity create action, docs, and QA scripts for schema-id-only content rows.\n\n## Production DB\n- Applied Supabase migration: drop_content_schema_mirror_columns.\n- Verified content rows now expose schema_id only; entity_schemas.schema_key remains.\n- Verified resolve_content_schema_id triggers now run on INSERT or UPDATE OF schema_id.\n- Performance advisor clean; security advisor only reports existing leaked-password-protection warning.\n\n## Verification\n- pnpm exec tsc --noEmit\n- pnpm run lint\n- pnpm run build\n- pnpm run qa:cms-schema-registry\n- pnpm run qa:schema-semantic-identity\n- pnpm run qa:content-graph\n- pnpm run qa:cms-db-first-loaders\n- pnpm run qa:schema-mirror-removal-readiness\n- pnpm run qa:graph-primary-seed-writes\n- pnpm run qa:legacy-media-table-readiness\n\n## Note\nSupabase CLI type generation failed because the GitHub/CLI account lacks that endpoint privilege, but Supabase MCP generate_typescript_types succeeded and the local types match the removed columns.