### PR TITLE
Prepare page-section compatibility retirement

### DIFF
--- a/app/ponix/relations/actions.ts
+++ b/app/ponix/relations/actions.ts
@@ -41,8 +41,6 @@ const PAGE_ENTITY_SCHEMA_KEY = "page/default/v1"
 const DEFAULT_RELATION_SCHEMA_KEY = "relation/default/v1"
 const PAGE_SECTION_RELATION_SCHEMA_KEY = "relation/page-section/v1"
 const SECTION_ENTITY_RELATION_SCHEMA_KEY = "relation/section-entity/v1"
-const PAGE_SHADOW_PREFIX = "page:"
-const SECTION_SHADOW_PREFIX = "section:"
 
 function stringField(formData: FormData, key: string) {
   const value = formData.get(key)
@@ -147,10 +145,6 @@ function revalidateRelationSurfaces(paths: string[]) {
   }
 }
 
-function shadowSlug(sourceTable: "pages" | "sections", sourceKey: string) {
-  return `${sourceTable === "pages" ? PAGE_SHADOW_PREFIX : SECTION_SHADOW_PREFIX}${sourceKey}`
-}
-
 async function loadSchemaIdByKey({
   supabase,
   schemaKey,
@@ -208,94 +202,41 @@ async function loadShadowEntityId({
   sourceId: string
   label: string
 }) {
-  const { data: directEntity, error: directEntityError } = await supabase
+  const { data: entity, error } = await supabase
     .from("entities")
     .select("id, schema_id")
     .eq("id", sourceId)
     .maybeSingle()
 
-  if (directEntityError) {
-    throw new Error(directEntityError.message)
+  if (error) {
+    throw new Error(error.message)
   }
 
-  if (directEntity) {
-    const validSchema =
-      sourceTable === "pages"
-        ? directEntity.schema_id ===
-          (await loadSchemaIdByKey({
+  if (!entity) {
+    throw new Error(`${label} graph entity not found.`)
+  }
+
+  const validSchema =
+    sourceTable === "pages"
+      ? entity.schema_id ===
+        (await loadSchemaIdByKey({
+          supabase,
+          schemaKey: PAGE_ENTITY_SCHEMA_KEY,
+          label: "Page",
+        }))
+      : (
+          await loadSchemaIdsByKind({
             supabase,
-            schemaKey: PAGE_ENTITY_SCHEMA_KEY,
-            label: "Page",
-          }))
-        : (
-            await loadSchemaIdsByKind({
-              supabase,
-              kind: "section",
-              label: "Section",
-            })
-          ).includes(directEntity.schema_id)
+            kind: "section",
+            label: "Section",
+          })
+        ).includes(entity.schema_id)
 
-    if (!validSchema) {
-      throw new Error(`${label} graph entity is not a ${label.toLowerCase()}.`)
-    }
-
-    return directEntity.id
+  if (!validSchema) {
+    throw new Error(`${label} graph entity is not a ${label.toLowerCase()}.`)
   }
 
-  const source =
-    sourceTable === "pages"
-      ? await supabase
-          .from("pages")
-          .select("slug")
-          .eq("id", sourceId)
-          .maybeSingle()
-      : await supabase
-          .from("sections")
-          .select("key")
-          .eq("id", sourceId)
-          .maybeSingle()
-
-  if (source.error) {
-    throw new Error(source.error.message)
-  }
-
-  const sourceKey =
-    sourceTable === "pages"
-      ? (source.data as { slug?: string } | null)?.slug
-      : (source.data as { key?: string } | null)?.key
-
-  if (!sourceKey) {
-    throw new Error(`${label} source record not found.`)
-  }
-
-  let query = supabase
-    .from("entities")
-    .select("id")
-    .eq("slug", shadowSlug(sourceTable, sourceKey))
-
-  if (sourceTable === "pages") {
-    const pageSchemaId = await loadSchemaIdByKey({
-      supabase,
-      schemaKey: PAGE_ENTITY_SCHEMA_KEY,
-      label: "Page",
-    })
-    query = query.eq("schema_id", pageSchemaId)
-  } else {
-    const sectionSchemaIds = await loadSchemaIdsByKind({
-      supabase,
-      kind: "section",
-      label: "Section",
-    })
-    query = query.in("schema_id", sectionSchemaIds)
-  }
-
-  const { data, error } = await query.maybeSingle()
-
-  if (error || !data?.id) {
-    throw new Error(error?.message ?? `${label} graph entity not found.`)
-  }
-
-  return data.id
+  return entity.id
 }
 
 async function loadPageSectionGraphRelation(

--- a/docs/content-graph.md
+++ b/docs/content-graph.md
@@ -50,8 +50,7 @@ Current PONIX contract:
   and section records. Page fields are projected from the page entity; section
   renderer identity and props are projected from section entity `data`.
 - CMS draft preview and composer paths accept page entity ids, then render from
-  the same `entity_relations` graph used by public pages. Legacy page ids remain
-  a transitional fallback only where explicitly retained.
+  the same `entity_relations` graph used by public pages.
 - CMS relation lists read page/section placement through `entity_relations`
   bridge rows, using relation `schema_id` values resolved from registered
   schema keys such as `relation/page-section/v1` and
@@ -64,8 +63,8 @@ Current PONIX contract:
   `section_entities`.
 - Code that mutates page or section composition must pass the graph relation id.
 - `pnpm run qa:content-graph` checks graph-only page composition integrity:
-  page shadow cardinality, section ordering, relation contracts, and missing or
-  unpublished section/entity references.
+  page/section entity key uniqueness, section ordering, relation contracts, and
+  missing or unpublished section/entity references.
 - Runtime CMS code must not read `page_sections` or `section_entities`.
   Use `pnpm run qa:cms-legacy-bridge-boundary` after CMS loader changes.
 - Use `pnpm run qa:legacy-mirror-readiness` when touching historical mirror
@@ -270,13 +269,27 @@ Profile-visible role text is member-editable and separate from permissions.
 ### Update Section Copy
 
 ```sql
-update public.sections
+update public.entities section_entity
 set title = 'New title',
     subtitle = '새 제목',
-    props = coalesce(props, '{}'::jsonb) || jsonb_build_object(
-      'body', 'New body copy'
+    data = coalesce(section_entity.data, '{}'::jsonb) || jsonb_build_object(
+      'props',
+      coalesce(section_entity.data -> 'props', '{}'::jsonb) || jsonb_build_object(
+        'body', 'New body copy'
+      )
     )
-where key = 'home-join';
+from public.entity_schemas schema_ref
+where section_entity.schema_id = schema_ref.id
+  and schema_ref.kind = 'section'
+  and schema_ref.active = true
+  and coalesce(
+    case
+      when section_entity.slug like 'section:%'
+      then substring(section_entity.slug from 9)
+      else null
+    end,
+    section_entity.data ->> 'key'
+  ) = 'home-join';
 ```
 
 ### Add a Content Entity
@@ -317,25 +330,30 @@ insert into public.entity_relations (
   props
 )
 select
-  section_shadow.id,
+  section_entity.id,
   entity_ref.id,
   relation_schema.id,
   'item',
   'default',
   120,
   '{}'::jsonb
-from public.sections section_ref
-join public.entities section_shadow
-  on section_shadow.schema_id in (
-    select id from public.entity_schemas
-    where kind = 'section' and active = true
-  )
- and section_shadow.slug = 'section:' || section_ref.key
+from public.entities section_entity
 join public.entities entity_ref on entity_ref.slug = 'history-2026-new-season'
+join public.entity_schemas section_schema
+  on section_entity.schema_id = section_schema.id
+ and section_schema.kind = 'section'
+ and section_schema.active = true
 join public.entity_schemas relation_schema
   on relation_schema.schema_key = 'relation/section-entity/v1'
  and relation_schema.active = true
-where section_ref.key = 'history-timeline'
+where coalesce(
+    case
+      when section_entity.slug like 'section:%'
+      then substring(section_entity.slug from 9)
+      else null
+    end,
+    section_entity.data ->> 'key'
+  ) = 'history-timeline'
 on conflict (from_entity_id, to_entity_id, relation_type, slot) do update
 set sort_order = excluded.sort_order,
     props = excluded.props,
@@ -347,73 +365,83 @@ set sort_order = excluded.sort_order,
 ```sql
 update public.entity_relations page_section_relation
 set sort_order = 30
-from public.pages page_ref
-join public.entities page_shadow
-  on page_shadow.schema_id = (
-    select id from public.entity_schemas
-    where schema_key = 'page/default/v1' and active = true
-  )
- and page_shadow.slug = 'page:' || page_ref.slug
-join public.sections section_ref on section_ref.key = 'home-activities'
-join public.entities section_shadow
-  on section_shadow.schema_id in (
+from public.entities page_entity
+join public.entities section_entity
+  on section_entity.schema_id in (
     select id from public.entity_schemas
     where kind = 'section' and active = true
   )
- and section_shadow.slug = 'section:' || section_ref.key
 join public.entity_schemas relation_schema
   on relation_schema.schema_key = 'relation/page-section/v1'
  and relation_schema.active = true
-where page_section_relation.from_entity_id = page_shadow.id
-  and page_section_relation.to_entity_id = section_shadow.id
+where page_entity.schema_id = (
+  select id from public.entity_schemas
+  where schema_key = 'page/default/v1' and active = true
+)
+  and page_entity.slug = 'page:home'
+  and coalesce(
+    case
+      when section_entity.slug like 'section:%'
+      then substring(section_entity.slug from 9)
+      else null
+    end,
+    section_entity.data ->> 'key'
+  ) = 'home-activities'
+  and page_section_relation.from_entity_id = page_entity.id
+  and page_section_relation.to_entity_id = section_entity.id
   and page_section_relation.schema_id = relation_schema.id
-  and page_section_relation.slot = 'sections'
-  and page_ref.slug = 'home';
+  and page_section_relation.slot = 'sections';
 ```
 
 ## Required Content Checks
 
 After changing content graph data, verify:
 
-- affected page exists and is published
-- expected sections exist and are published
+- affected page entity exists and is published
+- expected section entities exist and are published
 - required entity sections have enough linked entities
 - linked entities are published
-- `section_type` still has a renderer
+- `entities.data.section_type` still has a renderer
 - page no longer relies on removed section keys
 
 Useful query:
 
 ```sql
 select
-  p.slug,
+  coalesce(
+    case
+      when page_entity.slug like 'page:%'
+      then substring(page_entity.slug from 6)
+      else null
+    end,
+    page_entity.data ->> 'slug'
+  ) as page_slug,
   page_section_relation.sort_order,
-  s.key,
-  s.section_type,
+  coalesce(
+    case
+      when section_entity.slug like 'section:%'
+      then substring(section_entity.slug from 9)
+      else null
+    end,
+    section_entity.data ->> 'key'
+  ) as section_key,
+  section_entity.data ->> 'section_type' as section_type,
   count(content_entity.id) as entity_count
-from public.pages p
-join public.entities page_shadow
-  on page_shadow.schema_id = (
-    select id from public.entity_schemas
-    where schema_key = 'page/default/v1' and active = true
-  )
- and page_shadow.slug = 'page:' || p.slug
+from public.entities page_entity
 join public.entity_relations page_section_relation
-  on page_section_relation.from_entity_id = page_shadow.id
+  on page_section_relation.from_entity_id = page_entity.id
  and page_section_relation.schema_id = (
     select id from public.entity_schemas
     where schema_key = 'relation/page-section/v1' and active = true
- )
- and page_section_relation.slot = 'sections'
-join public.entities section_shadow
-  on section_shadow.id = page_section_relation.to_entity_id
- and section_shadow.schema_id in (
+  )
+join public.entities section_entity
+  on section_entity.id = page_section_relation.to_entity_id
+ and section_entity.schema_id in (
     select id from public.entity_schemas
     where kind = 'section' and active = true
- )
-join public.sections s on section_shadow.slug = 'section:' || s.key
+  )
 left join public.entity_relations section_item_relation
-  on section_item_relation.from_entity_id = section_shadow.id
+  on section_item_relation.from_entity_id = section_entity.id
  and section_item_relation.schema_id = (
     select id from public.entity_schemas
     where schema_key = 'relation/section-entity/v1' and active = true
@@ -421,9 +449,12 @@ left join public.entity_relations section_item_relation
 left join public.entities content_entity
   on content_entity.id = section_item_relation.to_entity_id
  and content_entity.published = true
-where p.slug in ('home', 'site', 'performances', 'videos', 'photos', 'history')
-  and p.published = true
-  and s.published = true
-group by p.slug, page_section_relation.sort_order, s.key, s.section_type
-order by p.slug, page_section_relation.sort_order;
+where page_entity.schema_id = (
+    select id from public.entity_schemas
+    where schema_key = 'page/default/v1' and active = true
+  )
+  and page_entity.published = true
+  and section_entity.published = true
+group by page_slug, page_section_relation.sort_order, section_key, section_type
+order by page_slug, page_section_relation.sort_order;
 ```

--- a/lib/cms/content.ts
+++ b/lib/cms/content.ts
@@ -18,8 +18,6 @@ const SECTION_ENTITY_RELATION_SCHEMA_KEY = "relation/section-entity/v1"
 const PAGE_SHADOW_PREFIX = "page:"
 const SECTION_SHADOW_PREFIX = "section:"
 
-type PageRow = Database["public"]["Tables"]["pages"]["Row"]
-type SectionRow = Database["public"]["Tables"]["sections"]["Row"]
 type EntityRow = Database["public"]["Tables"]["entities"]["Row"]
 type SupabaseClient = Awaited<ReturnType<typeof createClient>>
 
@@ -39,6 +37,34 @@ const CMS_PAGE_ENTITY_SELECT =
   "id, schema_id, slug, title, subtitle, summary, owner_member_id, published, data, created_at, updated_at"
 const CMS_SECTION_ENTITY_SELECT =
   "id, schema_id, slug, title, subtitle, owner_member_id, published, data, created_at, updated_at"
+
+type CmsPageRecord = {
+  id: string
+  slug: string
+  title: string
+  subtitle: string | null
+  description: string | null
+  owner_member_id: string | null
+  published: boolean
+  props: Json
+  created_at: string
+  updated_at: string
+}
+
+type CmsSectionRecord = {
+  id: string
+  key: string
+  section_type: string
+  schema_id: string
+  eyebrow: string | null
+  title: string | null
+  subtitle: string | null
+  owner_member_id: string | null
+  published: boolean
+  props: Json
+  created_at: string
+  updated_at: string
+}
 
 type SchemaSummary = {
   schemaKey: string
@@ -219,7 +245,7 @@ export type CmsContentDetail =
       subtitle: string | null
       published: boolean
       updatedAt: string
-      row: PageRow
+      row: CmsPageRecord
     } & SchemaSummary
   | {
       kind: "section"
@@ -228,7 +254,7 @@ export type CmsContentDetail =
       subtitle: string | null
       published: boolean
       updatedAt: string
-      row: SectionRow
+      row: CmsSectionRecord
     } & SchemaSummary
   | {
       kind: "entity"
@@ -314,7 +340,7 @@ function entitySchemaSummary(
 }
 
 function sectionSchemaSummary(
-  section: Pick<SectionRow, "schema_id">,
+  section: Pick<CmsSectionRecord, "schema_id">,
   registry: SchemaRegistryMap,
 ): SchemaSummary {
   return schemaReferenceSummary(section, registry)
@@ -358,7 +384,7 @@ function pageRowFromEntity(
     | "created_at"
     | "updated_at"
   >,
-): PageRow | null {
+): CmsPageRecord | null {
   const data = jsonObject(entity.data)
   const slug = shadowKey(entity, "pages") ?? stringValue(data.slug)
 
@@ -392,7 +418,7 @@ function sectionRowFromEntity(
     | "created_at"
     | "updated_at"
   >,
-): SectionRow | null {
+): CmsSectionRecord | null {
   const data = jsonObject(entity.data)
   const key = shadowKey(entity, "sections") ?? stringValue(data.key)
   const sectionType = stringValue(data.section_type)
@@ -528,10 +554,6 @@ function entityWithTimestamps(entity: RawEntityLink) {
   }
 }
 
-function shadowSlug(sourceTable: "pages" | "sections", sourceKey: string) {
-  return `${sourceTable === "pages" ? PAGE_SHADOW_PREFIX : SECTION_SHADOW_PREFIX}${sourceKey}`
-}
-
 function shadowKey(
   entity: Pick<EntityRow, "slug"> | RawEntityLink | null,
   sourceTable: "pages" | "sections",
@@ -642,7 +664,7 @@ export async function loadCmsPages(): Promise<CmsPageSummary[]> {
 
   return (data ?? [])
     .map((entity) => pageRowFromEntity(entity))
-    .filter((page): page is PageRow => Boolean(page))
+    .filter((page): page is CmsPageRecord => Boolean(page))
     .map((page) => ({
       ...schemaSummary(PAGE_ENTITY_SCHEMA_KEY, registry),
       id: page.id,
@@ -704,7 +726,7 @@ export async function loadCmsSections(): Promise<CmsSectionSummary[]> {
 
   return (data ?? [])
     .map((entity) => sectionRowFromEntity(entity))
-    .filter((section): section is SectionRow => Boolean(section))
+    .filter((section): section is CmsSectionRecord => Boolean(section))
     .map((section) => ({
       ...sectionSchemaSummary(section, registry),
       id: section.id,
@@ -916,70 +938,26 @@ async function loadShadowEntityId({
   sourceTable: "pages" | "sections"
   sourceId: string
 }) {
-  const { data: directEntity, error: directEntityError } = await supabase
+  const { data: entity, error } = await supabase
     .from("entities")
     .select("id, schema_id")
     .eq("id", sourceId)
     .maybeSingle()
 
-  if (directEntityError) {
+  if (error) {
     throw new Error(
-      `Failed to load ${sourceTable} graph entity: ${directEntityError.message}`,
+      `Failed to load ${sourceTable} graph entity: ${error.message}`,
     )
   }
 
-  if (directEntity) {
-    const validSchema =
-      sourceTable === "pages"
-        ? directEntity.schema_id === schemaIdForKey(registry, PAGE_ENTITY_SCHEMA_KEY)
-        : schemaIdsForKind(registry, "section").includes(directEntity.schema_id)
+  if (!entity) return null
 
-    return validSchema ? directEntity.id : null
-  }
-
-  const source =
+  const validSchema =
     sourceTable === "pages"
-      ? await supabase
-          .from("pages")
-          .select("slug")
-          .eq("id", sourceId)
-          .maybeSingle()
-      : await supabase
-          .from("sections")
-          .select("key")
-          .eq("id", sourceId)
-          .maybeSingle()
+      ? entity.schema_id === schemaIdForKey(registry, PAGE_ENTITY_SCHEMA_KEY)
+      : schemaIdsForKind(registry, "section").includes(entity.schema_id)
 
-  if (source.error) {
-    throw new Error(`Failed to load ${sourceTable} source: ${source.error.message}`)
-  }
-
-  const sourceKey =
-    sourceTable === "pages"
-      ? (source.data as { slug?: string } | null)?.slug
-      : (source.data as { key?: string } | null)?.key
-
-  if (!sourceKey) {
-    return null
-  }
-
-  let query = supabase
-    .from("entities")
-    .select("id")
-    .eq("slug", shadowSlug(sourceTable, sourceKey))
-
-  query =
-    sourceTable === "pages"
-      ? query.eq("schema_id", schemaIdForKey(registry, PAGE_ENTITY_SCHEMA_KEY))
-      : query.in("schema_id", schemaIdsForKind(registry, "section"))
-
-  const { data, error } = await query.maybeSingle()
-
-  if (error) {
-    throw new Error(`Failed to load ${sourceTable} graph entity: ${error.message}`)
-  }
-
-  return data?.id ?? null
+  return validSchema ? entity.id : null
 }
 
 async function loadPageSectionRelationsFromEntityGraph({

--- a/lib/cms/page-editor.ts
+++ b/lib/cms/page-editor.ts
@@ -3,9 +3,12 @@ import type {
   CmsSchemaDefinition,
 } from "@/lib/cms/schema-registry"
 import { getCmsSchema } from "@/lib/cms/schema-registry"
-import type { Database, Json } from "@/lib/supabase/types"
+import type { Json } from "@/lib/supabase/types"
 
-type PageRow = Database["public"]["Tables"]["pages"]["Row"]
+type PageEditorRecord = {
+  props: Json
+  [key: string]: unknown
+}
 
 const editablePageColumns = new Set([
   "title",
@@ -71,7 +74,7 @@ export function jsonObject(value: Json): CmsJsonObject {
 }
 
 export function getPageFieldValue(
-  page: PageRow,
+  page: PageEditorRecord,
   field: CmsEditablePageField,
 ) {
   if (field.source === "props") {

--- a/lib/cms/section-editor.ts
+++ b/lib/cms/section-editor.ts
@@ -3,9 +3,12 @@ import type {
   CmsSchemaDefinition,
 } from "@/lib/cms/schema-registry"
 import { getCmsSchema, getCmsSchemasByKind } from "@/lib/cms/schema-registry"
-import type { Database, Json } from "@/lib/supabase/types"
+import type { Json } from "@/lib/supabase/types"
 
-type SectionRow = Database["public"]["Tables"]["sections"]["Row"]
+type SectionEditorRecord = {
+  props: Json
+  [key: string]: unknown
+}
 
 const editableSectionColumns = new Set(["eyebrow", "title", "subtitle", "published"])
 
@@ -133,7 +136,7 @@ export function jsonObject(value: Json): CmsJsonObject {
 }
 
 export function getSectionFieldValue(
-  section: SectionRow,
+  section: SectionEditorRecord,
   field: CmsEditableSectionField,
 ) {
   if (field.source === "props") {

--- a/lib/data/content-graph.ts
+++ b/lib/data/content-graph.ts
@@ -18,7 +18,6 @@ import {
 } from "@/lib/data/videos"
 
 type EntityRow = Database["public"]["Tables"]["entities"]["Row"]
-type PageRow = Database["public"]["Tables"]["pages"]["Row"]
 type EntityRelationRow = Database["public"]["Tables"]["entity_relations"]["Row"]
 type ContentEntityRow = Pick<
   EntityRow,
@@ -40,6 +39,19 @@ const PAGE_SHADOW_PREFIX = "page:"
 const SECTION_SHADOW_PREFIX = "section:"
 const CONTENT_ENTITY_SELECT =
   "id, schema_id, slug, title, subtitle, summary, thumbnail_url, data, sort_at"
+
+type GraphPageRecord = {
+  id: string
+  slug: string
+  title: string
+  subtitle: string | null
+  description: string | null
+  owner_member_id: string | null
+  published: boolean
+  props: Json
+  created_at: string
+  updated_at: string
+}
 
 export type GraphSectionItem = {
   entity: ContentEntityRow
@@ -65,7 +77,7 @@ export type GraphSection = {
 }
 
 export type GraphPage = {
-  page: PageRow
+  page: GraphPageRecord
   sections: GraphSection[]
 }
 
@@ -578,7 +590,7 @@ function socialKind(value: string | null): SiteSocialItem["kind"] {
   return "link"
 }
 
-function contentPageFromGraph(page: PageRow): ContentPageConfig {
+function contentPageFromGraph(page: GraphPageRecord): ContentPageConfig {
   return {
     slug: page.slug,
     title: page.title,
@@ -587,7 +599,9 @@ function contentPageFromGraph(page: PageRow): ContentPageConfig {
   }
 }
 
-function pageRowFromShadowEntity(entity: PageShadowEntityRow): PageRow | null {
+function pageRecordFromEntity(
+  entity: PageShadowEntityRow,
+): GraphPageRecord | null {
   const data = jsonObject(entity.data)
   const slug =
     shadowKey(entity, "pages") ??
@@ -754,29 +768,33 @@ async function loadGraphPageUncached(
 
     if (!schemas) return null
 
-    if (options.slug && !options.id && !includeDrafts) {
-      const { data: pageEntity, error: pageEntityError } = await supabase
+    if (options.slug && !options.id) {
+      let pageEntityQuery = supabase
         .from("entities")
         .select(
           "id, schema_id, slug, title, subtitle, summary, owner_member_id, published, data, created_at, updated_at",
         )
         .eq("schema_id", schemas.pageSchemaId)
         .eq("slug", shadowSlug("pages", options.slug))
-        .eq("published", true)
-        .maybeSingle()
+
+      if (!includeDrafts) {
+        pageEntityQuery = pageEntityQuery.eq("published", true)
+      }
+
+      const { data: pageEntity, error: pageEntityError } =
+        await pageEntityQuery.maybeSingle()
 
       if (pageEntityError || !pageEntity) return null
 
-      const page = pageRowFromShadowEntity(pageEntity)
+      const page = pageRecordFromEntity(pageEntity)
       if (!page) return null
 
       return await loadGraphPageFromEntityRelations({
         page,
         supabase,
-        includeDrafts: false,
+        includeDrafts,
         schemas,
         pageEntityId: pageEntity.id,
-        useShadowSections: true,
       })
     }
 
@@ -797,7 +815,7 @@ async function loadGraphPageUncached(
         await pageEntityQuery.maybeSingle()
 
       if (!pageEntityError && pageEntity) {
-        const page = pageRowFromShadowEntity(pageEntity)
+        const page = pageRecordFromEntity(pageEntity)
 
         if (page) {
           return await loadGraphPageFromEntityRelations({
@@ -806,38 +824,12 @@ async function loadGraphPageUncached(
             includeDrafts,
             schemas,
             pageEntityId: pageEntity.id,
-            useShadowSections: true,
           })
         }
       }
     }
 
-    let pageQuery = supabase
-      .from("pages")
-      .select("*")
-
-    if (options.id) {
-      pageQuery = pageQuery.eq("id", options.id)
-    } else if (options.slug) {
-      pageQuery = pageQuery.eq("slug", options.slug)
-    } else {
-      return null
-    }
-
-    if (!includeDrafts) {
-      pageQuery = pageQuery.eq("published", true)
-    }
-
-    const { data: page, error: pageError } = await pageQuery.maybeSingle()
-
-    if (pageError || !page) return null
-
-    return await loadGraphPageFromEntityRelations({
-      page,
-      supabase,
-      includeDrafts,
-      schemas,
-    })
+    return null
   } catch {
     return null
   }
@@ -849,14 +841,12 @@ async function loadGraphPageFromEntityRelations({
   includeDrafts,
   schemas,
   pageEntityId,
-  useShadowSections = false,
 }: {
   supabase: PublicSupabaseClient
-  page: PageRow
+  page: GraphPageRecord
   includeDrafts: boolean
   schemas?: ContentGraphSchemaContext
   pageEntityId?: string
-  useShadowSections?: boolean
 }): Promise<GraphPage> {
   const resolvedSchemas = schemas ?? await loadContentGraphSchemaContext(supabase)
   if (!resolvedSchemas) return { page, sections: [] }
@@ -894,113 +884,32 @@ async function loadGraphPageFromEntityRelations({
   const graphPageSections =
     pageSectionRelations as unknown as EntityGraphRelation[]
 
-  if (useShadowSections) {
-    const sections = graphPageSections
-      .filter((relation) => includeDrafts || relation.toEntity?.published === true)
-      .map((relation) =>
-        graphSectionFromShadowEntity({
-          entity: relation.toEntity,
-          schemas: resolvedSchemas,
-          sortOrder: relation.sort_order,
-        }),
-      )
-      .filter((section): section is GraphSection => Boolean(section))
-    const sectionShadowIds = sections.map((section) => section.id)
-    const itemsBySectionId = await loadSectionItemsByShadowId({
-      supabase,
-      sectionShadowIds,
-      relationSchemaId: resolvedSchemas.sectionEntityRelationSchemaId,
-      includeDrafts,
-    })
-
-    if (!itemsBySectionId) return { page, sections: [] }
-
-    return {
-      page,
-      sections: sections.map((section) => ({
-        ...section,
-        items: itemsBySectionId.get(section.id) ?? [],
-      })),
-    }
-  }
-
-  const sectionKeys = uniqueStrings(
-    graphPageSections.map((relation) => shadowKey(relation.toEntity, "sections")),
-  )
-
-  if (!sectionKeys.length) return { page, sections: [] }
-
-  let sectionsQuery = supabase
-    .from("sections")
-    .select("id, key, section_type, schema_id, eyebrow, title, subtitle, props")
-    .in("key", sectionKeys)
-
-  if (!includeDrafts) {
-    sectionsQuery = sectionsQuery.eq("published", true)
-  }
-
-  const { data: sections, error: sectionsError } = await sectionsQuery
-
-  if (sectionsError || !sections?.length) {
-    return { page, sections: [] }
-  }
-
-  const sectionShadowIds = uniqueStrings(
-    graphPageSections.map((relation) => relation.toEntity?.id),
-  )
-  const itemsByShadowId = await loadSectionItemsByShadowId({
+  const sections = graphPageSections
+    .filter((relation) => includeDrafts || relation.toEntity?.published === true)
+    .map((relation) =>
+      graphSectionFromShadowEntity({
+        entity: relation.toEntity,
+        schemas: resolvedSchemas,
+        sortOrder: relation.sort_order,
+      }),
+    )
+    .filter((section): section is GraphSection => Boolean(section))
+  const sectionShadowIds = sections.map((section) => section.id)
+  const itemsBySectionId = await loadSectionItemsByShadowId({
     supabase,
     sectionShadowIds,
     relationSchemaId: resolvedSchemas.sectionEntityRelationSchemaId,
     includeDrafts,
   })
 
-  if (!itemsByShadowId) return { page, sections: [] }
-
-  const sectionByKey = new Map(sections.map((section) => [section.key, section]))
-  const sectionKeyByShadowId = new Map(
-    graphPageSections
-      .map((relation) => [
-        relation.toEntity?.id,
-        shadowKey(relation.toEntity, "sections"),
-      ])
-      .filter((entry): entry is [string, string] => Boolean(entry[0] && entry[1])),
-  )
-  const itemsBySectionId = new Map<string, GraphSectionItem[]>()
-
-  for (const [sectionShadowId, items] of itemsByShadowId.entries()) {
-    const sectionKey = sectionKeyByShadowId.get(sectionShadowId)
-    const section = sectionKey ? sectionByKey.get(sectionKey) : null
-    if (!section) continue
-
-    itemsBySectionId.set(section.id, items)
-  }
+  if (!itemsBySectionId) return { page, sections: [] }
 
   return {
     page,
-    sections: graphPageSections
-      .map((relation) => {
-        const sectionKey = shadowKey(relation.toEntity, "sections")
-        const section = sectionKey ? sectionByKey.get(sectionKey) : null
-        if (!section) return null
-
-        return {
-          id: section.id,
-          key: section.key,
-          sectionType: section.section_type,
-          schemaId: section.schema_id,
-          schemaKey:
-            resolvedSchemas.schemaKeyById.get(section.schema_id) ??
-            `unregistered:${section.schema_id}`,
-          eyebrow: section.eyebrow,
-          title: section.title,
-          subtitle: section.subtitle,
-          props: section.props,
-          sortOrder: relation.sort_order,
-          items: itemsBySectionId.get(section.id) ?? [],
-        }
-      })
-      .filter((section): section is GraphSection => Boolean(section)),
+    sections: sections.map((section) => ({
+      ...section,
+      items: itemsBySectionId.get(section.id) ?? [],
+    })),
   }
 }
 

--- a/scripts/qa-cms-legacy-bridge-boundary.mjs
+++ b/scripts/qa-cms-legacy-bridge-boundary.mjs
@@ -4,7 +4,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs"
 import path from "node:path"
 
 const repoRoot = process.cwd()
-const scanRoots = ["app/ponix", "app/ponix-canvas", "lib/cms"]
+const scanRoots = ["app/ponix", "app/ponix-canvas", "lib/cms", "lib/data"]
 const codeExtensions = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs"])
 const allowedFiles = new Set()
 
@@ -20,6 +20,14 @@ const forbiddenPatterns = [
   {
     label: "legacy relation source_table marker",
     pattern: /source_table\s*:\s*["'`](page_sections|section_entities)["'`]/,
+  },
+  {
+    label: "direct pages compatibility table access",
+    pattern: /(?:^|[^\w])from\(\s*["'`]pages["'`]\s*\)/,
+  },
+  {
+    label: "direct sections compatibility table access",
+    pattern: /(?:^|[^\w])from\(\s*["'`]sections["'`]\s*\)/,
   },
 ]
 
@@ -77,11 +85,21 @@ function runSelfTest() {
     "app/ponix/relations/actions.ts",
     'source_table: "section_entities"',
   )
+  const pageAccess = findViolations(
+    "lib/data/content-graph.ts",
+    'await supabase.from("pages").select("*")',
+  )
+  const sectionAccess = findViolations(
+    "lib/data/content-graph.ts",
+    'await supabase.from("sections").select("id")',
+  )
 
   if (
     blocked.length !== 1 ||
     retiredBoundary.length !== 1 ||
-    sourceMarker.length !== 1
+    sourceMarker.length !== 1 ||
+    pageAccess.length !== 1 ||
+    sectionAccess.length !== 1
   ) {
     throw new Error("Self-test failed for CMS legacy bridge boundary guard.")
   }
@@ -106,14 +124,14 @@ console.table([
 ])
 
 if (violations.length) {
-  console.error("\nDirect legacy composition table access found in runtime CMS code:")
+  console.error("\nDirect legacy/compatibility table access found in runtime code:")
   for (const violation of violations) {
     console.error(
       `- ${violation.file}:${violation.line} ${violation.rule}: ${violation.text}`,
     )
   }
   console.error(
-    "\nRuntime CMS code must stay graph-primary through entity_relations. Keep legacy mirror parity checks in QA scripts only.",
+    "\nRuntime CMS and public loaders must stay graph-primary through entities/entity_relations. Keep legacy table reads in classified QA or migration scripts only.",
   )
   process.exitCode = 1
 }

--- a/scripts/qa-content-graph-integrity.mjs
+++ b/scripts/qa-content-graph-integrity.mjs
@@ -49,10 +49,6 @@ function bySortThenCreated(left, right) {
   )
 }
 
-function uniqueStrings(values) {
-  return [...new Set(values.filter((value) => typeof value === "string" && value))]
-}
-
 function stable(value) {
   if (Array.isArray(value)) return value.map((item) => stable(item))
   if (!value || typeof value !== "object") return value
@@ -75,13 +71,29 @@ function hasUsableRelationCopy(relation) {
   return Boolean(relation.relation_type && relation.slot)
 }
 
-function shadowSlug(sourceTable, sourceKey) {
-  return `${sourceTable === "pages" ? PAGE_SHADOW_PREFIX : SECTION_SHADOW_PREFIX}${sourceKey}`
-}
-
 function shadowKey(entity, sourceTable) {
   const prefix = sourceTable === "pages" ? PAGE_SHADOW_PREFIX : SECTION_SHADOW_PREFIX
   return entity?.slug?.startsWith(prefix) ? entity.slug.slice(prefix.length) : null
+}
+
+function objectValue(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {}
+}
+
+function stringValue(value) {
+  return typeof value === "string" && value.trim() ? value : null
+}
+
+function pageKey(entity) {
+  return shadowKey(entity, "pages") ?? stringValue(objectValue(entity?.data).slug)
+}
+
+function sectionKey(entity) {
+  return shadowKey(entity, "sections") ?? stringValue(objectValue(entity?.data).key)
+}
+
+function sectionType(entity) {
+  return stringValue(objectValue(entity?.data).section_type)
 }
 
 async function loadSchemaContext(supabase) {
@@ -117,35 +129,36 @@ async function loadSchemaContext(supabase) {
   }
 }
 
-async function checkShadowUniqueness(supabase, sourceTable, schemas) {
-  const sourceRows = requireOk(
-    sourceTable === "pages"
-      ? await supabase.from("pages").select("id, slug").order("slug", { ascending: true })
-      : await supabase.from("sections").select("id, key").order("key", { ascending: true }),
-    `${sourceTable} source records`,
-  )
-  const sourceKeys = new Set(
-    sourceRows.map((row) => (sourceTable === "pages" ? row.slug : row.key)),
-  )
+async function checkEntityKeyUniqueness(supabase, sourceTable, schemas) {
   const rows = requireOk(
     sourceTable === "pages"
       ? await supabase
           .from("entities")
-          .select("id, slug, title")
+          .select("id, slug, title, data")
           .eq("schema_id", schemas.pageSchemaId)
           .order("slug", { ascending: true })
       : await supabase
           .from("entities")
-          .select("id, slug, title")
+          .select("id, slug, title, data")
           .in("schema_id", schemas.sectionSchemaIds)
           .order("slug", { ascending: true }),
-    `${sourceTable} shadow entities`,
+    `${sourceTable} graph entities`,
   )
 
   const bySourceKey = new Map()
+  const missingKeys = []
   for (const row of rows) {
-    const key = shadowKey(row, sourceTable)
-    if (!key) continue
+    const key = sourceTable === "pages" ? pageKey(row) : sectionKey(row)
+    if (!key) {
+      missingKeys.push(
+        issue("Graph entity is missing its stable content key", {
+          sourceTable,
+          entityId: row.id,
+          slug: row.slug,
+        }),
+      )
+      continue
+    }
 
     const existing = bySourceKey.get(key) ?? []
     existing.push(row)
@@ -155,75 +168,32 @@ async function checkShadowUniqueness(supabase, sourceTable, schemas) {
   const duplicates = [...bySourceKey.entries()]
     .filter(([, entries]) => entries.length > 1)
     .map(([sourceId, entries]) =>
-      issue("Source record has multiple graph shadow entities", {
+      issue("Content key has multiple graph entities", {
         sourceTable,
         sourceId,
         entityIds: entries.map((entry) => entry.id),
       }),
     )
-  const missing = [...sourceKeys]
-    .filter((sourceKey) => !bySourceKey.has(sourceKey))
-    .map((sourceKey) =>
-      issue("Source record is missing a graph shadow entity", {
-        sourceTable,
-        sourceKey,
-      }),
-    )
-  const extras = [...bySourceKey.keys()]
-    .filter((sourceKey) => !sourceKeys.has(sourceKey))
-    .map((sourceKey) =>
-      issue("Graph shadow entity has no matching source record", {
-        sourceTable,
-        sourceKey,
-      }),
-    )
 
   return {
     sourceTable,
-    shadows: rows.length,
-    duplicates: [...duplicates, ...missing, ...extras],
-    ok: duplicates.length === 0 && missing.length === 0 && extras.length === 0,
+    entities: rows.length,
+    duplicates: [...duplicates, ...missingKeys],
+    ok: duplicates.length === 0 && missingKeys.length === 0,
   }
-}
-
-async function loadPageEntity(supabase, page, schemas) {
-  const rows = requireOk(
-    await supabase
-      .from("entities")
-      .select("id, slug, title")
-      .eq("schema_id", schemas.pageSchemaId)
-      .eq("slug", shadowSlug("pages", page.slug)),
-    `page shadow entity ${page.slug}`,
-  )
-
-  return rows
 }
 
 async function checkPageComposition(supabase, page, schemas) {
   const issues = []
-  const pageEntities = await loadPageEntity(supabase, page, schemas)
+  const slug = pageKey(page)
 
-  if (pageEntities.length !== 1) {
+  if (!slug) {
     issues.push(
-      issue("Published page must resolve to exactly one graph shadow entity", {
-        page: page.slug,
-        pageId: page.id,
-        shadowCount: pageEntities.length,
-        shadowIds: pageEntities.map((entity) => entity.id),
+      issue("Published page entity must expose a stable route slug", {
+        pageEntityId: page.id,
+        rawSlug: page.slug,
       }),
     )
-  }
-
-  const pageEntity = pageEntities[0]
-  if (!pageEntity) {
-    return {
-      slug: page.slug,
-      sections: 0,
-      items: 0,
-      pageSectionRelations: 0,
-      sectionItemRelations: 0,
-      issues,
-    }
   }
 
   const pageSectionRelations = requireOk(
@@ -245,14 +215,15 @@ async function checkPageComposition(supabase, page, schemas) {
             schema_id,
             slug,
             title,
-            published
+            published,
+            data
           )
         `,
       )
       .eq("schema_id", schemas.pageSectionRelationSchemaId)
-      .eq("from_entity_id", pageEntity.id)
+      .eq("from_entity_id", page.id)
       .order("sort_order", { ascending: true }),
-    `page graph section relations ${page.slug}`,
+    `page graph section relations ${slug ?? page.id}`,
   )
 
   const duplicateSectionTargets = new Map()
@@ -263,7 +234,7 @@ async function checkPageComposition(supabase, page, schemas) {
     ) {
       issues.push(
         issue("Page relation has an invalid relation contract", {
-          page: page.slug,
+          page: slug ?? page.id,
           relationId: relation.id,
           relationType: relation.relation_type,
           slot: relation.slot,
@@ -271,11 +242,11 @@ async function checkPageComposition(supabase, page, schemas) {
       )
     }
 
-    const sectionKey = shadowKey(relation.toEntity, "sections")
-    if (!sectionKey) {
+    const targetSectionKey = sectionKey(relation.toEntity)
+    if (!targetSectionKey) {
       issues.push(
-        issue("Page relation must target a section shadow entity", {
-          page: page.slug,
+        issue("Page relation must target a section entity with a stable key", {
+          page: slug ?? page.id,
           relationId: relation.id,
           toEntity: relation.toEntity,
         }),
@@ -283,16 +254,16 @@ async function checkPageComposition(supabase, page, schemas) {
       continue
     }
 
-    const existing = duplicateSectionTargets.get(sectionKey) ?? []
+    const existing = duplicateSectionTargets.get(targetSectionKey) ?? []
     existing.push(relation.id)
-    duplicateSectionTargets.set(sectionKey, existing)
+    duplicateSectionTargets.set(targetSectionKey, existing)
   }
 
   for (const [sectionKey, relationIds] of duplicateSectionTargets.entries()) {
     if (relationIds.length > 1) {
       issues.push(
         issue("Page contains the same section more than once", {
-          page: page.slug,
+          page: slug ?? page.id,
           sectionKey,
           relationIds,
         }),
@@ -300,44 +271,40 @@ async function checkPageComposition(supabase, page, schemas) {
     }
   }
 
-  const sectionIds = uniqueStrings(
-    pageSectionRelations.map((relation) => shadowKey(relation.toEntity, "sections")),
-  )
-  const sections = sectionIds.length
-    ? requireOk(
-        await supabase
-          .from("sections")
-          .select("id, key, title, published")
-          .in("key", sectionIds)
-          .eq("published", true),
-        `published sections ${page.slug}`,
-      )
-    : []
-  const sectionByKey = new Map(sections.map((section) => [section.key, section]))
-  const sectionShadowIds = []
-  const sectionIdByShadowId = new Map()
+  const sections = []
+  const sectionEntityIds = []
+  const sectionIdByEntityId = new Map()
 
   for (const relation of pageSectionRelations) {
-    const sectionKey = shadowKey(relation.toEntity, "sections")
-    if (!sectionKey) continue
+    const targetSectionKey = sectionKey(relation.toEntity)
+    if (!targetSectionKey) continue
 
-    const section = sectionByKey.get(sectionKey)
-    if (!section) {
+    if (
+      !relation.toEntity ||
+      !schemas.sectionSchemaIds.includes(relation.toEntity.schema_id) ||
+      relation.toEntity.published !== true ||
+      !sectionType(relation.toEntity)
+    ) {
       issues.push(
-        issue("Page relation targets a missing or unpublished section", {
-          page: page.slug,
+        issue("Page relation targets an invalid or unpublished section entity", {
+          page: slug ?? page.id,
           relationId: relation.id,
-          sectionKey,
+          sectionKey: targetSectionKey,
+          sectionEntityId: relation.to_entity_id,
+          schemaId: relation.toEntity?.schema_id,
+          published: relation.toEntity?.published,
+          sectionType: sectionType(relation.toEntity),
         }),
       )
       continue
     }
 
-    sectionShadowIds.push(relation.toEntity.id)
-    sectionIdByShadowId.set(relation.toEntity.id, section.id)
+    sectionEntityIds.push(relation.toEntity.id)
+    sectionIdByEntityId.set(relation.toEntity.id, relation.toEntity.id)
+    sections.push(relation.toEntity)
   }
 
-  const sectionItemRelations = sectionShadowIds.length
+  const sectionItemRelations = sectionEntityIds.length
     ? requireOk(
         await supabase
           .from("entity_relations")
@@ -362,18 +329,18 @@ async function checkPageComposition(supabase, page, schemas) {
             `,
           )
           .eq("schema_id", schemas.sectionEntityRelationSchemaId)
-          .in("from_entity_id", sectionShadowIds),
-        `section item graph relations ${page.slug}`,
+          .in("from_entity_id", sectionEntityIds),
+        `section item graph relations ${slug ?? page.id}`,
       )
     : []
 
   const itemsBySectionId = new Map()
   for (const relation of [...sectionItemRelations].sort(bySortThenCreated)) {
-    const sectionId = sectionIdByShadowId.get(relation.from_entity_id)
+    const sectionId = sectionIdByEntityId.get(relation.from_entity_id)
     if (!sectionId) {
       issues.push(
         issue("Item relation is attached to a section outside this page", {
-          page: page.slug,
+          page: slug ?? page.id,
           relationId: relation.id,
           fromEntityId: relation.from_entity_id,
         }),
@@ -384,7 +351,7 @@ async function checkPageComposition(supabase, page, schemas) {
     if (!hasUsableRelationCopy(relation)) {
       issues.push(
         issue("Item relation must define renderer-facing relation copy", {
-          page: page.slug,
+          page: slug ?? page.id,
           relationId: relation.id,
           sectionId,
           relationType: relation.relation_type,
@@ -396,7 +363,7 @@ async function checkPageComposition(supabase, page, schemas) {
     if (!relation.toEntity?.id || relation.toEntity.published !== true) {
       issues.push(
         issue("Item relation targets a missing or unpublished entity", {
-          page: page.slug,
+          page: slug ?? page.id,
           relationId: relation.id,
           sectionId,
           targetEntityId: relation.to_entity_id,
@@ -411,7 +378,7 @@ async function checkPageComposition(supabase, page, schemas) {
   }
 
   return {
-    slug: page.slug,
+    slug: slug ?? page.id,
     sections: sections.length,
     items: [...itemsBySectionId.values()].reduce(
       (total, items) => total + items.length,
@@ -438,16 +405,17 @@ async function main() {
   const schemas = await loadSchemaContext(supabase)
   const pages = requireOk(
     await supabase
-      .from("pages")
-      .select("id, slug, title, published")
+      .from("entities")
+      .select("id, schema_id, slug, title, published, data")
+      .eq("schema_id", schemas.pageSchemaId)
       .eq("published", true)
       .order("slug", { ascending: true }),
     "published pages",
   )
 
-  const shadowChecks = [
-    await checkShadowUniqueness(supabase, "pages", schemas),
-    await checkShadowUniqueness(supabase, "sections", schemas),
+  const entityKeyChecks = [
+    await checkEntityKeyUniqueness(supabase, "pages", schemas),
+    await checkEntityKeyUniqueness(supabase, "sections", schemas),
   ]
   const pageResults = []
   for (const page of pages) {
@@ -466,18 +434,18 @@ async function main() {
     })),
   )
 
-  console.log("\nGraph shadow cardinality")
+  console.log("\nGraph entity key cardinality")
   console.table(
-    shadowChecks.map((result) => ({
+    entityKeyChecks.map((result) => ({
       sourceTable: result.sourceTable,
-      shadows: result.shadows,
+      entities: result.entities,
       duplicateSources: result.duplicates.length,
       integrity: result.ok ? "ok" : "failed",
     })),
   )
 
   const failures = [
-    ...shadowChecks.flatMap((result) => result.duplicates),
+    ...entityKeyChecks.flatMap((result) => result.duplicates),
     ...pageResults.flatMap((result) => result.issues),
   ]
 

--- a/scripts/qa-schema-semantic-identity.mjs
+++ b/scripts/qa-schema-semantic-identity.mjs
@@ -44,6 +44,14 @@ function issue(message, context = {}) {
   return { message, context }
 }
 
+function objectValue(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {}
+}
+
+function stringValue(value) {
+  return typeof value === "string" && value.trim() ? value : null
+}
+
 async function main() {
   loadEnv(envPath)
 
@@ -67,20 +75,14 @@ async function main() {
   const entities = requireOk(
     await supabase
       .from("entities")
-      .select("id, schema_id, slug, title")
+      .select("id, schema_id, slug, title, data")
       .order("title", { ascending: true }),
     "entities semantic identity",
-  )
-  const sections = requireOk(
-    await supabase
-      .from("sections")
-      .select("id, schema_id, key, title")
-      .order("key", { ascending: true }),
-    "sections schema identity",
   )
 
   const schemaById = new Map(schemas.map((schema) => [schema.id, schema]))
   const failures = []
+  let sectionEntityCount = 0
 
   for (const schema of schemas) {
     if (!schema.semantic_kind || !String(schema.semantic_kind).trim()) {
@@ -119,30 +121,29 @@ async function main() {
         }),
       )
     }
-  }
 
-  for (const section of sections) {
-    const schema = section.schema_id ? schemaById.get(section.schema_id) : null
+    if (schema?.kind !== "section") continue
 
-    if (!schema) {
+    sectionEntityCount += 1
+    const data = objectValue(entity.data)
+    if (!stringValue(data.key) && !entity.slug?.startsWith("section:")) {
       failures.push(
-        issue("Section cannot resolve an active schema", {
-          sectionId: section.id,
-          schemaId: section.schema_id,
-          key: section.key,
+        issue("Section entity is missing a stable key", {
+          sectionEntityId: entity.id,
+          schemaId: entity.schema_id,
+          schemaKey: schema.schema_key,
+          slug: entity.slug,
         }),
       )
-      continue
     }
 
-    if (schema.kind !== "section") {
+    if (!stringValue(data.section_type)) {
       failures.push(
-        issue("Section schema has non-section kind", {
-          sectionId: section.id,
-          schemaId: section.schema_id,
+        issue("Section entity is missing renderer type", {
+          sectionEntityId: entity.id,
+          schemaId: entity.schema_id,
           schemaKey: schema.schema_key,
-          key: section.key,
-          schemaKind: schema.kind,
+          slug: entity.slug,
         }),
       )
     }
@@ -153,15 +154,15 @@ async function main() {
     {
       activeSchemas: schemas.length,
       entities: entities.length,
-      sections: sections.length,
+      sectionEntities: sectionEntityCount,
       missingSemanticKind: failures.filter((failure) =>
         failure.message.includes("missing semantic_kind"),
       ).length,
       unresolvedEntities: failures.filter((failure) =>
         failure.message.includes("Entity cannot resolve"),
       ).length,
-      unresolvedSections: failures.filter((failure) =>
-        failure.message.includes("Section cannot resolve"),
+      invalidSectionEntities: failures.filter((failure) =>
+        failure.message.includes("Section entity"),
       ).length,
       semanticDrift: failures.filter((failure) =>
         failure.message.includes("differs"),


### PR DESCRIPTION
Closes #159.\n\n## Summary\n- Remove active runtime fallback reads from public.pages/public.sections in content graph and CMS relation paths.\n- Project page/section records from entities instead of typing runtime code against compatibility table rows.\n- Convert content graph QA to entity-only page/section validation and expand boundary guards to block pages/sections table reads in runtime loaders.\n- Update content graph docs and SQL recipes for entity-native page/section operations.\n\n## Validation\n- pnpm exec tsc --noEmit\n- pnpm run lint\n- pnpm run build\n- pnpm run qa:cms-db-first-loaders\n- pnpm run qa:cms-legacy-bridge-boundary\n- pnpm run qa:content-graph\n- pnpm run qa:schema-semantic-identity\n- pnpm run qa:schema-mirror-removal-readiness\n- pnpm run qa:graph-primary-seed-writes\n- git diff --check\n- cmux compose smoke: no browser errors; section switch updates URL/panel and iframe selected state without iframe reload\n\n## Safety\nNo destructive SQL, no table drops, no production data writes.