### PR TITLE
Retire compatibility tables from seed tooling

### DIFF
--- a/docs/content-graph.md
+++ b/docs/content-graph.md
@@ -58,9 +58,10 @@ Current PONIX contract:
 - Routine CMS composition writes target `entity_relations` without legacy
   source markers.
 - Maintenance apply scripts and generated seed migrations that refresh scraped
-  or Instagram content should also write section placement through
-  `entity_relations`, not directly through `page_sections` or
-  `section_entities`.
+  or Instagram content should treat page and section records as graph
+  `entities`, then write placement through `entity_relations`. They must not
+  require the compatibility `pages`, `sections`, `page_sections`, or
+  `section_entities` tables.
 - Code that mutates page or section composition must pass the graph relation id.
 - `pnpm run qa:content-graph` checks graph-only page composition integrity:
   page/section entity key uniqueness, section ordering, relation contracts, and
@@ -72,8 +73,9 @@ Current PONIX contract:
 - Use `pnpm run qa:legacy-media-table-readiness` after media graph changes to
   verify runtime code does not reintroduce direct legacy media table reads and
   the post-drop entity graph still exposes performance/video/photo content.
-- `pnpm run qa:graph-primary-seed-writes` checks that seed apply scripts and
-  migration generators do not reintroduce direct legacy composition writes.
+- `pnpm run qa:graph-primary-seed-writes` checks that seed apply scripts,
+  write helpers, and migration generators do not reintroduce direct
+  compatibility page/section table access or legacy composition writes.
 
 ## Tables
 

--- a/scripts/apply-instagram-feed.mjs
+++ b/scripts/apply-instagram-feed.mjs
@@ -2,6 +2,9 @@ import { createClient } from "@supabase/supabase-js"
 import { readFileSync } from "node:fs"
 import {
   deleteSectionEntityRelations,
+  loadPageEntityMapBySlug,
+  loadSectionEntityMapByKey,
+  upsertSectionEntities,
   upsertPageSectionRelations,
   upsertSectionEntityRelations,
 } from "./content-graph-write-helpers.mjs"
@@ -117,8 +120,9 @@ async function main() {
     "section/performance-updates/v1",
   )
 
