### PR TITLE
Add member profile guestbook

### DIFF
--- a/app/(site)/members/[id]/actions.ts
+++ b/app/(site)/members/[id]/actions.ts
@@ -1,0 +1,119 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+import { redirect } from "next/navigation"
+
+import { loadGuestbookViewer } from "@/lib/data/member-guestbook"
+import { createClient } from "@/lib/supabase/server"
+
+function stringField(formData: FormData, name: string) {
+  const value = formData.get(name)
+  return typeof value === "string" ? value.trim() : ""
+}
+
+function memberPath(memberId: string, params?: Record<string, string>) {
+  const searchParams = new URLSearchParams(params)
+  const suffix = searchParams.size > 0 ? `?${searchParams.toString()}` : ""
+  return `/members/${memberId}${suffix}`
+}
+
+async function requireApprovedGuestbookViewer(memberId: string) {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) redirect(`/login?next=/members/${memberId}`)
+
+  const viewer = await loadGuestbookViewer(supabase, user.id)
+  if (!viewer?.approved_at) {
+    redirect(
+      memberPath(memberId, {
+        guestbook_error: "멤버 확인이 끝난 뒤 글을 남길 수 있습니다.",
+      }),
+    )
+  }
+
+  return { supabase, viewer }
+}
+
+export async function createGuestbookEntryAction(formData: FormData) {
+  const memberId = stringField(formData, "member_id")
+  const body = stringField(formData, "body")
+
+  if (!memberId) redirect("/members")
+
+  if (body.length < 1) {
+    redirect(
+      memberPath(memberId, {
+        guestbook_error: "남길 말을 한 줄 이상 적어주세요.",
+      }),
+    )
+  }
+
+  if (body.length > 500) {
+    redirect(
+      memberPath(memberId, {
+        guestbook_error: "방명록은 500자 안에서 남길 수 있습니다.",
+      }),
+    )
+  }
+
+  const { supabase, viewer } = await requireApprovedGuestbookViewer(memberId)
+  const { error } = await supabase.from("member_guestbook_entries").insert({
+    profile_member_id: memberId,
+    author_member_id: viewer.id,
+    body,
+  })
+
+  if (error) {
+    redirect(
+      memberPath(memberId, {
+        guestbook_error: "지금은 글을 남기지 못했습니다. 잠시 뒤 다시 시도해 주세요.",
+      }),
+    )
+  }
+
+  revalidatePath(`/members/${memberId}`)
+  redirect(
+    memberPath(memberId, {
+      guestbook_message: "방명록에 남겼습니다.",
+    }),
+  )
+}
+
+export async function deleteGuestbookEntryAction(formData: FormData) {
+  const memberId = stringField(formData, "member_id")
+  const entryId = stringField(formData, "entry_id")
+
+  if (!memberId) redirect("/members")
+
+  if (!entryId) {
+    redirect(
+      memberPath(memberId, {
+        guestbook_error: "삭제할 글을 찾지 못했습니다.",
+      }),
+    )
+  }
+
+  const { supabase } = await requireApprovedGuestbookViewer(memberId)
+  const { error } = await supabase
+    .from("member_guestbook_entries")
+    .delete()
+    .eq("id", entryId)
+
+  if (error) {
+    redirect(
+      memberPath(memberId, {
+        guestbook_error: "이 글을 삭제할 권한이 없습니다.",
+      }),
+    )
+  }
+
+  revalidatePath(`/members/${memberId}`)
+  redirect(
+    memberPath(memberId, {
+      guestbook_message: "방명록 글을 지웠습니다.",
+    }),
+  )
+}

--- a/app/(site)/members/[id]/page.tsx
+++ b/app/(site)/members/[id]/page.tsx
@@ -11,6 +11,11 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
+import { MemberGuestbook } from "@/components/member-guestbook"
+import {
+  loadGuestbookViewer,
+  loadMemberGuestbook,
+} from "@/lib/data/member-guestbook"
 import { memberPublicSelect } from "@/lib/data/members"
 import { createClient } from "@/lib/supabase/server"
 import type { Database } from "@/lib/supabase/types"
