### PR TITLE
Add PONIX guestbook moderation

### DIFF
--- a/app/ponix/_components/ponix-shell.tsx
+++ b/app/ponix/_components/ponix-shell.tsx
@@ -11,6 +11,7 @@ import {
   FileText,
   GitBranch,
   LayoutDashboard,
+  MessageSquareText,
   Music2,
   Users,
 } from "lucide-react"
@@ -77,6 +78,12 @@ const navGroups = [
         label: "멤버 운영",
         description: "가입 승인, 권한, 활동 상태를 관리",
         icon: Users,
+      },
+      {
+        href: "/ponix/guestbook",
+        label: "방명록 관리",
+        description: "멤버 프로필에 남겨진 글을 확인하고 정리",
+        icon: MessageSquareText,
       },
     ],
   },

--- a/app/ponix/guestbook/actions.ts
+++ b/app/ponix/guestbook/actions.ts
@@ -1,0 +1,50 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+import { redirect } from "next/navigation"
+
+import { requireCmsAdmin } from "@/lib/cms/auth"
+import { createClient } from "@/lib/supabase/server"
+
+function stringField(formData: FormData, key: string) {
+  const value = formData.get(key)
+  return typeof value === "string" ? value.trim() : ""
+}
+
+function redirectWithParams(path: string, params: Record<string, string>): never {
+  const search = new URLSearchParams(params)
+  redirect(`${path}?${search.toString()}`)
+}
+
+export async function deleteGuestbookEntryAction(formData: FormData) {
+  const entryId = stringField(formData, "entry_id")
+  const profileMemberId = stringField(formData, "profile_member_id")
+
+  if (!entryId) {
+    redirectWithParams("/ponix/guestbook", {
+      error: "삭제할 방명록 글을 찾지 못했습니다.",
+    })
+  }
+
+  await requireCmsAdmin("/ponix/guestbook")
+  const supabase = await createClient()
+  const { error } = await supabase
+    .from("member_guestbook_entries")
+    .delete()
+    .eq("id", entryId)
+
+  if (error) {
+    redirectWithParams("/ponix/guestbook", {
+      error: "방명록 글을 삭제하지 못했습니다.",
+    })
+  }
+
+  revalidatePath("/ponix/guestbook")
+  if (profileMemberId) {
+    revalidatePath(`/members/${profileMemberId}`)
+  }
+
+  redirectWithParams("/ponix/guestbook", {
+    saved: "guestbook",
+  })
+}

