### PR TITLE
Make CMS schema identity entity-native

### DIFF
--- a/docs/agentic-workflow.md
+++ b/docs/agentic-workflow.md
@@ -9,7 +9,7 @@ Start from an issue. If no issue exists, the first agent task is to draft one us
 Agents should classify every task as one or more of:
 
 - `code`: React, Next.js, Tailwind, shadcn/ui, loaders, validation, tests
-- `content`: `pages`, `sections`, `entities`, `entity_relations`
+- `content`: page/section `entities`, content `entities`, `entity_relations`
 - `schema`: tables, columns, indexes, functions, triggers, RLS, storage policies
 - `ops`: Vercel, Supabase Auth, SMTP, domains, environment variables
 - `research`: YouTube, Instagram, history PDF, references, visual direction
@@ -22,7 +22,8 @@ Agents may do these without additional approval after an issue exists:
 - Propose implementation plans.
 - Edit code within the issue scope.
 - Add migrations for review.
-- Add data migrations that upsert content by stable keys such as `slug` or `key`.
+- Add data migrations that upsert entity graph content by stable keys such as
+  `entities.slug` or `entities.data.key`.
 - Run read-only Supabase queries through MCP.
 - Run local quality checks.
 - Draft GitHub issues using `.github/ISSUE_TEMPLATE`.

--- a/docs/content-graph.md
+++ b/docs/content-graph.md
@@ -14,6 +14,9 @@ page/section records, but PONIX authoring now treats their graph `entities` as
 the CMS-facing record ids. Ordered page/section composition is stored in
 `entity_relations`; the legacy `page_sections` and `section_entities` mirror
 tables have been removed.
+Page and section schema registry entries are also entity-native: their
+canonical `entity_schemas.table_name` is `entities`, not the remaining
+compatibility tables.
 
 The older media domain tables `performances`, `videos`, and `photos` have been
 removed. Media/archive content now lives in `entities` and `entity_relations`.
@@ -81,7 +84,7 @@ Current PONIX contract:
 
 | Table | Purpose |
 | --- | --- |
-| `entity_schemas` | DB-backed schema registry for page, section, entity, and relation records. This is the long-term source for CMS form metadata. |
+| `entity_schemas` | DB-backed schema registry for page, section, entity, and relation records. Page, section, and entity schemas point to `entities`; relation schemas point to `entity_relations`. This is the long-term source for CMS form metadata. |
 | `pages` | Compatibility mirror for routable page records such as `home`, `performances`, `videos`, `photos`, `history`, and `site`. PONIX authoring should prefer the page entity. |
 | `sections` | Compatibility mirror for renderer blocks. PONIX authoring should prefer the section entity with renderer identity in `entities.data`. |
 | `entities` | Reusable content units such as videos, photos, stats, posts, history milestones, activities, nav items, and social links. |
@@ -122,6 +125,11 @@ There are now two layers:
 - `lib/cms/schema-registry.ts` remains the reviewed code fallback and renderer
   compatibility contract. Keep it in sync until DB-only schema editing has its
   own review and QA path.
+
+For active schemas, `table_name` is storage identity, not domain identity.
+`kind = 'page'`, `kind = 'section'`, and `kind = 'entity'` records should use
+`table_name = 'entities'`; `kind = 'relation'` records should use
+`table_name = 'entity_relations'`.
 
 Use the registry contract for:
 