-  requireOk(
-    await supabase.from("sections").upsert(
+  const performanceUpdatesByKey = await upsertSectionEntities(
+    supabase,
+    [
       {
         key: "performances-updates",
         section_type: "entity_post_grid",
@@ -129,35 +133,32 @@ async function main() {
         published: true,
         props: {},
       },
-      { onConflict: "key" },
-    ),
-    "upsert performances-updates section",
+    ],
+    "upsert performances-updates section entity",
   )
 
-  const page = requireOk(
-    await supabase
-      .from("pages")
-      .select("id,slug")
-      .eq("slug", "performances")
-      .maybeSingle(),
-    "load performances page",
+  const pageBySlug = await loadPageEntityMapBySlug(
+    supabase,
+    ["performances"],
+    "load performances page entity",
   )
-  const performanceUpdatesSection = requireOk(
-    await supabase
-      .from("sections")
-      .select("id,key")
-      .eq("key", "performances-updates")
-      .maybeSingle(),
-    "load performances-updates section",
+  const sectionByKey = await loadSectionEntityMapByKey(
+    supabase,
+    ["photos-gallery", "performances-updates"],
+    "load Instagram target section entities",
   )
+  const page = pageBySlug.get("performances")
+  const performanceUpdatesSection =
+    performanceUpdatesByKey.get("performances-updates") ??
+    sectionByKey.get("performances-updates")
 
   if (page && performanceUpdatesSection) {
     await upsertPageSectionRelations(
       supabase,
       [
         {
-          page_id: page.id,
-          section_id: performanceUpdatesSection.id,
+          page_entity_id: page.id,
+          section_entity_id: performanceUpdatesSection.id,
           sort_order: 25,
           props: {},
         },
@@ -252,19 +253,12 @@ async function main() {
     )
   }
 
-  const gallerySection = requireOk(
-    await supabase
-      .from("sections")
-      .select("id,key")
-      .eq("key", "photos-gallery")
-      .maybeSingle(),
-    "load photos-gallery section",
-  )
+  const gallerySection = sectionByKey.get("photos-gallery")
 
   const sectionIds = [gallerySection?.id, performanceUpdatesSection?.id].filter(Boolean)
   if (sectionIds.length && instagramIds.length) {
     await deleteSectionEntityRelations(supabase, {
-      sectionIds,
+      sectionEntityIds: sectionIds,
       entityIds: instagramIds,
       label: "delete old Instagram section links",
     })
@@ -293,7 +287,7 @@ async function main() {
   const sectionEntities = [
     ...(gallerySection
       ? photos.map((entity, index) => ({
-          section_id: gallerySection.id,
+          section_entity_id: gallerySection.id,
           entity_id: entity.id,
           relation_type: "features_photo",
           slot: "gallery",
@@ -303,7 +297,7 @@ async function main() {
       : []),
     ...(performanceUpdatesSection
       ? posts.map((entity, index) => ({
-          section_id: performanceUpdatesSection.id,
+          section_entity_id: performanceUpdatesSection.id,
           entity_id: entity.id,
           relation_type: "features_post",
           slot: entity.data?.content_kind ?? "notice",

--- a/scripts/apply-scraped-content.mjs
+++ b/scripts/apply-scraped-content.mjs
@@ -2,7 +2,11 @@ import { createClient } from "@supabase/supabase-js"
 import { readFileSync } from "node:fs"
 import {
   deleteSectionEntityRelations,
+  loadPageEntityMapBySlug,
+  loadSectionEntityMapByKey,
+  upsertPageEntities,
   upsertPageSectionRelations,
+  upsertSectionEntities,
   upsertSectionEntityRelations,
 } from "./content-graph-write-helpers.mjs"
 
@@ -168,8 +172,9 @@ async function main() {
   const schemas = await loadSchemaRegistry(supabase)
   const defaultRelationSchemaId = schemaIdByKey(schemas, defaultRelationSchemaKey)
 
-  requireOk(
-    await supabase.from("pages").upsert(
+  await upsertPageEntities(
+    supabase,
+    [
       {
         slug: "history",
         title: "브레멘 히스토리",
@@ -178,63 +183,60 @@ async function main() {
         published: true,
         props: {},
       },
-      { onConflict: "slug" },
-    ),
-    "upsert history page",
+    ],
+    "upsert history page entity",
   )
 
-  requireOk(
-    await supabase.from("sections").upsert(
-      [
-        {
-          key: "videos-by-event",
-          section_type: "entity_grouped_grid",
-          schema_id: schemaIdByKey(schemas, "section/video-event-playlists/v1"),
-          eyebrow: "Events",
-          title: "Recordings by stage",
-          subtitle: "공연 단위로 묶어 보는 영상 기록",
-          published: true,
-          props: {},
-        },
-        {
-          key: "history-timeline",
-          section_type: "entity_timeline",
-          schema_id: schemaIdByKey(schemas, "section/history-timeline/v1"),
-          eyebrow: "Since 2001",
-          title: "Bremen History",
-          subtitle: "궤짝 유랑 악단에서 현재의 브레멘까지",
-          published: true,
-          props: {},
-        },
-      ],
-      { onConflict: "key" },
-    ),
-    "upsert extra sections",
+  await upsertSectionEntities(
+    supabase,
+    [
+      {
+        key: "videos-by-event",
+        section_type: "entity_grouped_grid",
+        schema_id: schemaIdByKey(schemas, "section/video-event-playlists/v1"),
+        eyebrow: "Events",
+        title: "Recordings by stage",
+        subtitle: "공연 단위로 묶어 보는 영상 기록",
+        published: true,
+        props: {},
+      },
+      {
+        key: "history-timeline",
+        section_type: "entity_timeline",
+        schema_id: schemaIdByKey(schemas, "section/history-timeline/v1"),
+        eyebrow: "Since 2001",
+        title: "Bremen History",
+        subtitle: "궤짝 유랑 악단에서 현재의 브레멘까지",
+        published: true,
+        props: {},
+      },
+    ],
+    "upsert extra section entities",
   )
 
-  const pages = requireOk(
-    await supabase.from("pages").select("id,slug").in("slug", ["videos", "history"]),
-    "load pages",
+  const pageBySlug = await loadPageEntityMapBySlug(
+    supabase,
+    ["videos", "history"],
+    "load page entities",
   )
-  const sections = requireOk(
-    await supabase.from("sections").select("id,key").in("key", sectionKeys),
-    "load sections",
+  const sectionByKey = await loadSectionEntityMapByKey(
+    supabase,
+    sectionKeys,
+    "load section entities",
   )
-  const pageBySlug = new Map(pages.map((page) => [page.slug, page]))
-  const sectionByKey = new Map(sections.map((section) => [section.key, section]))
 
   await upsertPageSectionRelations(
     supabase,
     [
       {
-        page_id: pageBySlug.get("videos").id,
-        section_id: sectionByKey.get("videos-by-event").id,
+        page_entity_id: pageBySlug.get("videos").id,
+        section_entity_id: sectionByKey.get("videos-by-event").id,
         sort_order: 25,
         props: {},
       },
       {
-        page_id: pageBySlug.get("history").id,
-        section_id: sectionByKey.get("history-timeline").id,
+        page_entity_id: pageBySlug.get("history").id,
+        section_entity_id: sectionByKey.get("history-timeline").id,
         sort_order: 10,
         props: {},
       },
@@ -364,15 +366,15 @@ async function main() {
     "upsert relations",
   )
 
-  const seededSections = requireOk(
-    await supabase.from("sections").select("id,key").in("key", sectionKeys),
-    "reload sections",
+  const seededSectionByKey = await loadSectionEntityMapByKey(
+    supabase,
+    sectionKeys,
+    "reload section entities",
   )
-  const seededSectionByKey = new Map(seededSections.map((section) => [section.key, section]))
-  const sectionIds = seededSections.map((section) => section.id)
+  const sectionIds = [...seededSectionByKey.values()].map((section) => section.id)
 
   await deleteSectionEntityRelations(supabase, {
-    sectionIds,
+    sectionEntityIds: sectionIds,
     label: "clear section entities",
   })
 
@@ -413,7 +415,7 @@ async function main() {
     if (!section) return
     items.forEach((item, index) => {
       sectionEntities.push({
-        section_id: section.id,
+        section_entity_id: section.id,
         entity_id: item.id,
         relation_type: "item",
         slot: slotForItem(item),

--- a/scripts/content-graph-write-helpers.mjs
+++ b/scripts/content-graph-write-helpers.mjs
@@ -20,8 +20,23 @@ function uniqueStrings(values) {
   return [...new Set(values.filter((value) => typeof value === "string" && value))]
 }
 
-function shadowSlug(sourceTable, sourceKey) {
-  return `${sourceTable === "pages" ? "page:" : "section:"}${sourceKey}`
+function pageEntitySlug(slug) {
+  return `page:${slug}`
+}
+
+function sectionEntitySlug(key) {
+  return `section:${key}`
+}
+
+function objectValue(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {}
+}
+
+function mergeData(base, patch) {
+  return {
+    ...objectValue(base),
+    ...objectValue(patch),
+  }
 }
 
 async function loadSchemaIdByKey(supabase, schemaKey, label) {
@@ -42,24 +57,14 @@ async function loadSchemaIdByKey(supabase, schemaKey, label) {
   return rows.id
 }
 
-async function loadShadowSchemaIds(supabase, sourceTable, label) {
-  if (sourceTable === "pages") {
-    return [
-      await loadSchemaIdByKey(
-        supabase,
-        "page/default/v1",
-        `${label} page shadow`,
-      ),
-    ]
-  }
-
+async function loadSectionSchemaIds(supabase, label) {
   const rows = requireOk(
     await supabase
       .from("entity_schemas")
       .select("id")
       .eq("kind", "section")
       .eq("active", true),
-    `${label} section shadow schemas`,
+    `${label} section schemas`,
   )
   const ids = rows.map((row) => row.id).filter(Boolean)
   if (!ids.length) {
@@ -69,75 +74,191 @@ async function loadShadowSchemaIds(supabase, sourceTable, label) {
   return ids
 }
 
-async function upsertRelationRows(supabase, rows, label) {
+async function upsertChunked(supabase, table, rows, options, label) {
   for (const [index, part] of chunk(rows).entries()) {
     requireOk(
-      await supabase
-        .from("entity_relations")
-        .upsert(part, { onConflict: "from_entity_id,to_entity_id,relation_type,slot" }),
+      await supabase.from(table).upsert(part, options),
       `${label} chunk ${index + 1}`,
     )
   }
 }
 
-async function loadShadowEntityMap(supabase, sourceTable, sourceIds, label) {
-  const ids = uniqueStrings(sourceIds)
-  if (!ids.length) return new Map()
-
-  const sourceRows = []
-  for (const part of chunk(ids)) {
-    sourceRows.push(
-      ...requireOk(
-        sourceTable === "pages"
-          ? await supabase.from("pages").select("id,slug").in("id", part)
-          : await supabase.from("sections").select("id,key").in("id", part),
-        `${label} ${sourceTable} source records`,
-      ),
-    )
-  }
-
-  const sourceKeyById = new Map(
-    sourceRows.map((row) => [row.id, sourceTable === "pages" ? row.slug : row.key]),
+async function upsertRelationRows(supabase, rows, label) {
+  await upsertChunked(
+    supabase,
+    "entity_relations",
+    rows,
+    { onConflict: "from_entity_id,to_entity_id,relation_type,slot" },
+    label,
   )
-  const missingSources = ids.filter((id) => !sourceKeyById.has(id))
-  if (missingSources.length) {
-    throw new Error(
-      `${label}: missing ${sourceTable} source records for ${missingSources.join(", ")}`,
-    )
-  }
+}
 
-  const shadowSlugs = ids.map((id) => shadowSlug(sourceTable, sourceKeyById.get(id)))
-  const schemaIds = await loadShadowSchemaIds(supabase, sourceTable, label)
+async function loadEntitiesBySlugs(supabase, slugs, schemaIds, label) {
+  const entitySlugs = uniqueStrings(slugs)
+  if (!entitySlugs.length) return []
   const rows = []
-  for (const part of chunk(shadowSlugs)) {
+  for (const part of chunk(entitySlugs)) {
     const query = supabase
       .from("entities")
-      .select("id,slug")
+      .select("id,slug,schema_id,title,data,published")
       .in("schema_id", schemaIds)
       .in("slug", part)
 
-    rows.push(
-      ...requireOk(await query, `${label} ${sourceTable} shadow entities`),
-    )
+    rows.push(...requireOk(await query, label))
   }
 
-  const idByShadowSlug = new Map(rows.map((row) => [row.slug, row.id]))
-  const bySourceId = new Map(
-    ids
-      .map((id) => [
-        id,
-        idByShadowSlug.get(shadowSlug(sourceTable, sourceKeyById.get(id))),
-      ])
-      .filter(([, entityId]) => typeof entityId === "string" && entityId),
+  return rows
+}
+
+export async function loadPageEntityMapBySlug(supabase, slugs, label = "load page entities") {
+  const pageSlugs = uniqueStrings(slugs)
+  if (!pageSlugs.length) return new Map()
+
+  const pageSchemaId = await loadSchemaIdByKey(
+    supabase,
+    "page/default/v1",
+    `${label} page`,
   )
-  const missing = ids.filter((id) => !bySourceId.has(id))
+  const rows = await loadEntitiesBySlugs(
+    supabase,
+    pageSlugs.map(pageEntitySlug),
+    [pageSchemaId],
+    label,
+  )
+  const bySlug = new Map(
+    rows.map((row) => [row.slug.replace(/^page:/, ""), row]),
+  )
+  const missing = pageSlugs.filter((slug) => !bySlug.has(slug))
   if (missing.length) {
-    throw new Error(
-      `${label}: missing ${sourceTable} shadow entities for ${missing.join(", ")}`,
-    )
+    throw new Error(`${label}: missing page entities for ${missing.join(", ")}`)
   }
 
-  return bySourceId
+  return bySlug
+}
+
+export async function loadSectionEntityMapByKey(
+  supabase,
+  keys,
+  label = "load section entities",
+) {
+  const sectionKeys = uniqueStrings(keys)
+  if (!sectionKeys.length) return new Map()
+
+  const sectionSchemaIds = await loadSectionSchemaIds(supabase, label)
+  const rows = await loadEntitiesBySlugs(
+    supabase,
+    sectionKeys.map(sectionEntitySlug),
+    sectionSchemaIds,
+    label,
+  )
+  const byKey = new Map(
+    rows.map((row) => [row.slug.replace(/^section:/, ""), row]),
+  )
+  const missing = sectionKeys.filter((key) => !byKey.has(key))
+  if (missing.length) {
+    throw new Error(`${label}: missing section entities for ${missing.join(", ")}`)
+  }
+
+  return byKey
+}
+
+export async function upsertPageEntities(supabase, pages, label = "upsert page entities") {
+  const rows = pages.filter(Boolean)
+  if (!rows.length) return new Map()
+
+  const pageSchemaId = await loadSchemaIdByKey(
+    supabase,
+    "page/default/v1",
+    `${label} page`,
+  )
+  const existingRows = await loadEntitiesBySlugs(
+    supabase,
+    rows.map((row) => pageEntitySlug(row.slug)),
+    [pageSchemaId],
+    `${label} existing pages`,
+  )
+  const existingBySlug = new Map(existingRows.map((row) => [row.slug, row]))
+
+  await upsertChunked(
+    supabase,
+    "entities",
+    rows.map((row) => {
+      const slug = pageEntitySlug(row.slug)
+      return {
+        schema_id: pageSchemaId,
+        slug,
+        title: row.title,
+        subtitle: row.subtitle ?? null,
+        summary: row.description ?? row.summary ?? null,
+        data: mergeData(
+          existingBySlug.get(slug)?.data,
+          mergeData(row.data, {
+            slug: row.slug,
+            props: row.props ?? objectValue(existingBySlug.get(slug)?.data).props ?? {},
+          }),
+        ),
+        published: row.published ?? true,
+      }
+    }),
+    { onConflict: "slug" },
+    label,
+  )
+
+  return loadPageEntityMapBySlug(supabase, rows.map((row) => row.slug), label)
+}
+
+export async function upsertSectionEntities(
+  supabase,
+  sections,
+  label = "upsert section entities",
+) {
+  const rows = sections.filter(Boolean)
+  if (!rows.length) return new Map()
+
+  const sectionSchemaIds = await loadSectionSchemaIds(supabase, label)
+  const existingRows = await loadEntitiesBySlugs(
+    supabase,
+    rows.map((row) => sectionEntitySlug(row.key)),
+    sectionSchemaIds,
+    `${label} existing sections`,
+  )
+  const existingBySlug = new Map(existingRows.map((row) => [row.slug, row]))
+
+  await upsertChunked(
+    supabase,
+    "entities",
+    rows.map((row) => {
+      const schemaId = row.schema_id ?? row.schemaId
+
+      if (!schemaId || !sectionSchemaIds.includes(schemaId)) {
+        throw new Error(`${label}: invalid section schema for ${row.key}`)
+      }
+
+      const slug = sectionEntitySlug(row.key)
+      const existingData = objectValue(existingBySlug.get(slug)?.data)
+
+      return {
+        schema_id: schemaId,
+        slug,
+        title: row.title ?? null,
+        subtitle: row.subtitle ?? null,
+        data: mergeData(
+          existingData,
+          mergeData(row.data, {
+            key: row.key,
+            section_type: row.section_type ?? row.sectionType,
+            eyebrow: row.eyebrow ?? existingData.eyebrow ?? null,
+            props: row.props ?? existingData.props ?? {},
+          }),
+        ),
+        published: row.published ?? true,
+      }
+    }),
+    { onConflict: "slug" },
+    label,
+  )
+
+  return loadSectionEntityMapByKey(supabase, rows.map((row) => row.key), label)
 }
 
 function relationId(value, camelKey, snakeKey) {
@@ -151,6 +272,11 @@ function requiredRelationId(value, camelKey, snakeKey, label) {
   }
 
   return id
+}
+
+function optionalRelationId(value, camelKey, snakeKey) {
+  const id = relationId(value, camelKey, snakeKey)
+  return typeof id === "string" && id ? id : null
 }
 
 function relationNumber(value, camelKey, snakeKey, fallback = 0) {
@@ -169,15 +295,11 @@ export async function upsertPageSectionRelations(
   const rows = placements.filter(Boolean)
   if (!rows.length) return 0
 
-  const pageIds = rows.map((row) =>
-    requiredRelationId(row, "pageId", "page_id", label),
-  )
-  const sectionIds = rows.map((row) =>
-    requiredRelationId(row, "sectionId", "section_id", label),
-  )
-  const [pageEntities, sectionEntities, relationSchemaId] = await Promise.all([
-    loadShadowEntityMap(supabase, "pages", pageIds, label),
-    loadShadowEntityMap(supabase, "sections", sectionIds, label),
+  const pageSlugs = rows.map((row) => relationId(row, "pageSlug", "page_slug"))
+  const sectionKeys = rows.map((row) => relationId(row, "sectionKey", "section_key"))
+  const [pageEntitiesBySlug, sectionEntitiesByKey, relationSchemaId] = await Promise.all([
+    loadPageEntityMapBySlug(supabase, pageSlugs, label),
+    loadSectionEntityMapByKey(supabase, sectionKeys, label),
     loadSchemaIdByKey(
       supabase,
       "relation/page-section/v1",
@@ -188,12 +310,20 @@ export async function upsertPageSectionRelations(
   await upsertRelationRows(
     supabase,
     rows.map((row) => {
-      const pageId = requiredRelationId(row, "pageId", "page_id", label)
-      const sectionId = requiredRelationId(row, "sectionId", "section_id", label)
+      const pageEntityId =
+        optionalRelationId(row, "pageEntityId", "page_entity_id") ??
+        pageEntitiesBySlug.get(relationId(row, "pageSlug", "page_slug"))?.id
+      const sectionEntityId =
+        optionalRelationId(row, "sectionEntityId", "section_entity_id") ??
+        sectionEntitiesByKey.get(relationId(row, "sectionKey", "section_key"))?.id
+
+      if (!pageEntityId || !sectionEntityId) {
+        throw new Error(`${label}: missing page/section entity id`)
+      }
 
       return {
-        from_entity_id: pageEntities.get(pageId),
-        to_entity_id: sectionEntities.get(sectionId),
+        from_entity_id: pageEntityId,
+        to_entity_id: sectionEntityId,
         schema_id: relationSchemaId,
         relation_type: "contains_section",
         slot: "sections",
@@ -209,19 +339,21 @@ export async function upsertPageSectionRelations(
 
 export async function deleteSectionEntityRelations(
   supabase,
-  { sectionIds = [], entityIds = [], label = "delete section-entity graph relations" },
+  {
+    sectionEntityIds,
+    sectionIds = [],
+    entityIds = [],
+    label = "delete section-entity graph relations",
+  },
 ) {
-  const normalizedSectionIds = uniqueStrings(sectionIds)
+  const normalizedSectionIds = uniqueStrings(sectionEntityIds ?? sectionIds)
   const normalizedEntityIds = uniqueStrings(entityIds)
 
   if (!normalizedSectionIds.length && !normalizedEntityIds.length) {
     throw new Error(`${label}: refusing to delete unscoped section-entity relations`)
   }
 
-  const sectionEntities = normalizedSectionIds.length
-    ? await loadShadowEntityMap(supabase, "sections", normalizedSectionIds, label)
-    : new Map()
-  const fromEntityIds = [...sectionEntities.values()]
+  const fromEntityIds = normalizedSectionIds
   const relationSchemaId = await loadSchemaIdByKey(
     supabase,
     "relation/section-entity/v1",
@@ -259,11 +391,9 @@ export async function upsertSectionEntityRelations(
   const rows = placements.filter(Boolean)
   if (!rows.length) return 0
 
-  const sectionIds = rows.map((row) =>
-    requiredRelationId(row, "sectionId", "section_id", label),
-  )
-  const [sectionEntities, relationSchemaId] = await Promise.all([
-    loadShadowEntityMap(supabase, "sections", sectionIds, label),
+  const sectionKeys = rows.map((row) => relationId(row, "sectionKey", "section_key"))
+  const [sectionEntitiesByKey, relationSchemaId] = await Promise.all([
+    loadSectionEntityMapByKey(supabase, sectionKeys, label),
     loadSchemaIdByKey(
       supabase,
       "relation/section-entity/v1",
@@ -274,11 +404,17 @@ export async function upsertSectionEntityRelations(
   await upsertRelationRows(
     supabase,
     rows.map((row) => {
-      const sectionId = requiredRelationId(row, "sectionId", "section_id", label)
+      const sectionEntityId =
+        optionalRelationId(row, "sectionEntityId", "section_entity_id") ??
+        sectionEntitiesByKey.get(relationId(row, "sectionKey", "section_key"))?.id
       const entityId = requiredRelationId(row, "entityId", "entity_id", label)
 
+      if (!sectionEntityId) {
+        throw new Error(`${label}: missing section entity id`)
+      }
+
       return {
-        from_entity_id: sectionEntities.get(sectionId),
+        from_entity_id: sectionEntityId,
         to_entity_id: entityId,
         schema_id: relationSchemaId,
         relation_type: relationId(row, "relationType", "relation_type") ?? "item",

--- a/scripts/generate-instagram-feed-migration.mjs
+++ b/scripts/generate-instagram-feed-migration.mjs
@@ -319,46 +319,44 @@ const sql = `-- Bremen — expanded Instagram feed seed.
 -- Captured ${feed.total} posts from ${feed.pages.length} paginated feed pages.
 -- Thumbnails are stored in Supabase Storage bucket images/instagram.
 
-insert into public.sections (
-  key,
-  section_type,
+insert into public.entities (
   schema_id,
-  eyebrow,
+  slug,
   title,
   subtitle,
   published,
-  props
+  data
 )
 values (
-  'performances-updates',
-  'entity_post_grid',
   ${schemaIdExpr("section/performance-updates/v1")},
-  'Notice board',
+  'section:performances-updates',
   'Around the stages',
   '공연 전후의 소식',
   true,
-  '{}'::jsonb
+  '{"key":"performances-updates","section_type":"entity_post_grid","eyebrow":"Notice board","props":{}}'::jsonb
 )
-on conflict (key) do update
-set section_type = excluded.section_type,
-    schema_id = excluded.schema_id,
-    eyebrow = excluded.eyebrow,
+on conflict (slug) do update
+set schema_id = excluded.schema_id,
     title = excluded.title,
     subtitle = excluded.subtitle,
     published = excluded.published,
-    props = excluded.props;
+    data = public.entities.data ||
+      (excluded.data - 'props') ||
+      jsonb_build_object(
+        'props',
+        coalesce(public.entities.data->'props', '{}'::jsonb) ||
+          coalesce(excluded.data->'props', '{}'::jsonb)
+      ),
+    updated_at = now();
 
 with target as (
   select page_entity.id as page_entity_id, section_entity.id as section_entity_id
-  from public.pages page
-  join public.sections section on section.key = 'performances-updates'
-  join public.entities page_entity
-    on page_entity.schema_id = ${schemaIdExpr("page/default/v1")}
-   and page_entity.slug = 'page:' || page.slug
+  from public.entities page_entity
   join public.entities section_entity
     on ${sectionSchemaPredicate("section_entity")}
-   and section_entity.slug = 'section:' || section.key
-  where page.slug = 'performances'
+   and section_entity.slug = 'section:performances-updates'
+  where page_entity.schema_id = ${schemaIdExpr("page/default/v1")}
+    and page_entity.slug = 'page:performances'
 )
 insert into public.entity_relations (
   from_entity_id,
@@ -453,22 +451,19 @@ set schema_id = excluded.schema_id,
     props = excluded.props;
 
 delete from public.entity_relations relation
-using public.entities section_entity, public.sections section_ref, public.entities entity
+using public.entities section_entity, public.entities entity
 where relation.schema_id = ${schemaIdExpr("relation/section-entity/v1")}
   and relation.from_entity_id = section_entity.id
   and relation.to_entity_id = entity.id
   and ${sectionSchemaPredicate("section_entity")}
-  and section_entity.slug = 'section:' || section_ref.key
-  and section_ref.key = 'photos-gallery'
+  and section_entity.slug = 'section:photos-gallery'
   and entity.data->>'source' = 'instagram';
 
 with target_section as (
   select section_entity.id as section_entity_id
-  from public.sections section_ref
-  join public.entities section_entity
-    on ${sectionSchemaPredicate("section_entity")}
-   and section_entity.slug = 'section:' || section_ref.key
-  where section_ref.key = 'photos-gallery'
+  from public.entities section_entity
+  where ${sectionSchemaPredicate("section_entity")}
+    and section_entity.slug = 'section:photos-gallery'
 ),
 ordered as (
   select
@@ -505,22 +500,19 @@ set schema_id = excluded.schema_id,
     props = excluded.props;
 
 delete from public.entity_relations relation
-using public.entities section_entity, public.sections section_ref, public.entities entity
+using public.entities section_entity, public.entities entity
 where relation.schema_id = ${schemaIdExpr("relation/section-entity/v1")}
   and relation.from_entity_id = section_entity.id
   and relation.to_entity_id = entity.id
   and ${sectionSchemaPredicate("section_entity")}
-  and section_entity.slug = 'section:' || section_ref.key
-  and section_ref.key = 'performances-updates'
+  and section_entity.slug = 'section:performances-updates'
   and entity.data->>'source' = 'instagram';
 
 with target_section as (
   select section_entity.id as section_entity_id
-  from public.sections section_ref
-  join public.entities section_entity
-    on ${sectionSchemaPredicate("section_entity")}
-   and section_entity.slug = 'section:' || section_ref.key
-  where section_ref.key = 'performances-updates'
+  from public.entities section_entity
+  where ${sectionSchemaPredicate("section_entity")}
+    and section_entity.slug = 'section:performances-updates'
 ),
 ordered as (
   select

--- a/scripts/generate-scraped-content-migration.mjs
+++ b/scripts/generate-scraped-content-migration.mjs
@@ -587,28 +587,63 @@ where ${semanticKindPredicate("public.entities", "video")}
   and slug is null
   and data ? 'youtube_id';
 
-insert into public.pages (slug, title, subtitle, description, published, props)
+insert into public.entities (schema_id, slug, title, subtitle, summary, published, data)
 values
-  ('history', '브레멘 히스토리', 'History', '브레멘의 시작과 치어로밴드, 공연 문화의 변화', true, '{}'::jsonb)
+  (
+    ${schemaIdExpr("page/default/v1")},
+    'page:history',
+    '브레멘 히스토리',
+    'History',
+    '브레멘의 시작과 치어로밴드, 공연 문화의 변화',
+    true,
+    '{"slug":"history","props":{}}'::jsonb
+  )
 on conflict (slug) do update
-set title = excluded.title,
+set schema_id = excluded.schema_id,
+    title = excluded.title,
     subtitle = excluded.subtitle,
-    description = excluded.description,
+    summary = excluded.summary,
     published = excluded.published,
-    props = excluded.props;
+    data = public.entities.data ||
+      (excluded.data - 'props') ||
+      jsonb_build_object(
+        'props',
+        coalesce(public.entities.data->'props', '{}'::jsonb) ||
+          coalesce(excluded.data->'props', '{}'::jsonb)
+      ),
+    updated_at = now();
 
-insert into public.sections (key, section_type, schema_id, eyebrow, title, subtitle, published, props)
+insert into public.entities (schema_id, slug, title, subtitle, published, data)
 values
-  ('videos-by-event', 'entity_grouped_grid', ${schemaIdExpr("section/video-event-playlists/v1")}, 'Events', 'Recordings by stage', '공연 단위로 묶어 보는 영상 기록', true, '{}'::jsonb),
-  ('history-timeline', 'entity_timeline', ${schemaIdExpr("section/history-timeline/v1")}, 'Since 2001', 'Bremen History', '궤짝 유랑 악단에서 현재의 브레멘까지', true, '{}'::jsonb)
-on conflict (key) do update
-set section_type = excluded.section_type,
-    schema_id = excluded.schema_id,
-    eyebrow = excluded.eyebrow,
+  (
+    ${schemaIdExpr("section/video-event-playlists/v1")},
+    'section:videos-by-event',
+    'Recordings by stage',
+    '공연 단위로 묶어 보는 영상 기록',
+    true,
+    '{"key":"videos-by-event","section_type":"entity_grouped_grid","eyebrow":"Events","props":{}}'::jsonb
+  ),
+  (
+    ${schemaIdExpr("section/history-timeline/v1")},
+    'section:history-timeline',
+    'Bremen History',
+    '궤짝 유랑 악단에서 현재의 브레멘까지',
+    true,
+    '{"key":"history-timeline","section_type":"entity_timeline","eyebrow":"Since 2001","props":{}}'::jsonb
+  )
+on conflict (slug) do update
+set schema_id = excluded.schema_id,
     title = excluded.title,
     subtitle = excluded.subtitle,
     published = excluded.published,
-    props = excluded.props;
+    data = public.entities.data ||
+      (excluded.data - 'props') ||
+      jsonb_build_object(
+        'props',
+        coalesce(public.entities.data->'props', '{}'::jsonb) ||
+          coalesce(excluded.data->'props', '{}'::jsonb)
+      ),
+    updated_at = now();
 
 with links(page_slug, section_key, sort_order) as (
   values
@@ -633,14 +668,12 @@ select
   links.sort_order,
   '{}'::jsonb
 from links
-join public.pages page_ref on page_ref.slug = links.page_slug
-join public.sections section_ref on section_ref.key = links.section_key
 join public.entities page_entity
   on page_entity.schema_id = ${schemaIdExpr("page/default/v1")}
- and page_entity.slug = 'page:' || page_ref.slug
+ and page_entity.slug = 'page:' || links.page_slug
 join public.entities section_entity
   on ${sectionSchemaPredicate("section_entity")}
- and section_entity.slug = 'section:' || section_ref.key
+ and section_entity.slug = 'section:' || links.section_key
 on conflict (from_entity_id, to_entity_id, relation_type, slot) do update
 set schema_id = excluded.schema_id,
     sort_order = excluded.sort_order,
@@ -775,20 +808,17 @@ set schema_id = excluded.schema_id,
     props = excluded.props;
 
 delete from public.entity_relations relation
-using public.entities section_entity, public.sections section_ref
+using public.entities section_entity
 where relation.schema_id = ${schemaIdExpr("relation/section-entity/v1")}
   and relation.from_entity_id = section_entity.id
   and ${sectionSchemaPredicate("section_entity")}
-  and section_entity.slug = 'section:' || section_ref.key
-  and section_ref.key in (${sectionKeys.map(sqlString).join(", ")});
+  and section_entity.slug in (${sectionKeys.map((key) => sqlString(`section:${key}`)).join(", ")});
 
 with target_section as (
   select section_entity.id as section_entity_id
-  from public.sections section_ref
-  join public.entities section_entity
-    on ${sectionSchemaPredicate("section_entity")}
-   and section_entity.slug = 'section:' || section_ref.key
-  where section_ref.key = 'performances-current-season'
+  from public.entities section_entity
+  where ${sectionSchemaPredicate("section_entity")}
+    and section_entity.slug = 'section:performances-current-season'
 ),
 ordered as (
   select
@@ -824,11 +854,9 @@ set schema_id = excluded.schema_id,
 
 with target_section as (
   select section_entity.id as section_entity_id
-  from public.sections section_ref
-  join public.entities section_entity
-    on ${sectionSchemaPredicate("section_entity")}
-   and section_entity.slug = 'section:' || section_ref.key
-  where section_ref.key = 'performances-archive'
+  from public.entities section_entity
+  where ${sectionSchemaPredicate("section_entity")}
+    and section_entity.slug = 'section:performances-archive'
 ),
 ordered as (
   select
@@ -867,11 +895,9 @@ set schema_id = excluded.schema_id,
 
 with target_section as (
   select section_entity.id as section_entity_id
-  from public.sections section_ref
-  join public.entities section_entity
-    on ${sectionSchemaPredicate("section_entity")}
-   and section_entity.slug = 'section:' || section_ref.key
-  where section_ref.key = 'videos-featured'
+  from public.entities section_entity
+  where ${sectionSchemaPredicate("section_entity")}
+    and section_entity.slug = 'section:videos-featured'
 ),
 ordered as (
   select
@@ -908,11 +934,9 @@ set schema_id = excluded.schema_id,
 
 with target_section as (
   select section_entity.id as section_entity_id
-  from public.sections section_ref
-  join public.entities section_entity
-    on ${sectionSchemaPredicate("section_entity")}
-   and section_entity.slug = 'section:' || section_ref.key
-  where section_ref.key = 'videos-popular'
+  from public.entities section_entity
+  where ${sectionSchemaPredicate("section_entity")}
+    and section_entity.slug = 'section:videos-popular'
 ),
 ordered as (
   select
@@ -950,11 +974,9 @@ set schema_id = excluded.schema_id,
 
 with target_section as (
   select section_entity.id as section_entity_id
-  from public.sections section_ref
-  join public.entities section_entity
-    on ${sectionSchemaPredicate("section_entity")}
-   and section_entity.slug = 'section:' || section_ref.key
-  where section_ref.key = 'videos-library'
+  from public.entities section_entity
+  where ${sectionSchemaPredicate("section_entity")}
+    and section_entity.slug = 'section:videos-library'
 ),
 ordered as (
   select
@@ -989,11 +1011,9 @@ set schema_id = excluded.schema_id,
 
 with target_section as (
   select section_entity.id as section_entity_id
-  from public.sections section_ref
-  join public.entities section_entity
-    on ${sectionSchemaPredicate("section_entity")}
-   and section_entity.slug = 'section:' || section_ref.key
-  where section_ref.key = 'videos-by-event'
+  from public.entities section_entity
+  where ${sectionSchemaPredicate("section_entity")}
+    and section_entity.slug = 'section:videos-by-event'
 ),
 ordered as (
   select
@@ -1028,11 +1048,9 @@ set schema_id = excluded.schema_id,
 
 with target_section as (
   select section_entity.id as section_entity_id
-  from public.sections section_ref
-  join public.entities section_entity
-    on ${sectionSchemaPredicate("section_entity")}
-   and section_entity.slug = 'section:' || section_ref.key
-  where section_ref.key = 'photos-gallery'
+  from public.entities section_entity
+  where ${sectionSchemaPredicate("section_entity")}
+    and section_entity.slug = 'section:photos-gallery'
 ),
 ordered as (
   select
@@ -1068,11 +1086,9 @@ set schema_id = excluded.schema_id,
 
 with target_section as (
   select section_entity.id as section_entity_id
-  from public.sections section_ref
-  join public.entities section_entity
-    on ${sectionSchemaPredicate("section_entity")}
-   and section_entity.slug = 'section:' || section_ref.key
-  where section_ref.key = 'history-timeline'
+  from public.entities section_entity
+  where ${sectionSchemaPredicate("section_entity")}
+    and section_entity.slug = 'section:history-timeline'
 ),
 ordered as (
   select

--- a/scripts/qa-graph-primary-seed-writes.mjs
+++ b/scripts/qa-graph-primary-seed-writes.mjs
@@ -3,6 +3,7 @@
 import { readFileSync } from "node:fs"
 
 const scanFiles = [
+  "scripts/content-graph-write-helpers.mjs",
   "scripts/apply-instagram-feed.mjs",
   "scripts/apply-scraped-content.mjs",
   "scripts/generate-instagram-feed-migration.mjs",
@@ -14,6 +15,30 @@ const applyScriptFiles = new Set([
 ])
 
 const forbiddenPatterns = [
+  {
+    label: "direct pages Supabase table access",
+    pattern: /(?:^|[^\w])from\(\s*["'`]pages["'`]\s*\)/,
+  },
+  {
+    label: "direct sections Supabase table access",
+    pattern: /(?:^|[^\w])from\(\s*["'`]sections["'`]\s*\)/,
+  },
+  {
+    label: "direct pages upsert helper target",
+    pattern: /upsertChunked\(\s*supabase\s*,\s*["'`]pages["'`]/,
+  },
+  {
+    label: "direct sections upsert helper target",
+    pattern: /upsertChunked\(\s*supabase\s*,\s*["'`]sections["'`]/,
+  },
+  {
+    label: "generated pages compatibility SQL",
+    pattern: /\bpublic\.pages\b/i,
+  },
+  {
+    label: "generated sections compatibility SQL",
+    pattern: /\bpublic\.sections\b/i,
+  },
   {
     label: "direct page_sections Supabase table access",
     pattern: /(?:^|[^\w])from\(\s*["'`]page_sections["'`]\s*\)/,
@@ -149,6 +174,14 @@ function runSelfTest() {
     "scripts/apply-example.mjs",
     "insert into public.entity_relations (source_table) values ('section_entities')",
   )
+  const pagesShouldFail = scanText(
+    "scripts/apply-example.mjs",
+    'await supabase.from("pages").select("id")',
+  )
+  const sectionsSqlShouldFail = scanText(
+    "scripts/generate-example.mjs",
+    "join public.sections section_ref on section_ref.key = links.section_key",
+  )
   const entityTypeSqlShouldFail = scanText(
     "scripts/generate-example.mjs",
     "where entity.entity_type = 'video'",
@@ -178,6 +211,8 @@ function runSelfTest() {
     shouldFail.length !== 1 ||
     sqlShouldFail.length !== 1 ||
     sourceMarkerShouldFail.length !== 1 ||
+    pagesShouldFail.length !== 1 ||
+    sectionsSqlShouldFail.length !== 1 ||
     entityTypeSqlShouldFail.length !== 1 ||
     sectionSchemaKeySqlShouldFail.length !== 1 ||
     sectionSchemaKeyColumnShouldFail.length !== 1 ||
@@ -197,10 +232,10 @@ console.log("Graph-primary seed write guard")
 console.table([
   {
     scannedFiles: scanFiles.length,
-      forbiddenPatterns: forbiddenPatterns.length,
-      applyScriptForbiddenPatterns: applyScriptForbiddenPatterns.length,
-      violations: violations.length,
-      selfTest: "ok",
+    forbiddenPatterns: forbiddenPatterns.length,
+    applyScriptForbiddenPatterns: applyScriptForbiddenPatterns.length,
+    violations: violations.length,
+    selfTest: "ok",
   },
 ])
 
@@ -212,7 +247,7 @@ if (violations.length) {
     )
   }
   console.error(
-    "\nUse scripts/content-graph-write-helpers.mjs so writes target entity_relations without legacy relation source markers.",
+    "\nUse scripts/content-graph-write-helpers.mjs so page/section writes target entities and composition writes target entity_relations without compatibility tables.",
   )
   process.exitCode = 1
 }


### PR DESCRIPTION
Closes #161.\n\n## Summary\n- Move active scraped/Instagram apply tooling to upsert page and section records as graph entities.\n- Update page-section and section-entity helper flows so composition writes target entity_relations using entity ids or graph keys, not compatibility table ids.\n- Update generated seed SQL to avoid public.pages/public.sections joins and writes.\n- Strengthen qa:graph-primary-seed-writes so active helpers/apply scripts/generators cannot reintroduce pages/sections/page_sections/section_entities access.\n\n## Validation\n- node --check scripts/content-graph-write-helpers.mjs scripts/apply-scraped-content.mjs scripts/apply-instagram-feed.mjs scripts/generate-scraped-content-migration.mjs scripts/generate-instagram-feed-migration.mjs scripts/qa-graph-primary-seed-writes.mjs\n- pnpm exec tsc --noEmit\n- pnpm run lint\n- pnpm run build\n- pnpm run qa:graph-primary-seed-writes\n- pnpm run qa:content-graph\n- pnpm run qa:schema-semantic-identity\n- pnpm run qa:legacy-mirror-readiness\n- pnpm run qa:cms-legacy-bridge-boundary\n- pnpm run qa:schema-mirror-removal-readiness\n- pnpm run qa:cms-db-first-loaders\n- pnpm run qa:legacy-media-table-readiness\n- pnpm run qa:cms-native-controls\n- git diff --check\n\n## Safety\nNo production seed/apply execution, no destructive SQL, no compatibility table drop.