### PR TITLE
Clarify PONIX save feedback states

### DIFF
--- a/app/ponix/_components/cms-save-controls.tsx
+++ b/app/ponix/_components/cms-save-controls.tsx
@@ -1,7 +1,9 @@
 "use client"
 
+import { useEffect } from "react"
 import { useFormStatus } from "react-dom"
-import { CheckCircle2 } from "lucide-react"
+import { CheckCircle2, Loader2 } from "lucide-react"
+import { toast } from "sonner"
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
@@ -13,16 +15,41 @@ export function CmsSaveNotice({
   errorTitle = "저장하지 못했습니다",
   savedTitle = "저장되었습니다",
   savedDescription = "변경 사항이 반영되었습니다.",
+  toastId,
 }: {
   saved?: boolean
   error?: string
   errorTitle?: string
   savedTitle?: string
   savedDescription?: string
+  toastId?: string
 }) {
+  useEffect(() => {
+    const id = toastId ?? `${savedTitle}:${savedDescription}:${error ?? "ok"}`
+
+    if (error) {
+      toast.error(errorTitle, {
+        description: error,
+        id,
+      })
+      return
+    }
+
+    if (saved) {
+      toast.success(savedTitle, {
+        description: savedDescription,
+        id,
+      })
+    }
+  }, [error, errorTitle, saved, savedDescription, savedTitle, toastId])
+
   if (error) {
     return (
-      <Alert variant="destructive" className="rounded-xl shadow-sm">
+      <Alert
+        variant="destructive"
+        className="rounded-xl shadow-sm"
+        data-cms-save-feedback="error"
+      >
         <AlertTitle>{errorTitle}</AlertTitle>
         <AlertDescription>{error}</AlertDescription>
       </Alert>
@@ -34,7 +61,10 @@ export function CmsSaveNotice({
   }
 
   return (
-    <Alert className="rounded-xl border-emerald-200 bg-emerald-50 text-emerald-950 shadow-sm">
+    <Alert
+      className="rounded-xl border-emerald-200 bg-emerald-50 text-emerald-950 shadow-sm"
+      data-cms-save-feedback="saved"
+    >
       <CheckCircle2 className="size-4 text-emerald-700" />
       <AlertTitle>{savedTitle}</AlertTitle>
       <AlertDescription>{savedDescription}</AlertDescription>
@@ -54,8 +84,15 @@ export function CmsSubmitButton({
   const { pending } = useFormStatus()
 
   return (
-    <Button type="submit" disabled={pending} className={cn("min-w-24", className)}>
-      {pending ? pendingLabel : children}
+    <Button
+      type="submit"
+      disabled={pending}
+      aria-busy={pending}
+      data-cms-submit-state={pending ? "pending" : "idle"}
+      className={cn("min-w-28", className)}
+    >
+      {pending && <Loader2 className="size-4 animate-spin" aria-hidden="true" />}
+      <span aria-live="polite">{pending ? pendingLabel : children}</span>
     </Button>
   )
 }

--- a/app/ponix/layout.tsx
+++ b/app/ponix/layout.tsx
@@ -1,10 +1,16 @@
 import type { ReactNode } from "react"
 
 import { PonixShell } from "@/app/ponix/_components/ponix-shell"
+import { Toaster } from "@/components/ui/sonner"
 import { requireCmsAdmin } from "@/lib/cms/auth"
 
 export default async function PonixLayout({ children }: { children: ReactNode }) {
   const member = await requireCmsAdmin("/ponix")
 
-  return <PonixShell memberName={member.name}>{children}</PonixShell>
+  return (
+    <>
+      <PonixShell memberName={member.name}>{children}</PonixShell>
+      <Toaster closeButton position="top-right" richColors />
+    </>
+  )
 }


### PR DESCRIPTION
## Summary

- Add the shadcn/Sonner toaster to the authenticated PONIX workspace.
- Make the shared CMS save notice emit success/error toasts from the existing saved/error redirect query state.
- Improve CMS submit buttons with spinner, `aria-busy`, disabled pending behavior, and a stable state attribute for QA.

Closes #171

## Supabase Impact

- None. This is UI feedback only.
- No schema, RLS, Storage, Auth, or data migration changes.

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `pnpm run qa:cms-native-controls`
- `pnpm run qa:cms-db-first-loaders`
- `pnpm run build`
- `git diff --check`

## Notes

- Authenticated manual save-click testing was not repeated in this pass. The change is centralized in the shared PONIX save controls and verified by typecheck/lint/CMS guards/build.