--- a/app/ponix/guestbook/guestbook-moderation-list.tsx
+++ b/app/ponix/guestbook/guestbook-moderation-list.tsx
@@ -1,0 +1,257 @@
+"use client"
+
+import { useDeferredValue, useState } from "react"
+import Link from "next/link"
+import { MessageSquareText, Search, Trash2, X } from "lucide-react"
+
+import { deleteGuestbookEntryAction } from "@/app/ponix/guestbook/actions"
+import { formatCmsDate } from "@/app/ponix/_components/cms-list"
+import { FormSubmitButton } from "@/components/form-submit-button"
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import type { CmsGuestbookEntry } from "@/lib/cms/guestbook"
+
+export function GuestbookModerationList({
+  entries,
+}: {
+  entries: CmsGuestbookEntry[]
+}) {
+  const [query, setQuery] = useState("")
+  const deferredQuery = useDeferredValue(query.trim().toLowerCase())
+  const filteredEntries = entries.filter((entry) =>
+    guestbookSearchText(entry).includes(deferredQuery),
+  )
+  const hasQuery = query.trim().length > 0
+
+  return (
+    <div data-guestbook-moderation>
+      <div className="border-b bg-muted/10 p-4 md:p-5">
+        <div className="flex flex-col gap-3 xl:flex-row xl:items-end xl:justify-between">
+          <div className="max-w-2xl">
+            <div className="flex items-center gap-2 text-sm font-medium">
+              <MessageSquareText className="size-4 text-muted-foreground" />
+              방명록 찾기
+            </div>
+            <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+              프로필 주인, 작성자, 본문으로 검색하고 문제가 있는 글은 바로 정리합니다.
+            </p>
+          </div>
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <span>표시 {filteredEntries.length}개</span>
+            <span>/</span>
+            <span>전체 {entries.length}개</span>
+          </div>
+        </div>
+
+        <div className="mt-4 flex flex-col gap-3 md:flex-row">
+          <div className="relative min-w-0 flex-1">
+            <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="멤버 이름, 작성자, 본문으로 검색"
+              className="h-10 rounded-full bg-background pl-9"
+              data-guestbook-search
+            />
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            className="h-10 rounded-full"
+            disabled={!hasQuery}
+            onClick={() => setQuery("")}
+          >
+            <X className="size-4" />
+            초기화
+          </Button>
+        </div>
+      </div>
+
+      {filteredEntries.length > 0 ? (
+        <div className="overflow-x-auto">
+          <Table className="min-w-[68rem]">
+            <TableHeader>
+              <TableRow>
+                <TableHead>프로필</TableHead>
+                <TableHead>작성자</TableHead>
+                <TableHead>내용</TableHead>
+                <TableHead>작성일</TableHead>
+                <TableHead>관리</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {filteredEntries.map((entry) => (
+                <TableRow key={entry.id}>
+                  <TableCell className="min-w-44">
+                    <MemberLink
+                      memberId={entry.profile_member_id}
+                      name={entry.profile?.name}
+                      meta={memberMeta(entry.profile)}
+                    />
+                  </TableCell>
+                  <TableCell className="min-w-44">
+                    <MemberLink
+                      memberId={entry.author_member_id}
+                      name={entry.author?.name}
+                      meta={memberMeta(entry.author)}
+                    />
+                  </TableCell>
+                  <TableCell className="max-w-xl">
+                    <p className="line-clamp-3 whitespace-pre-wrap text-sm leading-relaxed">
+                      {entry.body}
+                    </p>
+                  </TableCell>
+                  <TableCell className="whitespace-nowrap text-xs text-muted-foreground">
+                    {formatCmsDate(entry.created_at)}
+                  </TableCell>
+                  <TableCell>
+                    <DeleteEntryDialog entry={entry} />
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      ) : (
+        <div className="grid min-h-72 place-items-center px-5 py-12 text-center">
+          <div className="max-w-sm">
+            <p className="font-serif text-3xl italic">
+              방명록 글이 없습니다
+            </p>
+            <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+              {hasQuery
+                ? "검색어를 줄이거나 초기화해 다시 확인하세요."
+                : "아직 멤버 프로필에 남겨진 글이 없습니다."}
+            </p>
+            {hasQuery && (
+              <Button
+                type="button"
+                variant="outline"
+                className="mt-5 rounded-full"
+                onClick={() => setQuery("")}
+              >
+                검색 초기화
+              </Button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function MemberLink({
+  memberId,
+  name,
+  meta,
+}: {
+  memberId: string
+  name?: string
+  meta: string
+}) {
+  return (
+    <div>
+      <Link
+        href={`/members/${memberId}`}
+        className="font-medium underline-offset-4 hover:underline"
+      >
+        {name ?? "알 수 없는 멤버"}
+      </Link>
+      <div className="mt-1 flex flex-wrap gap-1.5">
+        <Badge variant="outline" className="rounded-full text-xs">
+          {meta}
+        </Badge>
+      </div>
+    </div>
+  )
+}
+
+function DeleteEntryDialog({ entry }: { entry: CmsGuestbookEntry }) {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="rounded-full text-muted-foreground hover:text-destructive"
+        >
+          <Trash2 className="size-4" />
+          삭제
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>이 방명록 글을 삭제할까요?</AlertDialogTitle>
+          <AlertDialogDescription>
+            삭제하면 멤버 프로필에서 바로 사라집니다. 복구 기능은 아직 없습니다.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <div className="rounded-xl border bg-muted/30 p-4 text-sm leading-relaxed text-muted-foreground">
+          {entry.body}
+        </div>
+        <AlertDialogFooter>
+          <AlertDialogCancel>취소</AlertDialogCancel>
+          <form action={deleteGuestbookEntryAction}>
+            <input type="hidden" name="entry_id" value={entry.id} />
+            <input
+              type="hidden"
+              name="profile_member_id"
+              value={entry.profile_member_id}
+            />
+            <FormSubmitButton
+              variant="destructive"
+              pendingLabel="삭제 중..."
+              className="w-full sm:w-auto"
+            >
+              삭제
+            </FormSubmitButton>
+          </form>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+
+function memberMeta(member: CmsGuestbookEntry["author"]) {
+  if (!member) return "멤버 정보 없음"
+
+  const parts = []
+  if (member.student_year) parts.push(`${member.student_year}학번`)
+  if (member.instrument) parts.push(member.instrument)
+  return parts.length ? parts.join(" · ") : "프로필"
+}
+
+function guestbookSearchText(entry: CmsGuestbookEntry) {
+  return [
+    entry.profile?.name,
+    entry.profile?.student_year?.toString(),
+    entry.profile?.instrument,
+    entry.author?.name,
+    entry.author?.student_year?.toString(),
+    entry.author?.instrument,
+    entry.body,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase()
+}

--- a/app/ponix/guestbook/page.tsx
+++ b/app/ponix/guestbook/page.tsx
@@ -1,0 +1,77 @@
+import type { Metadata } from "next"
+
+import { CmsListPage, CmsStatGrid, CmsStatTile, CmsTableCard } from "@/app/ponix/_components/cms-list"
+import { CmsSaveNotice } from "@/app/ponix/_components/cms-save-controls"
+import { GuestbookModerationList } from "@/app/ponix/guestbook/guestbook-moderation-list"
+import { requireCmsAdmin } from "@/lib/cms/auth"
+import { loadCmsGuestbookEntries } from "@/lib/cms/guestbook"
+
+export const metadata: Metadata = {
+  title: "방명록 관리 | Bremen Admin",
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
+
+type PonixGuestbookPageProps = {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>
+}
+
+function firstParam(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value
+}
+
+function latestDetail(value: string | null) {
+  if (!value) return "아직 남겨진 글 없음"
+
+  return new Intl.DateTimeFormat("ko-KR", {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(value))
+}
+
+export default async function PonixGuestbookPage({
+  searchParams,
+}: PonixGuestbookPageProps) {
+  await requireCmsAdmin("/ponix/guestbook")
+  const [query, { entries, stats }] = await Promise.all([
+    searchParams,
+    loadCmsGuestbookEntries(),
+  ])
+  const saved = firstParam(query?.saved) === "guestbook"
+  const error = firstParam(query?.error)
+
+  return (
+    <CmsListPage
+      eyebrow="동아리 운영 / 방명록"
+      title="Guestbook desk"
+      description="멤버 프로필에 남겨진 안부를 한곳에서 확인하고, 문제가 있는 글은 바로 정리합니다."
+    >
+      <CmsSaveNotice
+        saved={saved}
+        error={error}
+        savedTitle="방명록을 정리했습니다"
+        savedDescription="선택한 글이 멤버 프로필에서 사라졌습니다."
+        errorTitle="방명록을 정리하지 못했습니다"
+      />
+
+      <CmsStatGrid>
+        <CmsStatTile label="글" value={stats.total} detail="최근 200개 기준" accent />
+        <CmsStatTile label="프로필" value={stats.profiles} detail="글이 남겨진 멤버" />
+        <CmsStatTile label="작성자" value={stats.authors} detail="방명록을 남긴 멤버" />
+        <CmsStatTile
+          label="최근"
+          value={stats.latestAt ? "New" : "-"}
+          detail={latestDetail(stats.latestAt)}
+        />
+      </CmsStatGrid>
+
+      <CmsTableCard title="방명록 글" meta={`${entries.length}개`}>
+        <GuestbookModerationList entries={entries} />
+      </CmsTableCard>
+    </CmsListPage>
+  )
+}

--- a/lib/cms/guestbook.ts
+++ b/lib/cms/guestbook.ts
@@ -1,0 +1,83 @@
+import { createClient } from "@/lib/supabase/server"
+import type { Database } from "@/lib/supabase/types"
+
+type GuestbookRow =
+  Database["public"]["Tables"]["member_guestbook_entries"]["Row"]
+type MemberRow = Database["public"]["Tables"]["members"]["Row"]
+
+export type CmsGuestbookMember = Pick<
+  MemberRow,
+  "id" | "name" | "student_year" | "instrument"
+>
+
+export type CmsGuestbookEntry = Pick<
+  GuestbookRow,
+  "id" | "profile_member_id" | "author_member_id" | "body" | "created_at"
+> & {
+  profile: CmsGuestbookMember | null
+  author: CmsGuestbookMember | null
+}
+
+export type CmsGuestbookStats = {
+  total: number
+  profiles: number
+  authors: number
+  latestAt: string | null
+}
+
+const memberSelect = "id, name, student_year, instrument"
+
+export async function loadCmsGuestbookEntries(): Promise<{
+  entries: CmsGuestbookEntry[]
+  stats: CmsGuestbookStats
+}> {
+  const supabase = await createClient()
+  const { data: entries, error } = await supabase
+    .from("member_guestbook_entries")
+    .select("id, profile_member_id, author_member_id, body, created_at")
+    .order("created_at", { ascending: false })
+    .limit(200)
+
+  if (error || !entries?.length) {
+    return {
+      entries: [],
+      stats: {
+        total: 0,
+        profiles: 0,
+        authors: 0,
+        latestAt: null,
+      },
+    }
+  }
+
+  const memberIds = [
+    ...new Set(
+      entries.flatMap((entry) => [
+        entry.profile_member_id,
+        entry.author_member_id,
+      ]),
+    ),
+  ]
+  const { data: members } = await supabase
+    .from("members")
+    .select(memberSelect)
+    .in("id", memberIds)
+  const memberById = new Map(
+    (members ?? []).map((member) => [member.id, member] as const),
+  )
+  const mapped = entries.map((entry) => ({
+    ...entry,
+    profile: memberById.get(entry.profile_member_id) ?? null,
+    author: memberById.get(entry.author_member_id) ?? null,
+  }))
+
+  return {
+    entries: mapped,
+    stats: {
+      total: mapped.length,
+      profiles: new Set(mapped.map((entry) => entry.profile_member_id)).size,
+      authors: new Set(mapped.map((entry) => entry.author_member_id)).size,
+      latestAt: mapped[0]?.created_at ?? null,
+    },
+  }
+}


### PR DESCRIPTION
## Summary

Closes #180.

Adds a PONIX guestbook moderation desk so admins can search member guestbook entries and remove a single entry after a shadcn confirmation dialog.

## Supabase Impact

- No schema, RLS, storage, or data migration changes.
- Uses the existing `member_guestbook_entries` table and current admin/session RLS.

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `pnpm run qa:cms-native-controls`
- `pnpm run qa:cms-db-first-loaders`
- `git diff --check`
- `pnpm run build`
- Browser QA on localhost:
  - `/ponix/guestbook` renders behind the PONIX admin shell
  - search filters entries
  - delete opens an AlertDialog confirmation
  - a temporary QA guestbook note was deleted through PONIX
  - temporary QA note count returned to `0`
  - browser errors list was empty

## Notes

The route intentionally does not add bulk deletion, editing, replies, or a moderation queue. Those should be separate issues if needed.
