### PR TITLE
Refine PONIX composer inspector focus

### DIFF
--- a/app/ponix/pages/[id]/compose/composer-relation-list.tsx
+++ b/app/ponix/pages/[id]/compose/composer-relation-list.tsx
@@ -280,11 +280,11 @@ function SectionEntityRelationEditor({
                       {relation.entity?.title ?? relation.entityId}
                     </p>
                     <p className="font-mono text-xs text-muted-foreground">
-                      {relation.entity?.schemaKey ?? "schema"}
+                      {relation.entity?.schemaKey ?? "입력 양식"}
                     </p>
                   </div>
                   <Badge variant="outline" className="rounded-full">
-                    {relation.entity?.published ? "published" : "draft"}
+                    {relation.entity?.published ? "공개" : "비공개"}
                   </Badge>
                 </div>
                 <div className="flex flex-wrap gap-1.5">
@@ -320,19 +320,19 @@ function SectionEntityRelationEditor({
             <div className="flex items-start justify-between gap-5 pr-8">
               <div className="min-w-0">
                 <p className="caps mb-2 text-muted-foreground">
-                  Section relation
+                  섹션 연결
                 </p>
                 <DrawerTitle className="line-clamp-2 font-serif text-3xl italic">
                   {relation.entity?.title ?? relation.entityId}
                 </DrawerTitle>
                 <DrawerDescription className="mt-2 line-clamp-2">
-                  이 섹션에서 이 데이터가 어떻게 노출되는지 정리합니다.
+                  이 섹션에서 콘텐츠가 어떤 슬롯과 순서로 보일지 정리합니다.
                 </DrawerDescription>
               </div>
               <Badge variant="secondary" className="mt-1 shrink-0 rounded-full">
                 {relation.entity?.schemaLabel ??
                   relation.entity?.schemaKey ??
-                  "schema"}
+                  "입력 양식"}
               </Badge>
             </div>
           </DrawerHeader>
@@ -360,7 +360,7 @@ function SectionEntityRelationEditor({
                   variant="secondary"
                   className="rounded-full font-mono text-[10px]"
                 >
-                  {relation.entity?.entityType ?? "entity"}
+                  {relation.entity?.entityType ?? "콘텐츠"}
                 </Badge>
               </div>
               <div className="mt-3 flex flex-wrap gap-2">
@@ -375,7 +375,7 @@ function SectionEntityRelationEditor({
                   className="h-8 rounded-full"
                 >
                   <Link href={`/ponix/entities/${relation.entityId}`}>
-                    상세 화면
+                    상세 보기
                     <ExternalLink className="size-3.5" />
                   </Link>
                 </Button>
@@ -405,7 +405,7 @@ function SectionEntityRelationEditor({
                       htmlFor={`relation-type-${relation.id}`}
                       className="text-xs"
                     >
-                      Type
+                      관계
                     </Label>
                     <CmsComboboxField
                       id={`relation-type-${relation.id}`}
@@ -415,10 +415,10 @@ function SectionEntityRelationEditor({
                         value: option,
                         label: option,
                       }))}
-                      placeholder="Select type"
-                      searchPlaceholder="Search or type a relation type"
-                      emptyLabel="Type a relation type to add it"
-                      customLabel="Use"
+                      placeholder="관계 선택"
+                      searchPlaceholder="관계 검색 또는 입력"
+                      emptyLabel="새 관계 이름을 입력하세요"
+                      customLabel="사용"
                       triggerClassName="h-10 bg-card"
                     />
                   </div>
@@ -427,7 +427,7 @@ function SectionEntityRelationEditor({
                       htmlFor={`relation-slot-${relation.id}`}
                       className="text-xs"
                     >
-                      Slot
+                      슬롯
                     </Label>
                     <CmsComboboxField
                       id={`relation-slot-${relation.id}`}
@@ -437,10 +437,10 @@ function SectionEntityRelationEditor({
                         value: option,
                         label: option,
                       }))}
-                      placeholder="Select slot"
-                      searchPlaceholder="Search or type a slot"
-                      emptyLabel="Type a slot to add it"
-                      customLabel="Use"
+                      placeholder="슬롯 선택"
+                      searchPlaceholder="슬롯 검색 또는 입력"
+                      emptyLabel="새 슬롯 이름을 입력하세요"
+                      customLabel="사용"
                       triggerClassName="h-10 bg-card"
                     />
                   </div>
@@ -449,7 +449,7 @@ function SectionEntityRelationEditor({
                       htmlFor={`relation-order-${relation.id}`}
                       className="text-xs"
                     >
-                      Order
+                      순서
                     </Label>
                     <Input
                       id={`relation-order-${relation.id}`}
@@ -544,7 +544,7 @@ function EntityEditDrawer({
           data-composer-entity-drawer-trigger={relation.entityId}
         >
           <PencilLine className="size-3.5" />
-          데이터 수정
+          콘텐츠 수정
         </button>
       </DrawerTrigger>
       <DrawerContent
@@ -554,7 +554,7 @@ function EntityEditDrawer({
         <DrawerHeader className="border-b px-5 py-5">
           <div className="flex items-start justify-between gap-8 pr-8">
             <div className="min-w-0">
-              <p className="caps mb-2 text-muted-foreground">Entity editor</p>
+              <p className="caps mb-2 text-muted-foreground">콘텐츠 편집</p>
               <DrawerTitle className="line-clamp-2 font-serif text-3xl italic">
                 {entity?.title ?? relation.entityId}
               </DrawerTitle>
@@ -563,15 +563,14 @@ function EntityEditDrawer({
               </DrawerDescription>
             </div>
             <Badge variant="secondary" className="mt-1 shrink-0 rounded-full">
-              {entity?.schemaLabel ?? entity?.schemaKey ?? "schema"}
+              {entity?.schemaLabel ?? entity?.schemaKey ?? "입력 양식"}
             </Badge>
           </div>
         </DrawerHeader>
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
           <div className="flex flex-wrap items-center justify-between gap-3 border-b bg-muted/20 px-5 py-3 text-xs text-muted-foreground">
             <span>
-              현재 composer를 떠나지 않고 연결된 데이터의 주요 필드를 바로
-              수정합니다.
+              Composer를 떠나지 않고 연결된 콘텐츠의 주요 필드를 수정합니다.
             </span>
             <Button asChild variant="outline" size="sm" className="rounded-full">
               <Link href={`/ponix/entities/${relation.entityId}/edit`}>
@@ -785,7 +784,7 @@ function InlineEntityField({
         <Label htmlFor={id}>{field.label}</Label>
         {field.required && (
           <Badge variant="outline" className="rounded-full">
-            Required
+            필수
           </Badge>
         )}
       </div>
@@ -824,7 +823,7 @@ function renderInlineFieldInput({
           defaultChecked={Boolean(value)}
         />
         <Label htmlFor={id} className="text-sm font-normal">
-          Enabled
+          사용
         </Label>
       </div>
     )
@@ -853,7 +852,7 @@ function renderInlineFieldInput({
         name={name}
         defaultValue={inlineFieldDefaultText(field, value)}
         options={field.options ?? []}
-        placeholder={`Select ${field.label}`}
+        placeholder={`${field.label} 선택`}
         required={field.required}
       />
     )

--- a/app/ponix/pages/[id]/compose/page.tsx
+++ b/app/ponix/pages/[id]/compose/page.tsx
@@ -241,12 +241,12 @@ function SectionInspector({
               </div>
 
               <div className="grid gap-3 text-sm">
-                <MetaRow label="Page" value={`/${pageSlug}`} />
-                <MetaRow label="Schema" value={section.schemaKey} mono />
-                <MetaRow label="Sort" value={String(section.sortOrder)} />
+                <MetaRow label="페이지" value={`/${pageSlug}`} />
+                <MetaRow label="입력 양식" value={section.schemaKey} mono />
+                <MetaRow label="섹션 순서" value={String(section.sortOrder)} />
                 <MetaRow
-                  label="Entities"
-                  value={`${section.items.length} linked`}
+                  label="연결 데이터"
+                  value={`${section.items.length}개`}
                 />
               </div>
 
@@ -389,82 +389,16 @@ function SectionEntityWorkspace({
           <CardTitle className="font-serif text-2xl italic">연결 데이터</CardTitle>
         </div>
         <CardDescription>
-          이 섹션에 보여줄 영상, 사진, 공연, 기록을 고릅니다.
+          이 섹션에 실제로 노출되는 콘텐츠와 순서를 관리합니다.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-5 p-5">
-        <form
-          action={addSectionEntityRelationAction}
-          className="space-y-4"
-          data-composer-track-dirty
-        >
-          <input type="hidden" name="redirect_to" value={redirectTo} />
-          <input type="hidden" name="section_id" value={section.id} />
-          <CmsEntityPicker
-            name="entity_id"
-            entities={options.entities}
-            schemaOptions={options.entitySchemas}
-            showSchemaFilter
-          />
-          <div className="grid grid-cols-3 gap-2">
-            <div className="space-y-2">
-              <Label htmlFor="composer-relation-type">관계</Label>
-              <CmsComboboxField
-                id="composer-relation-type"
-                name="relation_type"
-                defaultValue="item"
-                options={relationTypeOptions.map((option) => ({
-                  value: option,
-                  label: option,
-                }))}
-                placeholder="관계 선택"
-                searchPlaceholder="관계 검색 또는 입력"
-                emptyLabel="새 관계 이름을 입력하세요"
-                customLabel="사용"
-                triggerClassName="h-10 bg-background/80"
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="composer-slot">슬롯</Label>
-              <CmsComboboxField
-                id="composer-slot"
-                name="slot"
-                defaultValue={slotOptions[0] ?? "default"}
-                options={slotOptions.map((option) => ({
-                  value: option,
-                  label: option,
-                }))}
-                placeholder="슬롯 선택"
-                searchPlaceholder="슬롯 검색 또는 입력"
-                emptyLabel="새 슬롯 이름을 입력하세요"
-                customLabel="사용"
-                triggerClassName="h-10 bg-background/80"
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="composer-sort-order">순서</Label>
-              <Input
-                id="composer-sort-order"
-                name="sort_order"
-                type="number"
-                defaultValue={nextSortOrder}
-                className="h-10 bg-background/80"
-              />
-            </div>
-          </div>
-          <CmsSubmitButton className="w-full rounded-full">
-            데이터 연결
-          </CmsSubmitButton>
-        </form>
-
-        <Separator />
-
         <div className="space-y-3">
           <div className="flex items-end justify-between gap-3">
             <div>
               <h2 className="font-medium">현재 노출 중인 데이터</h2>
               <p className="text-xs text-muted-foreground">
-                목록에서 항목을 고른 뒤 연결 정보만 펼쳐 수정합니다.
+                항목을 누르면 연결 정보를 Drawer에서 수정합니다.
               </p>
             </div>
             <Badge variant="outline" className="rounded-full">
@@ -482,6 +416,91 @@ function SectionEntityWorkspace({
           />
         </div>
 
+        <Separator />
+
+        <Accordion type="single" collapsible>
+          <AccordionItem
+            value="add-entity"
+            className="overflow-hidden rounded-xl border"
+          >
+            <AccordionTrigger
+              className="bg-muted/20 px-4 py-3 text-left hover:no-underline"
+              data-composer-add-entity-trigger
+            >
+              <div className="min-w-0">
+                <p className="font-medium">데이터 추가</p>
+                <p className="mt-1 text-xs font-normal text-muted-foreground">
+                  새 콘텐츠를 이 섹션에 연결할 때만 펼칩니다.
+                </p>
+              </div>
+            </AccordionTrigger>
+            <AccordionContent className="border-t p-4">
+              <form
+                action={addSectionEntityRelationAction}
+                className="space-y-4"
+                data-composer-track-dirty
+              >
+                <input type="hidden" name="redirect_to" value={redirectTo} />
+                <input type="hidden" name="section_id" value={section.id} />
+                <CmsEntityPicker
+                  name="entity_id"
+                  entities={options.entities}
+                  schemaOptions={options.entitySchemas}
+                  showSchemaFilter
+                />
+                <div className="grid grid-cols-3 gap-2">
+                  <div className="space-y-2">
+                    <Label htmlFor="composer-relation-type">노출 관계</Label>
+                    <CmsComboboxField
+                      id="composer-relation-type"
+                      name="relation_type"
+                      defaultValue="item"
+                      options={relationTypeOptions.map((option) => ({
+                        value: option,
+                        label: option,
+                      }))}
+                      placeholder="관계 선택"
+                      searchPlaceholder="관계 검색 또는 입력"
+                      emptyLabel="새 관계 이름을 입력하세요"
+                      customLabel="사용"
+                      triggerClassName="h-10 bg-background/80"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="composer-slot">슬롯</Label>
+                    <CmsComboboxField
+                      id="composer-slot"
+                      name="slot"
+                      defaultValue={slotOptions[0] ?? "default"}
+                      options={slotOptions.map((option) => ({
+                        value: option,
+                        label: option,
+                      }))}
+                      placeholder="슬롯 선택"
+                      searchPlaceholder="슬롯 검색 또는 입력"
+                      emptyLabel="새 슬롯 이름을 입력하세요"
+                      customLabel="사용"
+                      triggerClassName="h-10 bg-background/80"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="composer-sort-order">순서</Label>
+                    <Input
+                      id="composer-sort-order"
+                      name="sort_order"
+                      type="number"
+                      defaultValue={nextSortOrder}
+                      className="h-10 bg-background/80"
+                    />
+                  </div>
+                </div>
+                <CmsSubmitButton className="w-full rounded-full">
+                  데이터 연결
+                </CmsSubmitButton>
+              </form>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
       </CardContent>
     </Card>
   )


### PR DESCRIPTION
## Summary

- Make the PONIX page composer inspector list-first: connected section entities now appear before creation controls.
- Move “add data to this section” into a collapsed shadcn accordion so the default inspector is not dominated by a form.
- Keep relation editing and entity editing in the existing Drawer / nested Drawer flow.
- Replace affected developer-facing labels in the composer panel with operator-facing Korean labels.

Closes #173

## Supabase Impact

- None. This is UI/interaction polish only.
- No schema, RLS, Storage, Auth, or data migration changes.

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `pnpm run qa:cms-native-controls`
- `pnpm run qa:cms-db-first-loaders`
- `pnpm run build`
- `git diff --check`
- cmux browser smoke on `/ponix/pages/[id]/compose`:
  - Current connected data list renders first.
  - Add-data accordion is closed by default and opens to reveal the relation form.
  - Relation drawer opens from a list item.
  - Nested entity drawer opens from the relation drawer.
  - Browser errors list is empty.

## Notes

- The browser smoke intentionally did not save, delete, or reorder production content.
