### PR TITLE
Clarify graph-native page and section labels

### DIFF
--- a/app/ponix/_components/cms-relations.tsx
+++ b/app/ponix/_components/cms-relations.tsx
@@ -882,7 +882,6 @@ function BridgeSourceHint({
 }) {
   return (
     <div className="mt-1 space-y-0.5 text-[10px] leading-tight text-muted-foreground">
-      <div>미러 행: {relation.sourceId ? shortId(relation.sourceId) : "없음"}</div>
       <div>그래프 행: {shortId(relation.graphRelationId)}</div>
     </div>
   )

--- a/app/ponix/pages/[id]/compose/composer-relation-list.tsx
+++ b/app/ponix/pages/[id]/compose/composer-relation-list.tsx
@@ -238,7 +238,6 @@ function SectionEntityRelationEditor({
   return (
     <div
       data-composer-relation-item={relation.id}
-      data-composer-relation-source-id={relation.sourceId}
       data-composer-relation-graph-id={relation.graphRelationId}
       data-composer-entity-id={relation.entityId}
       onDragOver={onDragOver}

--- a/app/ponix/relations/actions.ts
+++ b/app/ponix/relations/actions.ts
@@ -193,19 +193,19 @@ async function loadSchemaIdsByKind({
 
 async function loadShadowEntityId({
   supabase,
-  sourceTable,
-  sourceId,
+  shadowKind,
+  entityId,
   label,
 }: {
   supabase: ServerSupabaseClient
-  sourceTable: "pages" | "sections"
-  sourceId: string
+  shadowKind: "page" | "section"
+  entityId: string
   label: string
 }) {
   const { data: entity, error } = await supabase
     .from("entities")
     .select("id, schema_id")
-    .eq("id", sourceId)
+    .eq("id", entityId)
     .maybeSingle()
 
   if (error) {
@@ -217,7 +217,7 @@ async function loadShadowEntityId({
   }
 
   const validSchema =
-    sourceTable === "pages"
+    shadowKind === "page"
       ? entity.schema_id ===
         (await loadSchemaIdByKey({
           supabase,
@@ -320,14 +320,14 @@ export async function addPageSectionRelationAction(formData: FormData) {
     const [pageEntityId, sectionEntityId, relationSchemaId] = await Promise.all([
       loadShadowEntityId({
         supabase,
-        sourceTable: "pages",
-        sourceId: pageId,
+        shadowKind: "page",
+        entityId: pageId,
         label: "Page",
       }),
       loadShadowEntityId({
         supabase,
-        sourceTable: "sections",
-        sourceId: sectionId,
+        shadowKind: "section",
+        entityId: sectionId,
         label: "Section",
       }),
       loadSchemaIdByKey({
@@ -455,8 +455,8 @@ export async function addSectionEntityRelationAction(formData: FormData) {
     const [sectionEntityId, relationSchemaId] = await Promise.all([
       loadShadowEntityId({
         supabase,
-        sourceTable: "sections",
-        sourceId: sectionId,
+        shadowKind: "section",
+        entityId: sectionId,
         label: "Section",
       }),
       loadSchemaIdByKey({
@@ -644,8 +644,8 @@ export async function reorderSectionEntityRelationsAction({
     const [sectionShadowId, relationSchemaId] = await Promise.all([
       loadShadowEntityId({
         supabase,
-        sourceTable: "sections",
-        sourceId: sectionId,
+        shadowKind: "section",
+        entityId: sectionId,
         label: "Section",
       }),
       loadSchemaIdByKey({

--- a/docs/legacy-mirror-stage-5-runbook.md
+++ b/docs/legacy-mirror-stage-5-runbook.md
@@ -14,7 +14,7 @@ CMS work.
 
 ## Current Production Snapshot
 
-Captured on 2026-05-11 with `pnpm run qa:legacy-media-table-readiness`,
+Updated on 2026-05-13 with `pnpm run qa:legacy-media-table-readiness`,
 `pnpm run qa:legacy-mirror-readiness`, and Supabase MCP `list_tables`:
 
 - `public.page_sections`: removed.
@@ -22,10 +22,12 @@ Captured on 2026-05-11 with `pnpm run qa:legacy-media-table-readiness`,
 - `public.performances`: removed.
 - `public.videos`: removed.
 - `public.photos`: removed.
-- Active public tables: `members`, `entities`, `entity_relations`, `pages`,
-  `sections`, `cms_audit_events`, `entity_schemas`.
-- Entity graph media summary: 33 performance entities, 215 video entities, 31
-  photo entities.
+- `public.pages`: removed.
+- `public.sections`: removed.
+- Active public tables: `members`, `entities`, `entity_relations`,
+  `cms_audit_events`, `entity_schemas`.
+- Entity graph summary: 6 page entities, 19 section entities, 33 performance
+  entities, 215 video entities, 31 photo entities.
 - `qa:legacy-mirror-readiness` reports zero active blocker references.
 - Follow-up migration `20260511000052_retire_legacy_relation_source_markers.sql`
   retires inert `entity_relations.source_table/source_id` markers that pointed

--- a/lib/cms/content.ts
+++ b/lib/cms/content.ts
@@ -147,7 +147,6 @@ export type CmsLinkedEntity = SchemaSummary & {
 export type CmsPageSectionRelation = {
   id: string
   graphRelationId: string
-  sourceId: string | null
   pageId: string
   sectionId: string
   sortOrder: number
@@ -160,7 +159,6 @@ export type CmsPageSectionRelation = {
 export type CmsSectionEntityRelation = {
   id: string
   graphRelationId: string
-  sourceId: string | null
   sectionId: string
   entityId: string
   relationType: string
@@ -386,7 +384,7 @@ function pageRowFromEntity(
   >,
 ): CmsPageRecord | null {
   const data = jsonObject(entity.data)
-  const slug = shadowKey(entity, "pages") ?? stringValue(data.slug)
+  const slug = shadowKey(entity, "page") ?? stringValue(data.slug)
 
   if (!slug) return null
 
@@ -420,7 +418,7 @@ function sectionRowFromEntity(
   >,
 ): CmsSectionRecord | null {
   const data = jsonObject(entity.data)
-  const key = shadowKey(entity, "sections") ?? stringValue(data.key)
+  const key = shadowKey(entity, "section") ?? stringValue(data.key)
   const sectionType = stringValue(data.section_type)
 
   if (!key || !sectionType) return null
@@ -556,9 +554,9 @@ function entityWithTimestamps(entity: RawEntityLink) {
 
 function shadowKey(
   entity: Pick<EntityRow, "slug"> | RawEntityLink | null,
-  sourceTable: "pages" | "sections",
+  shadowKind: "page" | "section",
 ) {
-  const prefix = sourceTable === "pages" ? PAGE_SHADOW_PREFIX : SECTION_SHADOW_PREFIX
+  const prefix = shadowKind === "page" ? PAGE_SHADOW_PREFIX : SECTION_SHADOW_PREFIX
   return entity?.slug?.startsWith(prefix) ? entity.slug.slice(prefix.length) : null
 }
 
@@ -930,30 +928,30 @@ export async function loadCmsEntityDetail(
 async function loadShadowEntityId({
   supabase,
   registry,
-  sourceTable,
-  sourceId,
+  shadowKind,
+  entityId,
 }: {
   supabase: SupabaseClient
   registry: SchemaRegistryMap
-  sourceTable: "pages" | "sections"
-  sourceId: string
+  shadowKind: "page" | "section"
+  entityId: string
 }) {
   const { data: entity, error } = await supabase
     .from("entities")
     .select("id, schema_id")
-    .eq("id", sourceId)
+    .eq("id", entityId)
     .maybeSingle()
 
   if (error) {
     throw new Error(
-      `Failed to load ${sourceTable} graph entity: ${error.message}`,
+      `Failed to load ${shadowKind} graph entity: ${error.message}`,
     )
   }
 
   if (!entity) return null
 
   const validSchema =
-    sourceTable === "pages"
+    shadowKind === "page"
       ? entity.schema_id === schemaIdForKey(registry, PAGE_ENTITY_SCHEMA_KEY)
       : schemaIdsForKind(registry, "section").includes(entity.schema_id)
 
@@ -977,16 +975,16 @@ async function loadPageSectionRelationsFromEntityGraph({
       ? loadShadowEntityId({
           supabase,
           registry,
-          sourceTable: "pages",
-          sourceId: pageId,
+          shadowKind: "page",
+          entityId: pageId,
         })
       : Promise.resolve(null),
     sectionId
       ? loadShadowEntityId({
           supabase,
           registry,
-          sourceTable: "sections",
-          sourceId: sectionId,
+          shadowKind: "section",
+          entityId: sectionId,
         })
       : Promise.resolve(null),
   ])
@@ -1025,7 +1023,6 @@ async function loadPageSectionRelationsFromEntityGraph({
       return {
         id: relation.id,
         graphRelationId: relation.id,
-        sourceId: null,
         pageId: mappedPageId,
         sectionId: mappedSectionId,
         sortOrder: relation.sort_order,
@@ -1057,8 +1054,8 @@ async function loadSectionEntityRelationsFromEntityGraph({
     ? await loadShadowEntityId({
         supabase,
         registry,
-        sourceTable: "sections",
-        sourceId: sectionId,
+        shadowKind: "section",
+        entityId: sectionId,
       })
     : null
 
@@ -1097,7 +1094,6 @@ async function loadSectionEntityRelationsFromEntityGraph({
       return {
         id: relation.id,
         graphRelationId: relation.id,
-        sourceId: null,
         sectionId: mappedSectionId,
         entityId: relation.to_entity_id,
         relationType: relation.relation_type,

--- a/lib/data/content-graph.ts
+++ b/lib/data/content-graph.ts
@@ -374,15 +374,17 @@ function uniqueStrings(values: Array<string | null | undefined>) {
   return [...new Set(values.filter((value): value is string => Boolean(value)))]
 }
 
-function shadowSlug(sourceTable: "pages" | "sections", sourceKey: string) {
-  return `${sourceTable === "pages" ? PAGE_SHADOW_PREFIX : SECTION_SHADOW_PREFIX}${sourceKey}`
+type ShadowEntityKind = "page" | "section"
+
+function shadowSlug(shadowKind: ShadowEntityKind, sourceKey: string) {
+  return `${shadowKind === "page" ? PAGE_SHADOW_PREFIX : SECTION_SHADOW_PREFIX}${sourceKey}`
 }
 
 function shadowKey(
   entity: EntityGraphLink | null | undefined,
-  sourceTable: "pages" | "sections",
+  shadowKind: ShadowEntityKind,
 ) {
-  const prefix = sourceTable === "pages" ? PAGE_SHADOW_PREFIX : SECTION_SHADOW_PREFIX
+  const prefix = shadowKind === "page" ? PAGE_SHADOW_PREFIX : SECTION_SHADOW_PREFIX
   return entity?.slug?.startsWith(prefix) ? entity.slug.slice(prefix.length) : null
 }
 
@@ -604,7 +606,7 @@ function pageRecordFromEntity(
 ): GraphPageRecord | null {
   const data = jsonObject(entity.data)
   const slug =
-    shadowKey(entity, "pages") ??
+    shadowKey(entity, "page") ??
     stringValue(data, "slug")
 
   if (!slug) return null
@@ -655,7 +657,7 @@ function graphSectionFromShadowEntity({
   if (!entity) return null
 
   const data = jsonObject(entity.data)
-  const key = shadowKey(entity, "sections") ?? stringValue(data, "key")
+  const key = shadowKey(entity, "section") ?? stringValue(data, "key")
   const sectionType = stringValue(data, "section_type")
 
   if (!key || !sectionType) return null
@@ -775,7 +777,7 @@ async function loadGraphPageUncached(
           "id, schema_id, slug, title, subtitle, summary, owner_member_id, published, data, created_at, updated_at",
         )
         .eq("schema_id", schemas.pageSchemaId)
-        .eq("slug", shadowSlug("pages", options.slug))
+        .eq("slug", shadowSlug("page", options.slug))
 
       if (!includeDrafts) {
         pageEntityQuery = pageEntityQuery.eq("published", true)
@@ -858,7 +860,7 @@ async function loadGraphPageFromEntityRelations({
       .from("entities")
       .select("id")
       .eq("schema_id", resolvedSchemas.pageSchemaId)
-      .eq("slug", shadowSlug("pages", page.slug))
+      .eq("slug", shadowSlug("page", page.slug))
       .maybeSingle()
 
     if (pageEntityError || !pageEntity) return { page, sections: [] }

--- a/scripts/qa-content-graph-integrity.mjs
+++ b/scripts/qa-content-graph-integrity.mjs
@@ -71,8 +71,8 @@ function hasUsableRelationCopy(relation) {
   return Boolean(relation.relation_type && relation.slot)
 }
 
-function shadowKey(entity, sourceTable) {
-  const prefix = sourceTable === "pages" ? PAGE_SHADOW_PREFIX : SECTION_SHADOW_PREFIX
+function shadowKey(entity, shadowKind) {
+  const prefix = shadowKind === "page" ? PAGE_SHADOW_PREFIX : SECTION_SHADOW_PREFIX
   return entity?.slug?.startsWith(prefix) ? entity.slug.slice(prefix.length) : null
 }
 
@@ -85,11 +85,11 @@ function stringValue(value) {
 }
 
 function pageKey(entity) {
-  return shadowKey(entity, "pages") ?? stringValue(objectValue(entity?.data).slug)
+  return shadowKey(entity, "page") ?? stringValue(objectValue(entity?.data).slug)
 }
 
 function sectionKey(entity) {
-  return shadowKey(entity, "sections") ?? stringValue(objectValue(entity?.data).key)
+  return shadowKey(entity, "section") ?? stringValue(objectValue(entity?.data).key)
 }
 
 function sectionType(entity) {
@@ -129,9 +129,9 @@ async function loadSchemaContext(supabase) {
   }
 }
 
-async function checkEntityKeyUniqueness(supabase, sourceTable, schemas) {
+async function checkEntityKeyUniqueness(supabase, shadowKind, schemas) {
   const rows = requireOk(
-    sourceTable === "pages"
+    shadowKind === "page"
       ? await supabase
           .from("entities")
           .select("id, slug, title, data")
@@ -142,17 +142,17 @@ async function checkEntityKeyUniqueness(supabase, sourceTable, schemas) {
           .select("id, slug, title, data")
           .in("schema_id", schemas.sectionSchemaIds)
           .order("slug", { ascending: true }),
-    `${sourceTable} graph entities`,
+    `${shadowKind} graph entities`,
   )
 
-  const bySourceKey = new Map()
+  const byContentKey = new Map()
   const missingKeys = []
   for (const row of rows) {
-    const key = sourceTable === "pages" ? pageKey(row) : sectionKey(row)
+    const key = shadowKind === "page" ? pageKey(row) : sectionKey(row)
     if (!key) {
       missingKeys.push(
         issue("Graph entity is missing its stable content key", {
-          sourceTable,
+          shadowKind,
           entityId: row.id,
           slug: row.slug,
         }),
@@ -160,23 +160,23 @@ async function checkEntityKeyUniqueness(supabase, sourceTable, schemas) {
       continue
     }
 
-    const existing = bySourceKey.get(key) ?? []
+    const existing = byContentKey.get(key) ?? []
     existing.push(row)
-    bySourceKey.set(key, existing)
+    byContentKey.set(key, existing)
   }
 
-  const duplicates = [...bySourceKey.entries()]
+  const duplicates = [...byContentKey.entries()]
     .filter(([, entries]) => entries.length > 1)
-    .map(([sourceId, entries]) =>
+    .map(([contentKey, entries]) =>
       issue("Content key has multiple graph entities", {
-        sourceTable,
-        sourceId,
+        shadowKind,
+        contentKey,
         entityIds: entries.map((entry) => entry.id),
       }),
     )
 
   return {
-    sourceTable,
+    shadowKind,
     entities: rows.length,
     duplicates: [...duplicates, ...missingKeys],
     ok: duplicates.length === 0 && missingKeys.length === 0,
@@ -414,8 +414,8 @@ async function main() {
   )
 
   const entityKeyChecks = [
-    await checkEntityKeyUniqueness(supabase, "pages", schemas),
-    await checkEntityKeyUniqueness(supabase, "sections", schemas),
+    await checkEntityKeyUniqueness(supabase, "page", schemas),
+    await checkEntityKeyUniqueness(supabase, "section", schemas),
   ]
   const pageResults = []
   for (const page of pages) {
@@ -437,9 +437,9 @@ async function main() {
   console.log("\nGraph entity key cardinality")
   console.table(
     entityKeyChecks.map((result) => ({
-      sourceTable: result.sourceTable,
+      shadowKind: result.shadowKind,
       entities: result.entities,
-      duplicateSources: result.duplicates.length,
+      duplicateKeys: result.duplicates.length,
       integrity: result.ok ? "ok" : "failed",
     })),
   )


### PR DESCRIPTION
Closes #167

## Summary

- Rename page/section graph helper terminology from table-oriented `sourceTable` to `shadowKind`.
- Remove the stale `미러 행` CMS relation hint and unused composer mirror data attribute.
- Update the legacy removal runbook snapshot so active public tables match production after #166.

## Supabase impact

No schema or data writes. Read-only MCP confirmed production public tables are now `members`, `entities`, `entity_relations`, `cms_audit_events`, and `entity_schemas`.

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm run qa:content-graph`
- `pnpm run qa:cms-legacy-bridge-boundary`
- `pnpm run qa:legacy-media-table-readiness`
- `pnpm run qa:legacy-mirror-readiness`
- `pnpm run qa:cms-schema-registry -- --strict`
- `pnpm run lint`
- `pnpm run build`
- `git diff --check`

## Not tested

- Interactive browser drag/drop relation editing was not manually exercised; this change removes one unused data attribute and does not change server actions.
