### PR TITLE
Move PONIX page and section authoring to entities

### DIFF
--- a/app/ponix/_components/cms-page-form.tsx
+++ b/app/ponix/_components/cms-page-form.tsx
@@ -129,8 +129,7 @@ export async function CmsPageEditorPage({
 
             <div className="flex flex-col gap-3 rounded-md border bg-card/95 p-4 shadow-xl sm:flex-row sm:items-center sm:justify-between">
               <p className="text-sm text-muted-foreground">
-                Saving updates this page row only. Section composition stays
-                untouched.
+                저장하면 페이지 제목, 설명, 공개 상태만 바뀝니다. 섹션 구성은 그대로 둡니다.
               </p>
               <div className="flex gap-2">
                 <Button asChild type="button" variant="outline">

--- a/app/ponix/_components/cms-section-create-form.tsx
+++ b/app/ponix/_components/cms-section-create-form.tsx
@@ -126,8 +126,7 @@ export function CmsSectionCreatePage({
 
           <div className="flex flex-col gap-3 rounded-md border bg-card/95 p-4 shadow-xl sm:flex-row sm:items-center sm:justify-between">
             <p className="text-sm text-muted-foreground">
-              Creation inserts one section row only. Page placement is a
-              separate relation step.
+              섹션을 만든 뒤 페이지에 배치하고 필요한 데이터를 연결합니다.
             </p>
             <div className="flex gap-2">
               <Button asChild type="button" variant="outline">

--- a/app/ponix/_components/cms-section-form.tsx
+++ b/app/ponix/_components/cms-section-form.tsx
@@ -142,7 +142,7 @@ export async function CmsSectionEditorPage({
 
               <div className="flex flex-col gap-3 rounded-md border bg-card/95 p-4 shadow-xl sm:flex-row sm:items-center sm:justify-between">
                 <p className="text-sm text-muted-foreground">
-                  Saving updates this section row only. Relations and entities stay untouched.
+                  저장하면 이 섹션의 문구와 설정만 바뀝니다. 연결된 데이터는 그대로 둡니다.
                 </p>
                 <div className="flex gap-2">
                   <Button asChild type="button" variant="outline">

--- a/app/ponix/pages/[id]/page.tsx
+++ b/app/ponix/pages/[id]/page.tsx
@@ -40,7 +40,7 @@ export default async function PonixPageRecordPage({
     loadCmsPageDetail(id),
     loadCmsPageRelations(id),
     loadCmsRelationEditorOptions({ includeEntities: false }),
-    loadCmsAuditEventsForTarget({ targetTable: "pages", targetId: id }),
+    loadCmsAuditEventsForTarget({ targetTable: "entities", targetId: id }),
     searchParams,
   ])
   const mutation = relationMutationState(search)

--- a/app/ponix/pages/actions.ts
+++ b/app/ponix/pages/actions.ts
@@ -16,7 +16,7 @@ import { PUBLIC_CONTENT_CACHE_TAG } from "@/lib/data/public-cache"
 import { createClient } from "@/lib/supabase/server"
 import type { Database, Json } from "@/lib/supabase/types"
 
-type PageUpdate = Database["public"]["Tables"]["pages"]["Update"]
+type EntityUpdate = Database["public"]["Tables"]["entities"]["Update"]
 
 type ParsedValue =
   | {
@@ -150,6 +150,23 @@ function updatePropsValue(
   props[field.key] = parsed.value
 }
 
+function pageSlugFromEntity({
+  slug,
+  data,
+}: {
+  slug: string | null
+  data: Json
+}) {
+  const props = jsonObject(data)
+  const dataSlug = props.slug
+
+  if (slug?.startsWith("page:")) {
+    return slug.slice("page:".length)
+  }
+
+  return typeof dataSlug === "string" && dataSlug.trim() ? dataSlug : undefined
+}
+
 export async function updateCmsPageAction(formData: FormData) {
   const pageId = stringField(formData, "page_id")
 
@@ -170,22 +187,30 @@ export async function updateCmsPageAction(formData: FormData) {
     })
   }
 
+  if (!schema.schemaId) {
+    redirectWithParams(editPath, {
+      error: "The page editor schema is missing a database id.",
+    })
+  }
+
   const supabase = await createClient()
-  const { data: page, error: loadError } = await supabase
-    .from("pages")
+  const { data: pageEntity, error: loadError } = await supabase
+    .from("entities")
     .select("*")
     .eq("id", pageId)
+    .eq("schema_id", schema.schemaId)
     .maybeSingle()
 
-  if (loadError || !page) {
+  if (loadError || !pageEntity) {
     redirectWithParams(editPath, {
       error: "Page not found.",
     })
   }
 
   const fields = editablePageFieldsForSchema(schema)
-  const props = jsonObject(page.props)
-  const update: PageUpdate = {}
+  const data = jsonObject(pageEntity.data)
+  const props = jsonObject((data.props ?? null) as Json)
+  const update: EntityUpdate = {}
 
   for (const field of fields) {
     const parsed = parseFieldValue(formData, field)
@@ -214,16 +239,20 @@ export async function updateCmsPageAction(formData: FormData) {
     }
 
     if (field.key === "description") {
-      update.description = parsed.value === null ? null : String(parsed.value)
+      update.summary = parsed.value === null ? null : String(parsed.value)
     }
   }
 
-  update.props = props
+  update.data = {
+    ...data,
+    props,
+  }
 
   const { error: updateError } = await supabase
-    .from("pages")
+    .from("entities")
     .update(update)
     .eq("id", pageId)
+    .eq("schema_id", schema.schemaId)
 
   if (updateError) {
     redirectWithParams(editPath, {
@@ -231,7 +260,10 @@ export async function updateCmsPageAction(formData: FormData) {
     })
   }
 
-  revalidatePageSurfaces(pageId, page.slug)
+  revalidatePageSurfaces(
+    pageId,
+    pageSlugFromEntity({ slug: pageEntity.slug, data: pageEntity.data }),
+  )
 
   redirectWithParams(redirectTo, {
     saved: "page",

--- a/app/ponix/relations/actions.ts
+++ b/app/ponix/relations/actions.ts
@@ -14,23 +14,16 @@ type EntityRelationUpdate =
   Database["public"]["Tables"]["entity_relations"]["Update"]
 type ServerSupabaseClient = Awaited<ReturnType<typeof createClient>>
 
-type SourceEntityLink = {
-  slug: string | null
-}
-
 type PageSectionGraphRelation = {
   id: string
   from_entity_id: string
   to_entity_id: string
-  fromEntity?: SourceEntityLink | null
-  toEntity?: SourceEntityLink | null
 }
 
 type SectionEntityGraphRelation = {
   id: string
   from_entity_id: string
   to_entity_id: string
-  fromEntity?: SourceEntityLink | null
 }
 
 type ActionResult =
@@ -158,14 +151,6 @@ function shadowSlug(sourceTable: "pages" | "sections", sourceKey: string) {
   return `${sourceTable === "pages" ? PAGE_SHADOW_PREFIX : SECTION_SHADOW_PREFIX}${sourceKey}`
 }
 
-function sourceKeyFromLink(
-  link: SourceEntityLink | null | undefined,
-  sourceTable: "pages" | "sections",
-) {
-  const prefix = sourceTable === "pages" ? PAGE_SHADOW_PREFIX : SECTION_SHADOW_PREFIX
-  return link?.slug?.startsWith(prefix) ? link.slug.slice(prefix.length) : null
-}
-
 async function loadSchemaIdByKey({
   supabase,
   schemaKey,
@@ -223,6 +208,40 @@ async function loadShadowEntityId({
   sourceId: string
   label: string
 }) {
+  const { data: directEntity, error: directEntityError } = await supabase
+    .from("entities")
+    .select("id, schema_id")
+    .eq("id", sourceId)
+    .maybeSingle()
+
+  if (directEntityError) {
+    throw new Error(directEntityError.message)
+  }
+
+  if (directEntity) {
+    const validSchema =
+      sourceTable === "pages"
+        ? directEntity.schema_id ===
+          (await loadSchemaIdByKey({
+            supabase,
+            schemaKey: PAGE_ENTITY_SCHEMA_KEY,
+            label: "Page",
+          }))
+        : (
+            await loadSchemaIdsByKind({
+              supabase,
+              kind: "section",
+              label: "Section",
+            })
+          ).includes(directEntity.schema_id)
+
+    if (!validSchema) {
+      throw new Error(`${label} graph entity is not a ${label.toLowerCase()}.`)
+    }
+
+    return directEntity.id
+  }
+
   const source =
     sourceTable === "pages"
       ? await supabase
@@ -279,34 +298,6 @@ async function loadShadowEntityId({
   return data.id
 }
 
-async function loadPageIdBySlug(supabase: ServerSupabaseClient, slug: string) {
-  const { data, error } = await supabase
-    .from("pages")
-    .select("id")
-    .eq("slug", slug)
-    .maybeSingle()
-
-  if (error || !data?.id) {
-    throw new Error(error?.message ?? "Page source record not found.")
-  }
-
-  return data.id
-}
-
-async function loadSectionIdByKey(supabase: ServerSupabaseClient, key: string) {
-  const { data, error } = await supabase
-    .from("sections")
-    .select("id")
-    .eq("key", key)
-    .maybeSingle()
-
-  if (error || !data?.id) {
-    throw new Error(error?.message ?? "Section source record not found.")
-  }
-
-  return data.id
-}
-
 async function loadPageSectionGraphRelation(
   supabase: ServerSupabaseClient,
   graphRelationId: string,
@@ -322,9 +313,7 @@ async function loadPageSectionGraphRelation(
       `
         id,
         from_entity_id,
-        to_entity_id,
-        fromEntity:entities!entity_relations_from_entity_id_fkey(slug),
-        toEntity:entities!entity_relations_to_entity_id_fkey(slug)
+        to_entity_id
       `,
     )
     .eq("id", graphRelationId)
@@ -332,22 +321,15 @@ async function loadPageSectionGraphRelation(
     .maybeSingle()
 
   const relation = data as unknown as PageSectionGraphRelation | null
-  const pageSlug = sourceKeyFromLink(relation?.fromEntity, "pages")
-  const sectionKey = sourceKeyFromLink(relation?.toEntity, "sections")
 
-  if (error || !relation || !pageSlug || !sectionKey) {
+  if (error || !relation) {
     throw new Error(error?.message ?? "Page section graph relation not found.")
   }
 
-  const [pageId, sectionId] = await Promise.all([
-    loadPageIdBySlug(supabase, pageSlug),
-    loadSectionIdByKey(supabase, sectionKey),
-  ])
-
   return {
     ...relation,
-    pageId,
-    sectionId,
+    pageId: relation.from_entity_id,
+    sectionId: relation.to_entity_id,
   }
 }
 
@@ -366,8 +348,7 @@ async function loadSectionEntityGraphRelation(
       `
         id,
         from_entity_id,
-        to_entity_id,
-        fromEntity:entities!entity_relations_from_entity_id_fkey(slug)
+        to_entity_id
       `,
     )
     .eq("id", graphRelationId)
@@ -375,17 +356,14 @@ async function loadSectionEntityGraphRelation(
     .maybeSingle()
 
   const relation = data as unknown as SectionEntityGraphRelation | null
-  const sectionKey = sourceKeyFromLink(relation?.fromEntity, "sections")
 
-  if (error || !relation || !sectionKey) {
+  if (error || !relation) {
     throw new Error(error?.message ?? "Section graph relation not found.")
   }
 
-  const sectionId = await loadSectionIdByKey(supabase, sectionKey)
-
   return {
     ...relation,
-    sectionId,
+    sectionId: relation.from_entity_id,
     entityId: relation.to_entity_id,
   }
 }

--- a/app/ponix/sections/[id]/page.tsx
+++ b/app/ponix/sections/[id]/page.tsx
@@ -43,7 +43,7 @@ export default async function PonixSectionRecordPage({
     loadCmsSectionDetail(id),
     loadCmsSectionRelations(id),
     loadCmsRelationEditorOptions(),
-    loadCmsAuditEventsForTarget({ targetTable: "sections", targetId: id }),
+    loadCmsAuditEventsForTarget({ targetTable: "entities", targetId: id }),
     searchParams,
   ])
   const mutation = relationMutationState(search)

--- a/app/ponix/sections/actions.ts
+++ b/app/ponix/sections/actions.ts
@@ -20,8 +20,8 @@ import { PUBLIC_CONTENT_CACHE_TAG } from "@/lib/data/public-cache"
 import { createClient } from "@/lib/supabase/server"
 import type { Database, Json } from "@/lib/supabase/types"
 
-type SectionUpdate = Database["public"]["Tables"]["sections"]["Update"]
-type SectionInsert = Database["public"]["Tables"]["sections"]["Insert"]
+type EntityInsert = Database["public"]["Tables"]["entities"]["Insert"]
+type EntityUpdate = Database["public"]["Tables"]["entities"]["Update"]
 
 type ParsedValue =
   | {
@@ -255,6 +255,58 @@ function updatePropsValue(
   props[field.key] = parsed.value
 }
 
+async function loadSectionSchemaIds(supabase: Awaited<ReturnType<typeof createClient>>) {
+  const { data, error } = await supabase
+    .from("entity_schemas")
+    .select("id")
+    .eq("kind", "section")
+    .eq("active", true)
+
+  const ids = (data ?? []).map((schema) => schema.id).filter(Boolean)
+  if (error || !ids.length) {
+    throw new Error(error?.message ?? "No active section schemas are registered.")
+  }
+
+  return ids
+}
+
+async function ensureSectionKeyAvailable({
+  supabase,
+  key,
+  currentEntityId,
+}: {
+  supabase: Awaited<ReturnType<typeof createClient>>
+  key: string
+  currentEntityId?: string
+}) {
+  const sectionSchemaIds = await loadSectionSchemaIds(supabase)
+  const { data, error } = await supabase
+    .from("entities")
+    .select("id, slug, data")
+    .in("schema_id", sectionSchemaIds)
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  const duplicate = (data ?? []).find((entity) => {
+    if (entity.id === currentEntityId) return false
+    const entityData = jsonObject(entity.data)
+    const entityKey =
+      entity.slug?.startsWith("section:")
+        ? entity.slug.slice("section:".length)
+        : typeof entityData.key === "string"
+          ? entityData.key
+          : null
+
+    return entityKey === key
+  })
+
+  if (duplicate) {
+    throw new Error("Section key is already in use.")
+  }
+}
+
 export async function createCmsSectionAction(formData: FormData) {
   const admin = await requireCmsAdmin("/ponix/sections/new")
   const schemaId = stringField(formData, "schema_id")
@@ -278,13 +330,19 @@ export async function createCmsSectionAction(formData: FormData) {
 
   const fields = editableSectionFieldsForSchema(schema)
   const props: CmsJsonObject = {}
-  const insert: SectionInsert = {
-    key: parseSectionKey(formData, createPath),
-    owner_member_id: admin.id,
+  const sectionKey = parseSectionKey(formData, createPath)
+  const data: CmsJsonObject = {
+    key: sectionKey,
+    section_type: sectionType,
     props,
+  }
+  const insert: EntityInsert = {
+    owner_member_id: admin.id,
     published: false,
     schema_id: schemaId,
-    section_type: sectionType,
+    slug: null,
+    title: sectionKey,
+    data,
   }
 
   for (const field of fields) {
@@ -306,11 +364,11 @@ export async function createCmsSectionAction(formData: FormData) {
     }
 
     if (field.key === "eyebrow") {
-      insert.eyebrow = parsed.value === null ? null : String(parsed.value)
+      data.eyebrow = parsed.value === null ? null : String(parsed.value)
     }
 
     if (field.key === "title") {
-      insert.title = parsed.value === null ? null : String(parsed.value)
+      insert.title = parsed.value === null ? sectionKey : String(parsed.value)
     }
 
     if (field.key === "subtitle") {
@@ -319,8 +377,19 @@ export async function createCmsSectionAction(formData: FormData) {
   }
 
   const supabase = await createClient()
+  try {
+    await ensureSectionKeyAvailable({ supabase, key: sectionKey })
+  } catch (error) {
+    redirectWithParams(createPath, {
+      error:
+        error instanceof Error
+          ? error.message
+          : "Section key availability check failed.",
+    })
+  }
+
   const { data: created, error: insertError } = await supabase
-    .from("sections")
+    .from("entities")
     .insert(insert)
     .select("*")
     .single()
@@ -355,7 +424,7 @@ export async function updateCmsSectionAction(formData: FormData) {
 
   const supabase = await createClient()
   const { data: section, error: loadError } = await supabase
-    .from("sections")
+    .from("entities")
     .select("*")
     .eq("id", sectionId)
     .maybeSingle()
@@ -374,8 +443,24 @@ export async function updateCmsSectionAction(formData: FormData) {
   }
 
   const fields = editableSectionFieldsForSchema(schema)
-  const props = jsonObject(section.props)
-  const update: SectionUpdate = {}
+  const data = jsonObject(section.data)
+  const props = jsonObject((data.props ?? null) as Json)
+  const sectionKey =
+    section.slug?.startsWith("section:")
+      ? section.slug.slice("section:".length)
+      : typeof data.key === "string" && data.key.trim()
+        ? data.key
+        : section.id
+  const sectionType =
+    typeof data.section_type === "string" && data.section_type.trim()
+      ? data.section_type
+      : sectionTypeFromSchemaKey(schema.schemaKey)
+  if (!sectionType) {
+    redirectWithParams(editPath, {
+      error: "This section schema has no registered renderer type.",
+    })
+  }
+  const update: EntityUpdate = {}
 
   for (const field of fields) {
     const parsed = parseFieldValue(formData, field)
@@ -396,11 +481,11 @@ export async function updateCmsSectionAction(formData: FormData) {
     }
 
     if (field.key === "eyebrow") {
-      update.eyebrow = parsed.value === null ? null : String(parsed.value)
+      data.eyebrow = parsed.value === null ? null : String(parsed.value)
     }
 
     if (field.key === "title") {
-      update.title = parsed.value === null ? null : String(parsed.value)
+      update.title = parsed.value === null ? sectionKey : String(parsed.value)
     }
 
     if (field.key === "subtitle") {
@@ -408,12 +493,18 @@ export async function updateCmsSectionAction(formData: FormData) {
     }
   }
 
-  update.props = props
+  update.data = {
+    ...data,
+    key: sectionKey,
+    section_type: sectionType,
+    props,
+  }
 
   const { error: updateError } = await supabase
-    .from("sections")
+    .from("entities")
     .update(update)
     .eq("id", sectionId)
+    .eq("schema_id", section.schema_id)
 
   if (updateError) {
     redirectWithParams(editPath, {

--- a/docs/content-graph.md
+++ b/docs/content-graph.md
@@ -9,8 +9,9 @@ entity_schemas
       -> entities
 ```
 
-`pages` and `sections` remain domain tables because they are routable and
-renderer-facing records. Ordered page/section composition is stored in
+`pages` and `sections` currently remain compatibility tables for historical
+page/section records, but PONIX authoring now treats their graph `entities` as
+the CMS-facing record ids. Ordered page/section composition is stored in
 `entity_relations`; the legacy `page_sections` and `section_entities` mirror
 tables have been removed.
 
@@ -45,9 +46,12 @@ Current PONIX contract:
   `entity_relations` for page-to-section and section-to-content composition.
   Content graph QA validates the graph directly instead of comparing against
   legacy mirrors.
-- CMS draft preview and composer paths still resolve authoring records from
-  `pages` and `sections` by page/section id so existing edit URLs, audit
-  targets, and admin permissions remain stable.
+- CMS page and section list/detail/edit paths use graph `entities.id` for page
+  and section records. Page fields are projected from the page entity; section
+  renderer identity and props are projected from section entity `data`.
+- CMS draft preview and composer paths accept page entity ids, then render from
+  the same `entity_relations` graph used by public pages. Legacy page ids remain
+  a transitional fallback only where explicitly retained.
 - CMS relation lists read page/section placement through `entity_relations`
   bridge rows, using relation `schema_id` values resolved from registered
   schema keys such as `relation/page-section/v1` and
@@ -77,15 +81,17 @@ Current PONIX contract:
 | Table | Purpose |
 | --- | --- |
 | `entity_schemas` | DB-backed schema registry for page, section, entity, and relation records. This is the long-term source for CMS form metadata. |
-| `pages` | Routable page records such as `home`, `performances`, `videos`, `photos`, `history`, and `site`. |
-| `sections` | Renderer blocks with `section_type`, copy, and renderer props. |
+| `pages` | Compatibility mirror for routable page records such as `home`, `performances`, `videos`, `photos`, `history`, and `site`. PONIX authoring should prefer the page entity. |
+| `sections` | Compatibility mirror for renderer blocks. PONIX authoring should prefer the section entity with renderer identity in `entities.data`. |
 | `entities` | Reusable content units such as videos, photos, stats, posts, history milestones, activities, nav items, and social links. |
 | `entity_relations` | Ordered page-to-section, section-to-entity, and domain relations such as performance to recording/photo/post. |
 | `members` | Domain-specific member/auth/profile table. This intentionally remains separate from generic entities. |
 
 ## Renderer Contract
 
-The app chooses a UI renderer from `sections.section_type`.
+The app chooses a UI renderer from graph section metadata. Entity-native
+sections store it in `entities.data.section_type`; legacy mirrored sections
+expose the same value through `sections.section_type`.
 
 Examples:
 
@@ -177,7 +183,19 @@ Renderer implementations remain in React code. Database schemas may name a
 
 ## Where Data Belongs
 
-Use `sections` columns for section identity:
+Legacy `sections` rows still expose these columns for compatibility, but new
+PONIX authoring should model section identity on the section entity:
+
+- `entities.schema_id`
+- `entities.title`
+- `entities.subtitle`
+- `entities.published`
+- `entities.data.key`
+- `entities.data.section_type`
+- `entities.data.eyebrow`
+- `entities.data.props`
+
+The compatibility `sections` columns are:
 
 - `key`
 - `section_type`
@@ -187,7 +205,8 @@ Use `sections` columns for section identity:
 - `subtitle`
 - `published`
 
-Use `sections.props` for renderer-level copy and behavior:
+Compatibility `sections.props` and entity-native `entities.data.props` carry
+renderer-level copy and behavior:
 
 - `body`
 - `href`

--- a/lib/cms/content.ts
+++ b/lib/cms/content.ts
@@ -35,6 +35,10 @@ const ENTITY_RELATION_SELECT = `
   fromEntity:entities!entity_relations_from_entity_id_fkey(id, slug, title, subtitle, summary, thumbnail_url, schema_id, data, published, sort_at),
   toEntity:entities!entity_relations_to_entity_id_fkey(id, slug, title, subtitle, summary, thumbnail_url, schema_id, data, published, sort_at)
 `
+const CMS_PAGE_ENTITY_SELECT =
+  "id, schema_id, slug, title, subtitle, summary, owner_member_id, published, data, created_at, updated_at"
+const CMS_SECTION_ENTITY_SELECT =
+  "id, schema_id, slug, title, subtitle, owner_member_id, published, data, created_at, updated_at"
 
 type SchemaSummary = {
   schemaKey: string
@@ -210,7 +214,7 @@ export type CmsEntityRelationContext = {
 export type CmsContentDetail =
   | {
       kind: "page"
-      table: "pages"
+      table: "entities"
       title: string
       subtitle: string | null
       published: boolean
@@ -219,7 +223,7 @@ export type CmsContentDetail =
     } & SchemaSummary
   | {
       kind: "section"
-      table: "sections"
+      table: "entities"
       title: string
       subtitle: string | null
       published: boolean
@@ -323,6 +327,94 @@ function entitySemanticKind(
   return schemaForEntity(entity, registry)?.semanticKind ?? "unregistered"
 }
 
+function isRecord(value: Json | unknown): value is Record<string, Json> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value)
+}
+
+function jsonObject(value: Json): Record<string, Json> {
+  return isRecord(value) ? { ...value } : {}
+}
+
+function jsonObjectField(value: Json, key: string): Record<string, Json> {
+  const fieldValue = jsonObject(value)[key]
+  return isRecord(fieldValue) ? { ...fieldValue } : {}
+}
+
+function stringValue(value: Json | unknown) {
+  return typeof value === "string" && value.trim() ? value : null
+}
+
+function pageRowFromEntity(
+  entity: Pick<
+    EntityRow,
+    | "id"
+    | "slug"
+    | "title"
+    | "subtitle"
+    | "summary"
+    | "owner_member_id"
+    | "published"
+    | "data"
+    | "created_at"
+    | "updated_at"
+  >,
+): PageRow | null {
+  const data = jsonObject(entity.data)
+  const slug = shadowKey(entity, "pages") ?? stringValue(data.slug)
+
+  if (!slug) return null
+
+  return {
+    id: entity.id,
+    slug,
+    title: entity.title,
+    subtitle: entity.subtitle,
+    description: entity.summary,
+    owner_member_id: entity.owner_member_id,
+    published: entity.published,
+    props: jsonObjectField(entity.data, "props"),
+    created_at: entity.created_at,
+    updated_at: entity.updated_at,
+  }
+}
+
+function sectionRowFromEntity(
+  entity: Pick<
+    EntityRow,
+    | "id"
+    | "schema_id"
+    | "slug"
+    | "title"
+    | "subtitle"
+    | "owner_member_id"
+    | "published"
+    | "data"
+    | "created_at"
+    | "updated_at"
+  >,
+): SectionRow | null {
+  const data = jsonObject(entity.data)
+  const key = shadowKey(entity, "sections") ?? stringValue(data.key)
+  const sectionType = stringValue(data.section_type)
+
+  if (!key || !sectionType) return null
+
+  return {
+    id: entity.id,
+    key,
+    section_type: sectionType,
+    schema_id: entity.schema_id,
+    eyebrow: stringValue(data.eyebrow),
+    title: entity.title,
+    subtitle: entity.subtitle,
+    owner_member_id: entity.owner_member_id,
+    published: entity.published,
+    props: jsonObjectField(entity.data, "props"),
+    created_at: entity.created_at,
+    updated_at: entity.updated_at,
+  }
+}
+
 async function entitySchemaOptions(): Promise<CmsEntitySchemaOption[]> {
   const schemas = await loadCmsSchemasByKind("entity")
   return schemas
@@ -373,10 +465,10 @@ function relationList<T>(
   }
 }
 
-function linkedPage(page: RawPageLink | null): CmsLinkedPage | null {
-  if (!page) {
-    return null
-  }
+function linkedPageFromEntity(entity: RawEntityLink | null): CmsLinkedPage | null {
+  const page = entity ? pageRowFromEntity(entityWithTimestamps(entity)) : null
+
+  if (!page) return null
 
   return {
     id: page.id,
@@ -386,13 +478,13 @@ function linkedPage(page: RawPageLink | null): CmsLinkedPage | null {
   }
 }
 
-function linkedSection(
-  section: RawSectionLink | null,
+function linkedSectionFromEntity(
+  entity: RawEntityLink | null,
   registry: SchemaRegistryMap,
 ): CmsLinkedSection | null {
-  if (!section) {
-    return null
-  }
+  const section = entity ? sectionRowFromEntity(entityWithTimestamps(entity)) : null
+
+  if (!section) return null
 
   return {
     ...sectionSchemaSummary(section, registry),
@@ -427,25 +519,27 @@ function linkedEntity(
   }
 }
 
+function entityWithTimestamps(entity: RawEntityLink) {
+  return {
+    ...entity,
+    owner_member_id: null,
+    created_at: "",
+    updated_at: "",
+  }
+}
+
 function shadowSlug(sourceTable: "pages" | "sections", sourceKey: string) {
   return `${sourceTable === "pages" ? PAGE_SHADOW_PREFIX : SECTION_SHADOW_PREFIX}${sourceKey}`
 }
 
-function shadowKey(entity: RawEntityLink | null, sourceTable: "pages" | "sections") {
+function shadowKey(
+  entity: Pick<EntityRow, "slug"> | RawEntityLink | null,
+  sourceTable: "pages" | "sections",
+) {
   const prefix = sourceTable === "pages" ? PAGE_SHADOW_PREFIX : SECTION_SHADOW_PREFIX
   return entity?.slug?.startsWith(prefix) ? entity.slug.slice(prefix.length) : null
 }
 
-type RawPageLink = Pick<PageRow, "id" | "slug" | "title" | "published">
-type RawSectionLink = Pick<
-  SectionRow,
-  | "id"
-  | "key"
-  | "title"
-  | "section_type"
-  | "schema_id"
-  | "published"
->
 type RawEntityLink = Pick<
   EntityRow,
   | "id"
@@ -535,128 +629,126 @@ function byEntityRelationOrder(left: CmsEntityRelation, right: CmsEntityRelation
 
 export async function loadCmsPages(): Promise<CmsPageSummary[]> {
   const supabase = await createClient()
-  const pagesQuery = supabase
-    .from("pages")
-    .select("id, slug, title, subtitle, published, updated_at")
+  const registry = await loadCmsSchemaRegistryMap()
+  const { data, error } = await supabase
+    .from("entities")
+    .select(CMS_PAGE_ENTITY_SELECT)
+    .eq("schema_id", schemaIdForKey(registry, PAGE_ENTITY_SCHEMA_KEY))
     .order("slug", { ascending: true })
-  const [registry, result] = await Promise.all([
-    loadCmsSchemaRegistryMap(),
-    pagesQuery,
-  ])
-  const { data, error } = result
 
   if (error) {
     throw new Error(`Failed to load CMS pages: ${error.message}`)
   }
 
-  return (data ?? []).map((page) => ({
-    ...schemaSummary("page/default/v1", registry),
-    id: page.id,
-    slug: page.slug,
-    title: page.title,
-    subtitle: page.subtitle,
-    published: page.published,
-    updatedAt: page.updated_at,
-  }))
+  return (data ?? [])
+    .map((entity) => pageRowFromEntity(entity))
+    .filter((page): page is PageRow => Boolean(page))
+    .map((page) => ({
+      ...schemaSummary(PAGE_ENTITY_SCHEMA_KEY, registry),
+      id: page.id,
+      slug: page.slug,
+      title: page.title,
+      subtitle: page.subtitle,
+      published: page.published,
+      updatedAt: page.updated_at,
+    }))
+    .sort((left, right) => left.slug.localeCompare(right.slug, "ko"))
 }
 
 export async function loadCmsPageDetail(
   id: string,
 ): Promise<CmsContentDetail | null> {
   const supabase = await createClient()
-  const pageQuery = supabase
-    .from("pages")
-    .select("*")
+  const registry = await loadCmsSchemaRegistryMap()
+  const { data, error } = await supabase
+    .from("entities")
+    .select(CMS_PAGE_ENTITY_SELECT)
     .eq("id", id)
+    .eq("schema_id", schemaIdForKey(registry, PAGE_ENTITY_SCHEMA_KEY))
     .maybeSingle()
-  const [registry, result] = await Promise.all([
-    loadCmsSchemaRegistryMap(),
-    pageQuery,
-  ])
-  const { data, error } = result
 
   if (error) {
     throw new Error(`Failed to load CMS page detail: ${error.message}`)
   }
 
-  if (!data) {
+  const page = data ? pageRowFromEntity(data) : null
+
+  if (!page) {
     return null
   }
 
   return {
-    ...schemaSummary("page/default/v1", registry),
+    ...schemaSummary(PAGE_ENTITY_SCHEMA_KEY, registry),
     kind: "page",
-    table: "pages",
-    title: data.title,
-    subtitle: data.subtitle,
-    published: data.published,
-    updatedAt: data.updated_at,
-    row: data,
+    table: "entities",
+    title: page.title,
+    subtitle: page.subtitle,
+    published: page.published,
+    updatedAt: page.updated_at,
+    row: page,
   }
 }
 
 export async function loadCmsSections(): Promise<CmsSectionSummary[]> {
   const supabase = await createClient()
-  const sectionsQuery = supabase
-    .from("sections")
-    .select(
-      "id, key, section_type, schema_id, title, subtitle, published, updated_at",
-    )
-    .order("key", { ascending: true })
-  const [registry, result] = await Promise.all([
-    loadCmsSchemaRegistryMap(),
-    sectionsQuery,
-  ])
-  const { data, error } = result
+  const registry = await loadCmsSchemaRegistryMap()
+  const { data, error } = await supabase
+    .from("entities")
+    .select(CMS_SECTION_ENTITY_SELECT)
+    .in("schema_id", schemaIdsForKind(registry, "section"))
+    .order("title", { ascending: true })
 
   if (error) {
     throw new Error(`Failed to load CMS sections: ${error.message}`)
   }
 
-  return (data ?? []).map((section) => ({
-    ...sectionSchemaSummary(section, registry),
-    id: section.id,
-    key: section.key,
-    sectionType: section.section_type,
-    title: section.title,
-    subtitle: section.subtitle,
-    published: section.published,
-    updatedAt: section.updated_at,
-  }))
+  return (data ?? [])
+    .map((entity) => sectionRowFromEntity(entity))
+    .filter((section): section is SectionRow => Boolean(section))
+    .map((section) => ({
+      ...sectionSchemaSummary(section, registry),
+      id: section.id,
+      key: section.key,
+      sectionType: section.section_type,
+      title: section.title,
+      subtitle: section.subtitle,
+      published: section.published,
+      updatedAt: section.updated_at,
+    }))
+    .sort((left, right) => left.key.localeCompare(right.key, "ko"))
 }
 
 export async function loadCmsSectionDetail(
   id: string,
 ): Promise<CmsContentDetail | null> {
   const supabase = await createClient()
-  const sectionQuery = supabase
-    .from("sections")
-    .select("*")
+  const registry = await loadCmsSchemaRegistryMap()
+  const { data, error } = await supabase
+    .from("entities")
+    .select(CMS_SECTION_ENTITY_SELECT)
     .eq("id", id)
+    .in("schema_id", schemaIdsForKind(registry, "section"))
     .maybeSingle()
-  const [registry, result] = await Promise.all([
-    loadCmsSchemaRegistryMap(),
-    sectionQuery,
-  ])
-  const { data, error } = result
 
   if (error) {
     throw new Error(`Failed to load CMS section detail: ${error.message}`)
   }
 
-  if (!data) {
+  const section = data ? sectionRowFromEntity(data) : null
+
+  if (!section) {
     return null
   }
 
   return {
-    ...sectionSchemaSummary(data, registry),
+    ...sectionSchemaSummary(section, registry),
     kind: "section",
-    table: "sections",
-    title: data.title ?? data.key,
-    subtitle: data.subtitle,
-    published: data.published,
-    updatedAt: data.updated_at,
-    row: data,
+    table: "entities",
+    title: section.title ?? section.key,
+    subtitle: section.subtitle,
+    published: section.published,
+    updatedAt: section.updated_at,
+    row: section,
   }
 }
 
@@ -745,41 +837,19 @@ export async function loadCmsRelationEditorOptions({
   const entityQuery = countEntities
     ? supabase.from("entities").select(entitySelect, { count: "exact" })
     : supabase.from("entities").select(entitySelect)
-  const pagesQuery = supabase
-    .from("pages")
-    .select("id, slug, title, subtitle, published, updated_at")
-    .order("slug", { ascending: true })
-  const sectionsQuery = supabase
-    .from("sections")
-    .select(
-      "id, key, section_type, schema_id, title, subtitle, published, updated_at",
-    )
-    .order("key", { ascending: true })
   const entitiesPromise = includeEntities
     ? entityQuery
         .order("sort_at", { ascending: false })
         .range(0, Math.min(Math.max(entityLimit, 1), 100) - 1)
     : Promise.resolve({ data: [], error: null, count: null })
-  const [registry, schemaOptions, pagesResult, sectionsResult, entitiesResult] =
+  const [registry, schemaOptions, pages, sections, entitiesResult] =
     await Promise.all([
       loadCmsSchemaRegistryMap(),
       entitySchemaOptions(),
-      pagesQuery,
-      sectionsQuery,
+      loadCmsPages(),
+      loadCmsSections(),
       entitiesPromise,
     ])
-
-  if (sectionsResult.error) {
-    throw new Error(
-      `Failed to load CMS section options: ${sectionsResult.error.message}`,
-    )
-  }
-
-  if (pagesResult.error) {
-    throw new Error(
-      `Failed to load CMS page options: ${pagesResult.error.message}`,
-    )
-  }
 
   if (entitiesResult.error) {
     throw new Error(
@@ -788,25 +858,8 @@ export async function loadCmsRelationEditorOptions({
   }
 
   return {
-    pages: (pagesResult.data ?? []).map((page) => ({
-      ...schemaSummary("page/default/v1", registry),
-      id: page.id,
-      slug: page.slug,
-      title: page.title,
-      subtitle: page.subtitle,
-      published: page.published,
-      updatedAt: page.updated_at,
-    })),
-    sections: (sectionsResult.data ?? []).map((section) => ({
-      ...sectionSchemaSummary(section, registry),
-      id: section.id,
-      key: section.key,
-      sectionType: section.section_type,
-      title: section.title,
-      subtitle: section.subtitle,
-      published: section.published,
-      updatedAt: section.updated_at,
-    })),
+    pages,
+    sections,
     entitySchemas: schemaOptions,
     entities: (entitiesResult.data ?? []).map((entity) =>
       mapEntitySummary(entity, registry),
@@ -852,10 +905,6 @@ export async function loadCmsEntityDetail(
   }
 }
 
-function uniqueStrings(values: Array<string | null | undefined>) {
-  return [...new Set(values.filter((value): value is string => Boolean(value)))]
-}
-
 async function loadShadowEntityId({
   supabase,
   registry,
@@ -867,6 +916,27 @@ async function loadShadowEntityId({
   sourceTable: "pages" | "sections"
   sourceId: string
 }) {
+  const { data: directEntity, error: directEntityError } = await supabase
+    .from("entities")
+    .select("id, schema_id")
+    .eq("id", sourceId)
+    .maybeSingle()
+
+  if (directEntityError) {
+    throw new Error(
+      `Failed to load ${sourceTable} graph entity: ${directEntityError.message}`,
+    )
+  }
+
+  if (directEntity) {
+    const validSchema =
+      sourceTable === "pages"
+        ? directEntity.schema_id === schemaIdForKey(registry, PAGE_ENTITY_SCHEMA_KEY)
+        : schemaIdsForKind(registry, "section").includes(directEntity.schema_id)
+
+    return validSchema ? directEntity.id : null
+  }
+
   const source =
     sourceTable === "pages"
       ? await supabase
@@ -910,42 +980,6 @@ async function loadShadowEntityId({
   }
 
   return data?.id ?? null
-}
-
-async function loadPageLinksBySlug(
-  supabase: SupabaseClient,
-  pageSlugs: string[],
-) {
-  if (!pageSlugs.length) return new Map<string, RawPageLink>()
-
-  const { data, error } = await supabase
-    .from("pages")
-    .select("id, slug, title, published")
-    .in("slug", pageSlugs)
-
-  if (error) {
-    throw new Error(`Failed to load page bridge links: ${error.message}`)
-  }
-
-  return new Map((data ?? []).map((page) => [page.slug, page]))
-}
-
-async function loadSectionLinksByKey(
-  supabase: SupabaseClient,
-  sectionKeys: string[],
-) {
-  if (!sectionKeys.length) return new Map<string, RawSectionLink>()
-
-  const { data, error } = await supabase
-    .from("sections")
-    .select("id, key, title, section_type, schema_id, published")
-    .in("key", sectionKeys)
-
-  if (error) {
-    throw new Error(`Failed to load section bridge links: ${error.message}`)
-  }
-
-  return new Map((data ?? []).map((section) => [section.key, section]))
 }
 
 async function loadPageSectionRelationsFromEntityGraph({
@@ -1001,23 +1035,10 @@ async function loadPageSectionRelationsFromEntityGraph({
   }
 
   const rawRelations = (data ?? []) as unknown as RawEntityRelation[]
-  const pageSlugs = uniqueStrings(
-    rawRelations.map((relation) => shadowKey(relation.fromEntity, "pages")),
-  )
-  const sectionKeys = uniqueStrings(
-    rawRelations.map((relation) => shadowKey(relation.toEntity, "sections")),
-  )
-  const [pagesBySlug, sectionsByKey] = await Promise.all([
-    loadPageLinksBySlug(supabase, pageSlugs),
-    loadSectionLinksByKey(supabase, sectionKeys),
-  ])
-
   const relations = rawRelations
     .map((relation): CmsPageSectionRelation | null => {
-      const pageSlug = shadowKey(relation.fromEntity, "pages")
-      const sectionKey = shadowKey(relation.toEntity, "sections")
-      const page = pageSlug ? pagesBySlug.get(pageSlug) : null
-      const section = sectionKey ? sectionsByKey.get(sectionKey) : null
+      const page = linkedPageFromEntity(relation.fromEntity)
+      const section = linkedSectionFromEntity(relation.toEntity, registry)
       const mappedPageId = page?.id ?? pageId
       const mappedSectionId = section?.id ?? sectionId
 
@@ -1032,8 +1053,8 @@ async function loadPageSectionRelationsFromEntityGraph({
         sortOrder: relation.sort_order,
         props: relation.props,
         updatedAt: relation.updated_at,
-        page: linkedPage(page ?? null),
-        section: linkedSection(section ?? null, registry),
+        page,
+        section,
       }
     })
     .filter((relation): relation is CmsPageSectionRelation => Boolean(relation))
@@ -1086,15 +1107,9 @@ async function loadSectionEntityRelationsFromEntityGraph({
   }
 
   const rawRelations = (data ?? []) as unknown as RawEntityRelation[]
-  const sectionKeys = uniqueStrings(
-    rawRelations.map((relation) => shadowKey(relation.fromEntity, "sections")),
-  )
-  const sectionsByKey = await loadSectionLinksByKey(supabase, sectionKeys)
-
   const relations = rawRelations
     .map((relation): CmsSectionEntityRelation | null => {
-      const sectionKey = shadowKey(relation.fromEntity, "sections")
-      const section = sectionKey ? sectionsByKey.get(sectionKey) : null
+      const section = linkedSectionFromEntity(relation.fromEntity, registry)
       const mappedSectionId = section?.id ?? sectionId
 
       if (!mappedSectionId || !relation.toEntity) {
@@ -1112,7 +1127,7 @@ async function loadSectionEntityRelationsFromEntityGraph({
         sortOrder: relation.sort_order,
         props: relation.props,
         updatedAt: relation.updated_at,
-        section: linkedSection(section ?? null, registry),
+        section,
         entity: linkedEntity(relation.toEntity, registry),
       }
     })

--- a/lib/data/content-graph.ts
+++ b/lib/data/content-graph.ts
@@ -780,6 +780,38 @@ async function loadGraphPageUncached(
       })
     }
 
+    if (options.id) {
+      let pageEntityQuery = supabase
+        .from("entities")
+        .select(
+          "id, schema_id, slug, title, subtitle, summary, owner_member_id, published, data, created_at, updated_at",
+        )
+        .eq("id", options.id)
+        .eq("schema_id", schemas.pageSchemaId)
+
+      if (!includeDrafts) {
+        pageEntityQuery = pageEntityQuery.eq("published", true)
+      }
+
+      const { data: pageEntity, error: pageEntityError } =
+        await pageEntityQuery.maybeSingle()
+
+      if (!pageEntityError && pageEntity) {
+        const page = pageRowFromShadowEntity(pageEntity)
+
+        if (page) {
+          return await loadGraphPageFromEntityRelations({
+            page,
+            supabase,
+            includeDrafts,
+            schemas,
+            pageEntityId: pageEntity.id,
+            useShadowSections: true,
+          })
+        }
+      }
+    }
+
     let pageQuery = supabase
       .from("pages")
       .select("*")


### PR DESCRIPTION
## Summary
- Move PONIX page/section CMS list, detail, edit, and relation option flows to graph entity ids.
- Save page and section edits into entities/data instead of pages/sections rows.
- Let draft preview/composer load by page entity id and document the updated content graph contract.

Closes #157.

## Verification
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm run build
- pnpm run qa:content-graph
- pnpm run qa:cms-db-first-loaders
- pnpm run qa:cms-legacy-bridge-boundary
- pnpm run qa:cms-schema-registry
- pnpm run qa:schema-semantic-identity
- pnpm run qa:schema-mirror-removal-readiness
- cmux smoke: /ponix/pages, page compose, section edit, section create picker, no browser errors

## Not Tested
- No production Supabase save/create mutation was submitted during QA; avoided non-reversible data writes.