--- a/lib/cms/page-editor.ts
+++ b/lib/cms/page-editor.ts
@@ -38,7 +38,7 @@ export function getPageEditorSchema(): CmsSchemaDefinition | null {
 }
 
 export function isPageEditorSchema(schema: CmsSchemaDefinition) {
-  return schema.kind === "page" && schema.table === "pages"
+  return schema.kind === "page" && schema.schemaKey === "page/default/v1"
 }
 
 export function getEditablePageFields() {

--- a/lib/cms/schema-registry.server.ts
+++ b/lib/cms/schema-registry.server.ts
@@ -55,8 +55,6 @@ const schemaKinds = new Set<CmsSchemaKind>([
 ])
 
 const schemaTables = new Set<CmsSchemaDefinition["table"]>([
-  "pages",
-  "sections",
   "entities",
   "entity_relations",
 ])
@@ -148,16 +146,45 @@ function normalizeFields(value: Json): CmsFieldDefinition[] | null {
   return fields.length === value.length && fields.length > 0 ? fields : null
 }
 
+function normalizeSchemaTable(
+  kind: CmsSchemaKind,
+  tableName: string | null,
+): CmsSchemaDefinition["table"] | null {
+  if (kind === "relation") {
+    return tableName === "entity_relations" ? "entity_relations" : null
+  }
+
+  if (kind === "entity" && tableName === "entities") {
+    return "entities"
+  }
+
+  if (kind === "page" && (tableName === "entities" || tableName === "pages")) {
+    return "entities"
+  }
+
+  if (
+    kind === "section" &&
+    (tableName === "entities" || tableName === "sections")
+  ) {
+    return "entities"
+  }
+
+  return null
+}
+
 function normalizeSchemaRow(row: EntitySchemaRow): CmsSchemaDefinition | null {
   const kind = stringValue(row.kind)
-  const table = stringValue(row.table_name)
   const fields = normalizeFields(row.fields)
 
   if (
     !schemaKinds.has(kind as CmsSchemaKind) ||
-    !schemaTables.has(table as CmsSchemaDefinition["table"]) ||
     !fields
   ) {
+    return null
+  }
+
+  const table = normalizeSchemaTable(kind as CmsSchemaKind, stringValue(row.table_name))
+  if (!table || !schemaTables.has(table)) {
     return null
   }
 
@@ -165,7 +192,7 @@ function normalizeSchemaRow(row: EntitySchemaRow): CmsSchemaDefinition | null {
     schemaId: row.id,
     schemaKey: row.schema_key,
     kind: kind as CmsSchemaKind,
-    table: table as CmsSchemaDefinition["table"],
+    table,
     semanticKind: stringValue(row.semantic_kind) ?? "generic",
     semanticGroup: stringValue(row.semantic_group) ?? undefined,
     label: row.label,

--- a/lib/cms/schema-registry.ts
+++ b/lib/cms/schema-registry.ts
@@ -35,7 +35,7 @@ export type CmsSchemaDefinition = {
   schemaId?: string
   schemaKey: string
   kind: CmsSchemaKind
-  table: "pages" | "sections" | "entities" | "entity_relations"
+  table: "entities" | "entity_relations"
   semanticKind: string
   semanticGroup?: string
   label: string
@@ -94,7 +94,7 @@ const sectionSchema = (
 ): CmsSchemaDraft => ({
   schemaKey,
   kind: "section",
-  table: "sections",
+  table: "entities",
   label,
   description,
   fields: [...sectionBaseFields, ...propsFields],
@@ -209,7 +209,7 @@ const rawCmsSchemaRegistry: CmsSchemaDraft[] = [
   {
     schemaKey: "page/default/v1",
     kind: "page",
-    table: "pages",
+    table: "entities",
     semanticKind: "page",
     semanticGroup: "site",
     label: "Page",

--- a/lib/cms/section-editor.ts
+++ b/lib/cms/section-editor.ts
@@ -35,7 +35,7 @@ export function getSectionEditorSchema(
 }
 
 export function isSectionEditorSchema(schema: CmsSchemaDefinition) {
-  return schema.kind === "section" && schema.table === "sections"
+  return schema.kind === "section"
 }
 
 const sectionTypeBySchemaKey: Record<string, string> = {

--- a/scripts/qa-cms-schema-registry.mjs
+++ b/scripts/qa-cms-schema-registry.mjs
@@ -127,6 +127,25 @@ function compareFields(codeFields, dbFields) {
   }
 }
 
+function canonicalTableName(kind, tableName) {
+  if (kind === "relation") {
+    return tableName === "entity_relations" ? "entity_relations" : tableName
+  }
+
+  if (kind === "entity") {
+    return tableName
+  }
+
+  if (
+    (kind === "page" && tableName === "pages") ||
+    (kind === "section" && tableName === "sections")
+  ) {
+    return "entities"
+  }
+
+  return tableName
+}
+
 async function main() {
   loadEnv(envPath)
 
@@ -163,6 +182,9 @@ async function main() {
       codeSchema && Array.isArray(dbSchema?.fields) && dbSchema.fields.length > 0
         ? compareFields(codeSchema.fields, dbSchema.fields)
         : null
+    const canonicalDbTable = dbSchema
+      ? canonicalTableName(dbSchema.kind, dbSchema.table_name)
+      : null
     const relationSlotsMatch =
       codeSchema && dbSchema
         ? sameList(codeSchema.relationSlots ?? [], dbSchema.relation_slots ?? [])
@@ -177,7 +199,8 @@ async function main() {
       kindMatch: Boolean(codeSchema && dbSchema && codeSchema.kind === dbSchema.kind),
       codeTable: codeSchema?.table ?? null,
       dbTable: dbSchema?.table_name ?? null,
-      tableMatch: Boolean(codeSchema && dbSchema && codeSchema.table === dbSchema.table_name),
+      canonicalDbTable,
+      tableMatch: Boolean(codeSchema && dbSchema && codeSchema.table === canonicalDbTable),
       codeSemanticKind: codeSchema?.semanticKind ?? null,
       dbSemanticKind: dbSchema?.semantic_kind ?? null,
       semanticKindMatch: Boolean(
@@ -216,6 +239,9 @@ async function main() {
         row.inDb &&
         (!row.kindMatch || !row.tableMatch || !row.relationSlotsMatch),
     ).length,
+    legacyCanonicalDbTables: rows.filter(
+      (row) => row.dbTable && row.dbTable !== row.canonicalDbTable,
+    ).length,
     semanticMismatch: rows.filter(
       (row) =>
         row.inCode &&
@@ -247,6 +273,10 @@ async function main() {
   const fieldMismatches = rows.filter(
     (row) => row.inCode && row.inDb && row.dbFields > 0 && !row.fieldsMatch,
   )
+  const invalidCodeTables = codeRegistry.filter((schema) => {
+    if (schema.kind === "relation") return schema.table !== "entity_relations"
+    return schema.table !== "entities"
+  })
   const metadataMismatches = rows.filter(
     (row) =>
       row.inCode &&
@@ -267,6 +297,7 @@ async function main() {
         dbKind: row.dbKind,
         codeTable: row.codeTable,
         dbTable: row.dbTable,
+        canonicalDbTable: row.canonicalDbTable,
         codeSemanticKind: row.codeSemanticKind,
         dbSemanticKind: row.dbSemanticKind,
         codeSemanticGroup: row.codeSemanticGroup,
@@ -283,6 +314,21 @@ async function main() {
       console.error(row.schemaKey)
       console.error(JSON.stringify(row.fieldComparison, null, 2))
     }
+  }
+
+  if (invalidCodeTables.length) {
+    console.error("\nCode registry uses non-canonical storage table names:")
+    console.table(
+      invalidCodeTables.map((schema) => ({
+        schemaKey: schema.schemaKey,
+        kind: schema.kind,
+        table: schema.table,
+      })),
+    )
+    console.error(
+      "Page, section, and entity schemas must store content in entities; relation schemas must store links in entity_relations.",
+    )
+    process.exit(1)
   }
 
   if (strict) {

--- a/supabase/migrations/20260513000066_canonical_schema_storage_tables.sql
+++ b/supabase/migrations/20260513000066_canonical_schema_storage_tables.sql
@@ -1,0 +1,22 @@
+-- Page and section schemas are now entity-native.
+--
+-- public.pages and public.sections may still exist as compatibility tables, but
+-- entity_schemas.table_name must describe the canonical storage surface used by
+-- active CMS code.
+
+update public.entity_schemas
+set table_name = 'entities',
+    updated_at = now()
+where active is true
+  and kind in ('page', 'section')
+  and table_name in ('pages', 'sections');
+
+alter table public.entity_schemas
+  drop constraint if exists entity_schemas_table_name_check;
+
+alter table public.entity_schemas
+  add constraint entity_schemas_table_name_check
+  check (
+    (kind in ('page', 'section', 'entity') and table_name = 'entities')
+    or (kind = 'relation' and table_name = 'entity_relations')
+  );


### PR DESCRIPTION
## Summary

- Canonicalizes page/section CMS schemas to store content in entities instead of pages/sections.
- Keeps DB-first registry loading compatible with current production rows that still report table_name=pages/sections.
- Adds a reviewed non-destructive migration to update active entity_schemas.table_name values and tighten the check constraint.
- Updates docs and schema registry QA so page/section/editor logic is not tied to compatibility table identity.

## Supabase Impact

- Migration file added: supabase/migrations/20260513000066_canonical_schema_storage_tables.sql
- The migration updates entity_schemas metadata and check constraints only.
- It does not drop public.pages or public.sections.
- It has not been applied to production in this PR session.

## Validation

- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm run build
- pnpm run qa:cms-schema-registry
- pnpm run qa:cms-schema-registry -- --strict
- pnpm run qa:cms-db-first-loaders
- pnpm run qa:cms-legacy-bridge-boundary
- pnpm run qa:graph-primary-seed-writes
- pnpm run qa:schema-mirror-removal-readiness
- pnpm run qa:content-graph
- pnpm run qa:schema-semantic-identity
- pnpm run qa:legacy-media-table-readiness
- pnpm run qa:cms-native-controls
- git diff --check

Closes #163