@@ -24,6 +29,7 @@ export const metadata: Metadata = {
 
 type MemberDetailPageProps = {
   params: Promise<{ id: string }>
+  searchParams?: Promise<Record<string, string | string[] | undefined>>
 }
 
 function statusLabel(status: MemberStatus) {
@@ -33,8 +39,18 @@ function statusLabel(status: MemberStatus) {
   return "미정"
 }
 
-export default async function MemberDetailPage({ params }: MemberDetailPageProps) {
+function firstParam(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value
+}
+
+export default async function MemberDetailPage({
+  params,
+  searchParams,
+}: MemberDetailPageProps) {
   const { id } = await params
+  const query = (await searchParams) ?? {}
+  const guestbookMessage = firstParam(query.guestbook_message)
+  const guestbookError = firstParam(query.guestbook_error)
   const supabase = await createClient()
   const {
     data: { user },
@@ -42,11 +58,13 @@ export default async function MemberDetailPage({ params }: MemberDetailPageProps
 
   if (!user) redirect(`/login?next=/members/${id}`)
 
-  const { data: member, error } = await supabase
-    .from("members")
-    .select(memberPublicSelect)
-    .eq("id", id)
-    .maybeSingle()
+  const [memberResult, viewer, guestbookEntries] = await Promise.all([
+    supabase.from("members").select(memberPublicSelect).eq("id", id).maybeSingle(),
+    loadGuestbookViewer(supabase, user.id),
+    loadMemberGuestbook(supabase, id),
+  ])
+
+  const { data: member, error } = memberResult
 
   if (error || !member) notFound()
 
@@ -130,6 +148,17 @@ export default async function MemberDetailPage({ params }: MemberDetailPageProps
               </div>
             </CardContent>
           </Card>
+        </div>
+
+        <div className="mt-6">
+          <MemberGuestbook
+            profileMemberId={member.id}
+            profileName={member.name}
+            entries={guestbookEntries}
+            viewer={viewer}
+            message={guestbookMessage}
+            error={guestbookError}
+          />
         </div>
       </section>
     </main>

--- a/components/member-guestbook.tsx
+++ b/components/member-guestbook.tsx
@@ -1,0 +1,174 @@
+import { MessageCircle, Trash2 } from "lucide-react"
+
+import {
+  createGuestbookEntryAction,
+  deleteGuestbookEntryAction,
+} from "@/app/(site)/members/[id]/actions"
+import { FormSubmitButton } from "@/components/form-submit-button"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Textarea } from "@/components/ui/textarea"
+import type {
+  GuestbookViewer,
+  MemberGuestbookEntry,
+} from "@/lib/data/member-guestbook"
+import { cn } from "@/lib/utils"
+
+type MemberGuestbookProps = {
+  profileMemberId: string
+  profileName: string
+  entries: MemberGuestbookEntry[]
+  viewer: GuestbookViewer
+  message?: string
+  error?: string
+}
+
+function formatEntryDate(value: string) {
+  const date = new Date(value)
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, "0")
+  const day = String(date.getDate()).padStart(2, "0")
+
+  return `${year}.${month}.${day}`
+}
+
+function authorLine(entry: MemberGuestbookEntry) {
+  if (!entry.author) return "Bremen member"
+
+  const parts = [`${entry.author.student_year ?? "??"}학번`]
+  if (entry.author.instrument) parts.push(entry.author.instrument)
+  return parts.join(" · ")
+}
+
+export function MemberGuestbook({
+  profileMemberId,
+  profileName,
+  entries,
+  viewer,
+  message,
+  error,
+}: MemberGuestbookProps) {
+  const canWrite = Boolean(viewer?.approved_at)
+  const isAdmin = viewer?.role === "admin"
+
+  return (
+    <Card className="gap-0 overflow-hidden rounded-md border bg-card/95 py-0 shadow-xl">
+      <CardHeader className="border-b px-6 py-6 md:px-8">
+        <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+          <div>
+            <p className="caps mb-2">Guestbook</p>
+            <CardTitle className="font-serif italic text-5xl leading-none">
+              Notes for {profileName}
+            </CardTitle>
+            <CardDescription className="mt-4 font-serif-kr text-base">
+              공연장에서, 연습실에서, 오래 지나 다시 떠오른 말을 짧게 남깁니다.
+            </CardDescription>
+          </div>
+          <Badge variant="outline" className="w-fit rounded-full">
+            {entries.length} notes
+          </Badge>
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-6 px-6 py-6 md:px-8 md:py-8">
+        {(message || error) && (
+          <Alert
+            variant={error ? "destructive" : "default"}
+            className={cn(!error && "bg-muted/40")}
+          >
+            <AlertDescription>{error ?? message}</AlertDescription>
+          </Alert>
+        )}
+
+        {canWrite ? (
+          <form action={createGuestbookEntryAction} className="rounded-md border bg-muted/25 p-4">
+            <input type="hidden" name="member_id" value={profileMemberId} />
+            <Textarea
+              name="body"
+              maxLength={500}
+              required
+              rows={4}
+              placeholder="함께 남기고 싶은 짧은 안부를 적어주세요."
+              className="resize-none bg-background/80"
+            />
+            <div className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                멤버에게 보이는 공간입니다. 500자 안에서 남길 수 있습니다.
+              </p>
+              <FormSubmitButton className="rounded-full" pendingLabel="남기는 중...">
+                Leave a note
+              </FormSubmitButton>
+            </div>
+          </form>
+        ) : (
+          <div className="rounded-md border border-dashed bg-muted/25 px-4 py-5 text-sm text-muted-foreground">
+            멤버 확인이 끝난 뒤 방명록을 남길 수 있습니다.
+          </div>
+        )}
+
+        {entries.length > 0 ? (
+          <ul className="space-y-3">
+            {entries.map((entry) => {
+              const canDelete =
+                isAdmin || Boolean(viewer && viewer.id === entry.author_member_id)
+
+              return (
+                <li
+                  key={entry.id}
+                  className="rounded-md border bg-background/65 p-4 shadow-sm"
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="min-w-0">
+                      <p className="font-serif-kr text-lg leading-tight">
+                        {entry.author?.name ?? "브레멘 멤버"}
+                      </p>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        {authorLine(entry)} · {formatEntryDate(entry.created_at)}
+                      </p>
+                    </div>
+                    {canDelete && (
+                      <form action={deleteGuestbookEntryAction}>
+                        <input type="hidden" name="member_id" value={profileMemberId} />
+                        <input type="hidden" name="entry_id" value={entry.id} />
+                        <FormSubmitButton
+                          type="submit"
+                          size="icon"
+                          variant="ghost"
+                          className="size-8 rounded-full text-muted-foreground hover:text-destructive"
+                          pendingLabel=""
+                          aria-label="방명록 글 삭제"
+                        >
+                          <Trash2 className="size-4" />
+                        </FormSubmitButton>
+                      </form>
+                    )}
+                  </div>
+                  <p className="mt-4 whitespace-pre-wrap text-sm leading-relaxed text-muted-foreground">
+                    {entry.body}
+                  </p>
+                </li>
+              )
+            })}
+          </ul>
+        ) : (
+          <div className="grid min-h-48 place-items-center rounded-md border border-dashed bg-muted/20 p-8 text-center">
+            <div>
+              <MessageCircle className="mx-auto size-8 text-muted-foreground/60" />
+              <p className="mt-4 font-serif-kr text-xl">아직 남겨진 말이 없습니다.</p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                첫 안부가 이 멤버 페이지의 작은 기록이 됩니다.
+              </p>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/lib/data/member-guestbook.ts
+++ b/lib/data/member-guestbook.ts
@@ -1,0 +1,71 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+import type { Database } from "@/lib/supabase/types"
+
+type Supabase = SupabaseClient<Database>
+type GuestbookRow =
+  Database["public"]["Tables"]["member_guestbook_entries"]["Row"]
+
+export type MemberGuestbookAuthor = {
+  id: string
+  name: string
+  student_year: number | null
+  instrument: string | null
+}
+
+export type MemberGuestbookEntry = Pick<
+  GuestbookRow,
+  "id" | "author_member_id" | "body" | "created_at"
+> & {
+  author: MemberGuestbookAuthor | null
+}
+
+export type GuestbookViewer = {
+  id: string
+  role: Database["public"]["Enums"]["member_role"]
+  approved_at: string | null
+} | null
+
+const guestbookMemberSelect = "id, name, student_year, instrument"
+
+export async function loadGuestbookViewer(
+  supabase: Supabase,
+  authUserId: string,
+): Promise<GuestbookViewer> {
+  const { data } = await supabase
+    .from("members")
+    .select("id, role, approved_at")
+    .eq("auth_user_id", authUserId)
+    .maybeSingle()
+
+  return data ?? null
+}
+
+export async function loadMemberGuestbook(
+  supabase: Supabase,
+  profileMemberId: string,
+): Promise<MemberGuestbookEntry[]> {
+  const { data: entries, error } = await supabase
+    .from("member_guestbook_entries")
+    .select("id, author_member_id, body, created_at")
+    .eq("profile_member_id", profileMemberId)
+    .order("created_at", { ascending: false })
+    .limit(30)
+
+  if (error || !entries?.length) return []
+
+  const authorIds = [...new Set(entries.map((entry) => entry.author_member_id))]
+  const { data: authors } = await supabase
+    .from("members")
+    .select(guestbookMemberSelect)
+    .in("id", authorIds)
+
+  const authorById = new Map(
+    (authors ?? []).map((author) => [author.id, author] as const),
+  )
+
+  return entries.map((entry) => ({
+    ...entry,
+    author: authorById.get(entry.author_member_id) ?? null,
+  }))
+}

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -254,6 +254,48 @@ export type Database = {
         }
         Relationships: []
       }
+      member_guestbook_entries: {
+        Row: {
+          author_member_id: string
+          body: string
+          created_at: string
+          id: string
+          profile_member_id: string
+          updated_at: string
+        }
+        Insert: {
+          author_member_id: string
+          body: string
+          created_at?: string
+          id?: string
+          profile_member_id: string
+          updated_at?: string
+        }
+        Update: {
+          author_member_id?: string
+          body?: string
+          created_at?: string
+          id?: string
+          profile_member_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "member_guestbook_entries_author_member_id_fkey"
+            columns: ["author_member_id"]
+            isOneToOne: false
+            referencedRelation: "members"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "member_guestbook_entries_profile_member_id_fkey"
+            columns: ["profile_member_id"]
+            isOneToOne: false
+            referencedRelation: "members"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       members: {
         Row: {
           approved_at: string | null

--- a/supabase/migrations/20260515113714_member_guestbook_entries.sql
+++ b/supabase/migrations/20260515113714_member_guestbook_entries.sql
@@ -1,0 +1,76 @@
+-- Bremen - member profile guestbook.
+--
+-- Adds a small member-only UGC surface for profile pages. RLS keeps reads and
+-- writes behind approved member identity and does not trust client-provided
+-- author IDs beyond matching the current member helper.
+
+create table if not exists public.member_guestbook_entries (
+  id uuid primary key default gen_random_uuid(),
+  profile_member_id uuid not null references public.members(id) on delete cascade,
+  author_member_id uuid not null references public.members(id) on delete cascade,
+  body text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint member_guestbook_entries_body_length
+    check (char_length(trim(body)) between 1 and 500)
+);
+
+create index if not exists member_guestbook_entries_profile_created_idx
+  on public.member_guestbook_entries(profile_member_id, created_at desc);
+
+create index if not exists member_guestbook_entries_author_idx
+  on public.member_guestbook_entries(author_member_id);
+
+drop trigger if exists member_guestbook_entries_set_updated_at
+  on public.member_guestbook_entries;
+
+create trigger member_guestbook_entries_set_updated_at
+  before update on public.member_guestbook_entries
+  for each row
+  execute function public.set_updated_at();
+
+alter table public.member_guestbook_entries enable row level security;
+
+drop policy if exists "member_guestbook_entries_read_access"
+  on public.member_guestbook_entries;
+drop policy if exists "member_guestbook_entries_insert_access"
+  on public.member_guestbook_entries;
+drop policy if exists "member_guestbook_entries_author_delete"
+  on public.member_guestbook_entries;
+
+create policy "member_guestbook_entries_read_access"
+  on public.member_guestbook_entries for select
+  using (
+    private.is_admin()
+    or exists (
+      select 1
+      from public.members viewer
+      where viewer.auth_user_id = (select auth.uid())
+        and viewer.approved_at is not null
+    )
+  );
+
+create policy "member_guestbook_entries_insert_access"
+  on public.member_guestbook_entries for insert
+  with check (
+    author_member_id = private.current_member_id()
+    and exists (
+      select 1
+      from public.members author
+      where author.id = author_member_id
+        and author.approved_at is not null
+    )
+    and exists (
+      select 1
+      from public.members profile
+      where profile.id = profile_member_id
+        and profile.approved_at is not null
+    )
+  );
+
+create policy "member_guestbook_entries_author_delete"
+  on public.member_guestbook_entries for delete
+  using (
+    private.is_admin()
+    or author_member_id = private.current_member_id()
+  );

--- a/supabase/migrations/20260515115636_drop_unused_guestbook_author_index.sql
+++ b/supabase/migrations/20260515115636_drop_unused_guestbook_author_index.sql
@@ -1,0 +1,7 @@
+-- Bremen - remove unused guestbook author-only index.
+--
+-- Guestbook profile reads use the profile/date index. Deletes target the row
+-- primary key and let RLS check authorship, so the author-only index adds
+-- advisor noise without serving the current UI path.
+
+drop index if exists public.member_guestbook_entries_author_idx;

--- a/supabase/migrations/20260515115703_restore_guestbook_author_fk_index.sql
+++ b/supabase/migrations/20260515115703_restore_guestbook_author_fk_index.sql
@@ -1,0 +1,7 @@
+-- Bremen - restore guestbook author FK covering index.
+--
+-- Supabase advisor prefers foreign keys to have covering indexes. Keep this
+-- even though the first UI path primarily reads by profile member.
+
+create index if not exists member_guestbook_entries_author_idx
+  on public.member_guestbook_entries(author_member_id);


### PR DESCRIPTION
## Summary

Closes #177.

Adds a member-only guestbook to `/members/[id]` so approved signed-in members can leave short notes on member profiles and remove their own notes.

## Supabase Impact

- Added `member_guestbook_entries` with RLS enabled.
- Insert is restricted to the current approved member via `private.current_member_id()`.
- Read is restricted to approved members/admins.
- Delete is restricted to the entry author/admin.
- Applied migrations in production:
  - `20260515113714_member_guestbook_entries`
  - `20260515115636_drop_unused_guestbook_author_index`
  - `20260515115703_restore_guestbook_author_fk_index`

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `git diff --check`
- `pnpm run qa:content-graph`
- `pnpm run qa:cms-db-first-loaders`
- `pnpm run build`
- Supabase security advisor: only existing leaked-password-protection WARN remains
- Supabase performance advisor: no lints
- Browser QA on localhost: created and deleted a temporary note on `/members/5ef6ae5e-387e-49b8-ba43-faef20b0a292`
- Verified temporary QA note count returned to `0`

## Notes

The cmux surface left a pending Next RSC swap callback during local QA; running the pending callback showed the actual rendered page. No browser console errors were reported.
