### PR TITLE
Add UGC visibility and storage guardrails

### DIFF
--- a/app/ponix/_components/cms-detail.tsx
+++ b/app/ponix/_components/cms-detail.tsx
@@ -28,7 +28,12 @@ import {
 import { loadCmsSchema } from "@/lib/cms/schema-registry.server"
 
 import { CmsAuditTrailCard } from "./cms-audit-card"
-import { formatCmsDate, PublishBadge, SchemaBadge } from "./cms-list"
+import {
+  formatCmsDate,
+  PublishBadge,
+  SchemaBadge,
+  VisibilityBadge,
+} from "./cms-list"
 
 const sourceLabels: Record<CmsFieldSource, string> = {
   column: "기본 정보",
@@ -75,6 +80,9 @@ export async function CmsDetailPage({
             )}
             <div className="mt-5 flex flex-wrap items-center gap-2">
               <PublishBadge published={detail.published} />
+              {detail.kind === "entity" && (
+                <VisibilityBadge visibility={detail.row.visibility} />
+              )}
               <SchemaBadge
                 label={detail.schemaLabel}
                 registered={detail.schemaRegistered}

--- a/app/ponix/_components/cms-entity-create-form.tsx
+++ b/app/ponix/_components/cms-entity-create-form.tsx
@@ -219,6 +219,10 @@ function createDefaultValue(field: CmsEditableEntityField) {
     return new Date().toISOString().slice(0, 16)
   }
 
+  if (field.source === "column" && field.key === "visibility") {
+    return "public"
+  }
+
   if (field.type === "boolean") {
     return false
   }

--- a/app/ponix/_components/cms-list.tsx
+++ b/app/ponix/_components/cms-list.tsx
@@ -184,6 +184,24 @@ export function PublishBadge({ published }: { published: boolean }) {
   )
 }
 
+export function VisibilityBadge({ visibility }: { visibility: string }) {
+  const label =
+    visibility === "members"
+      ? "멤버 공개"
+      : visibility === "private"
+        ? "비공개"
+        : "전체 공개"
+
+  return (
+    <Badge
+      variant={visibility === "public" ? "secondary" : "outline"}
+      className={cn("rounded-full", visibility !== "public" && "text-muted-foreground")}
+    >
+      {label}
+    </Badge>
+  )
+}
+
 export function SchemaBadge({
   label,
   registered,

--- a/app/ponix/entities/actions.ts
+++ b/app/ponix/entities/actions.ts
@@ -361,6 +361,10 @@ async function buildEntityUpdate({
       update.published = Boolean(parsed.value)
     }
 
+    if (field.key === "visibility") {
+      update.visibility = String(parsed.value)
+    }
+
     if (field.key === "slug") {
       update.slug = parsed.value === null ? null : String(parsed.value)
     }
@@ -437,6 +441,10 @@ export async function createCmsEntityAction(formData: FormData) {
 
     if (field.key === "published") {
       insert.published = Boolean(parsed.value)
+    }
+
+    if (field.key === "visibility") {
+      insert.visibility = String(parsed.value)
     }
 
     if (field.key === "slug") {

--- a/app/ponix/entities/page.tsx
+++ b/app/ponix/entities/page.tsx
@@ -10,6 +10,7 @@ import {
   formatCmsDate,
   PublishBadge,
   SchemaBadge,
+  VisibilityBadge,
 } from "@/app/ponix/_components/cms-list"
 import { Button } from "@/components/ui/button"
 import { requireCmsAdmin } from "@/lib/cms/auth"
@@ -63,6 +64,7 @@ export default async function PonixEntitiesPage() {
             badges={
               <>
                 <PublishBadge published={entity.published} />
+                <VisibilityBadge visibility={entity.visibility} />
                 <SchemaBadge
                   label={entity.schemaLabel}
                   registered={entity.schemaRegistered}

--- a/docs/content-graph.md
+++ b/docs/content-graph.md
@@ -215,6 +215,7 @@ Use `entities` columns for shared display identity:
 - `thumbnail_url`
 - `sort_at`
 - `published`
+- `visibility`
 
 Use `entities.data` for entity-specific structured data:
 
@@ -240,6 +241,25 @@ Expected flow:
 4. Render from the stored URL.
 
 Avoid adding `image_url`, `thumbnail_url`, `cover_url`, and `preview_url` for the same concept unless a renderer truly needs multiple image roles.
+
+For member-uploaded UGC, do not use the public `images` bucket by default.
+Store photos and direct video uploads in the private `member-media` bucket and
+link them from `entities.data.storage_bucket = "member-media"` plus
+`entities.data.storage_path`. `entities.published` means the submission has
+been approved; `entities.visibility` controls who can read it:
+
+- `public`: approved content can be shown to everyone.
+- `members`: approved content is available only to active members and admins.
+- `private`: visible only to the owner and admins.
+
+If a public card needs a stable thumbnail, keep `thumbnail_url` public only for
+assets that are intended to be public. Member-only/private media should be
+served through Storage RLS/signed URL flows, not full public URLs.
+
+Public image buckets (`images`, `photos`, `posters`, `avatars`) are only for
+assets intended to be public and are constrained to image MIME types/extensions
+with bucket-level size limits. Do not store private UGC or direct video uploads
+there.
 
 ## Members Are Not Generic Entities
 

--- a/docs/supabase-setup.md
+++ b/docs/supabase-setup.md
@@ -187,6 +187,36 @@ Avoid:
 - Moving `members` into generic entities; member auth/profile data remains
   domain-specific.
 
+## Storage and Member UGC
+
+Public buckets are only appropriate for assets that may be downloaded by anyone
+with the URL. For member-uploaded photos or videos, use the private
+`member-media` bucket and enforce access through `storage.objects` RLS.
+
+Current convention:
+
+- Path: `member-media/{auth.uid()}/photos/...` or
+  `member-media/{auth.uid()}/videos/...`
+- Entity link: `entities.data.storage_bucket = "member-media"` and
+  `entities.data.storage_path = <object path>`
+- Approval: `entities.published`
+- Visibility: `entities.visibility` (`public`, `members`, `private`)
+
+Do not make a private/member-only asset public by storing its full public object
+URL. Use Storage RLS and signed URL/download flows for protected media.
+
+Public Storage buckets still exist for assets that are meant to be public:
+
+- `images`: CMS thumbnails and imported public display assets.
+- `photos` / `posters`: legacy public gallery and poster assets.
+- `avatars`: member profile images; members can write only under their own
+  `{auth.uid()}/...` folder.
+
+These public buckets must stay image-only. Bucket configuration and
+`storage.objects` policies enforce image MIME types, image extensions, and size
+limits. Do not use them for member-only uploads, arbitrary attachments, or video
+files.
+
 ## CMS Audit Trail
 
 PONIX CMS write auditing is documented in `docs/cms-audit.md`.

--- a/lib/cms/content.ts
+++ b/lib/cms/content.ts
@@ -30,8 +30,8 @@ const ENTITY_RELATION_SELECT = `
   sort_order,
   props,
   updated_at,
-  fromEntity:entities!entity_relations_from_entity_id_fkey(id, slug, title, subtitle, summary, thumbnail_url, schema_id, data, published, sort_at),
-  toEntity:entities!entity_relations_to_entity_id_fkey(id, slug, title, subtitle, summary, thumbnail_url, schema_id, data, published, sort_at)
+  fromEntity:entities!entity_relations_from_entity_id_fkey(id, slug, title, subtitle, summary, thumbnail_url, schema_id, data, published, visibility, sort_at),
+  toEntity:entities!entity_relations_to_entity_id_fkey(id, slug, title, subtitle, summary, thumbnail_url, schema_id, data, published, visibility, sort_at)
 `
 const CMS_PAGE_ENTITY_SELECT =
   "id, schema_id, slug, title, subtitle, summary, owner_member_id, published, data, created_at, updated_at"
@@ -100,6 +100,7 @@ export type CmsEntitySummary = SchemaSummary & {
   subtitle: string | null
   thumbnailUrl: string | null
   published: boolean
+  visibility: string
   sortAt: string
   updatedAt: string
 }
@@ -141,6 +142,7 @@ export type CmsLinkedEntity = SchemaSummary & {
   thumbnailUrl: string | null
   data: Json
   published: boolean
+  visibility: string
   sortAt: string
 }
 
@@ -458,6 +460,7 @@ function mapEntitySummary(entity: Pick<
   | "subtitle"
   | "thumbnail_url"
   | "published"
+  | "visibility"
   | "sort_at"
   | "updated_at"
 >,
@@ -472,6 +475,7 @@ function mapEntitySummary(entity: Pick<
     subtitle: entity.subtitle,
     thumbnailUrl: entity.thumbnail_url,
     published: entity.published,
+    visibility: entity.visibility,
     sortAt: entity.sort_at,
     updatedAt: entity.updated_at,
   }
@@ -539,6 +543,7 @@ function linkedEntity(
     thumbnailUrl: entity.thumbnail_url,
     data: entity.data,
     published: entity.published,
+    visibility: entity.visibility,
     sortAt: entity.sort_at,
   }
 }
@@ -571,6 +576,7 @@ type RawEntityLink = Pick<
   | "thumbnail_url"
   | "data"
   | "published"
+  | "visibility"
   | "sort_at"
 >
 
@@ -777,7 +783,7 @@ export async function loadCmsEntities(): Promise<CmsEntityList> {
   const entitiesQuery = supabase
     .from("entities")
     .select(
-      "id, schema_id, slug, title, subtitle, thumbnail_url, published, sort_at, updated_at",
+      "id, schema_id, slug, title, subtitle, thumbnail_url, published, visibility, sort_at, updated_at",
       { count: "exact" },
     )
     .order("sort_at", { ascending: false })
@@ -812,7 +818,7 @@ export async function loadCmsEntityOptions({
   let entityQuery = supabase
     .from("entities")
     .select(
-      "id, schema_id, slug, title, subtitle, thumbnail_url, published, sort_at, updated_at",
+      "id, schema_id, slug, title, subtitle, thumbnail_url, published, visibility, sort_at, updated_at",
     )
 
   if (normalizedSchema && normalizedSchema !== "all") {
@@ -853,7 +859,7 @@ export async function loadCmsRelationEditorOptions({
 }: LoadCmsRelationEditorOptionsOptions = {}): Promise<CmsRelationEditorOptions> {
   const supabase = await createClient()
   const entitySelect =
-    "id, schema_id, slug, title, subtitle, thumbnail_url, published, sort_at, updated_at"
+    "id, schema_id, slug, title, subtitle, thumbnail_url, published, visibility, sort_at, updated_at"
   const entityQuery = countEntities
     ? supabase.from("entities").select(entitySelect, { count: "exact" })
     : supabase.from("entities").select(entitySelect)

--- a/lib/cms/entity-editor.ts
+++ b/lib/cms/entity-editor.ts
@@ -15,6 +15,7 @@ const editableEntityColumns = new Set([
   "thumbnail_url",
   "sort_at",
   "published",
+  "visibility",
 ])
 
 export type CmsEditableEntityField = CmsFieldDefinition & {

--- a/lib/cms/schema-registry.ts
+++ b/lib/cms/schema-registry.ts
@@ -63,6 +63,12 @@ const field = (
 
 const textOption = (value: string, label = value): CmsFieldOption => ({ label, value })
 
+const visibilityOptions = [
+  textOption("public", "전체 공개"),
+  textOption("members", "멤버 공개"),
+  textOption("private", "비공개"),
+]
+
 const sectionBaseFields = [
   field("column", "key", "Section key", "text", { readOnly: true, required: true }),
   field("column", "section_type", "Renderer type", "text", {
@@ -83,6 +89,10 @@ const entityBaseFields = [
   field("column", "thumbnail_url", "Thumbnail URL", "image"),
   field("column", "sort_at", "Sort date", "datetime", { required: true }),
   field("column", "published", "Published", "boolean", { required: true }),
+  field("column", "visibility", "공개 범위", "select", {
+    required: true,
+    options: visibilityOptions,
+  }),
 ]
 
 const sectionSchema = (
@@ -168,10 +178,12 @@ const semanticGroupOverrides: Record<string, string> = {
   "activity/home-card/v1": "home",
   "contact/site-footer/v1": "site",
   "navigation/item/v1": "site",
+  "photo/member-upload/v1": "ugc",
   "playlist/youtube/v1": "video",
   "post/instagram/v1": "instagram",
   "social/site-footer/v1": "site",
   "stat/home-number/v1": "home",
+  "video/member-upload/v1": "ugc",
 }
 
 function defaultSemanticKind(schema: Pick<CmsSchemaDraft, "schemaKey" | "kind">) {
@@ -453,6 +465,26 @@ const rawCmsSchemaRegistry: CmsSchemaDraft[] = [
     ],
   ),
   entitySchema(
+    "video/member-upload/v1",
+    "Member video",
+    "A video link or upload submitted by an approved Bremen member.",
+    [
+      field("data", "video_url", "Video URL", "url"),
+      field("data", "artist", "Artist", "text"),
+      field("data", "song", "Song", "text"),
+      field("data", "team", "Team", "text"),
+      field("data", "event_slug", "Event slug", "text"),
+      field("data", "event_title", "Event title", "text"),
+      field("data", "duration", "Duration", "text"),
+      field("data", "storage_bucket", "Storage bucket", "text", { readOnly: true }),
+      field("data", "storage_path", "Storage path", "text", { readOnly: true }),
+      field("data", "media_type", "Media type", "text", { readOnly: true }),
+      field("data", "original_filename", "Original filename", "text", {
+        readOnly: true,
+      }),
+    ],
+  ),
+  entitySchema(
     "playlist/youtube/v1",
     "YouTube playlist",
     "YouTube playlist or performance collection imported from the Bremen channel.",
@@ -477,6 +509,23 @@ const rawCmsSchemaRegistry: CmsSchemaDraft[] = [
       field("data", "aspect", "Aspect", "select", { options: photoAspectOptions }),
       field("data", "gallery_include", "Show in gallery", "boolean"),
       field("data", "taken_at", "Taken at", "date"),
+    ],
+  ),
+  entitySchema(
+    "photo/member-upload/v1",
+    "Member photo",
+    "A photo uploaded by an approved Bremen member.",
+    [
+      field("data", "category", "Category", "select", { options: photoCategoryOptions }),
+      field("data", "aspect", "Aspect", "select", { options: photoAspectOptions }),
+      field("data", "gallery_include", "Show in gallery", "boolean"),
+      field("data", "taken_at", "Taken at", "date"),
+      field("data", "storage_bucket", "Storage bucket", "text", { readOnly: true }),
+      field("data", "storage_path", "Storage path", "text", { readOnly: true }),
+      field("data", "media_type", "Media type", "text", { readOnly: true }),
+      field("data", "original_filename", "Original filename", "text", {
+        readOnly: true,
+      }),
     ],
   ),
   entitySchema(

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -81,6 +81,7 @@ export type Database = {
           thumbnail_url: string | null
           title: string
           updated_at: string
+          visibility: string
         }
         Insert: {
           created_at?: string
@@ -96,6 +97,7 @@ export type Database = {
           thumbnail_url?: string | null
           title: string
           updated_at?: string
+          visibility?: string
         }
         Update: {
           created_at?: string
@@ -111,6 +113,7 @@ export type Database = {
           thumbnail_url?: string | null
           title?: string
           updated_at?: string
+          visibility?: string
         }
         Relationships: [
           {

--- a/supabase/migrations/20260515132021_ugc_visibility_storage_guardrails.sql
+++ b/supabase/migrations/20260515132021_ugc_visibility_storage_guardrails.sql
@@ -1,0 +1,413 @@
+-- Bremen - add entity visibility and member media storage guardrails.
+--
+-- `published` remains the editorial approval flag. `visibility` controls who
+-- may read an approved entity. Member-uploaded media is stored in a private
+-- bucket and read through RLS/signed URL capable policies rather than public
+-- object URLs.
+
+alter table public.entities
+  add column if not exists visibility text not null default 'public';
+
+alter table public.entities
+  drop constraint if exists entities_visibility_check;
+
+alter table public.entities
+  add constraint entities_visibility_check
+  check (visibility in ('public', 'members', 'private'));
+
+create index if not exists entities_visibility_published_sort_idx
+  on public.entities(visibility, published, sort_at desc);
+
+create index if not exists entities_owner_visibility_idx
+  on public.entities(owner_member_id, visibility, published);
+
+create or replace function private.can_read_entity(
+  row_published boolean,
+  row_visibility text,
+  row_owner_member_id uuid
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, auth, private
+as $$
+  select
+    private.is_admin()
+    or row_owner_member_id = private.current_member_id()
+    or (
+      row_published = true
+      and row_visibility = 'public'
+    )
+    or (
+      row_published = true
+      and row_visibility = 'members'
+      and private.is_active_member()
+    );
+$$;
+
+revoke all on function private.can_read_entity(boolean, text, uuid)
+  from public;
+grant execute on function private.can_read_entity(boolean, text, uuid)
+  to anon, authenticated;
+
+alter policy "entities_read_access"
+  on public.entities
+  using (private.can_read_entity(published, visibility, owner_member_id));
+
+alter policy "entities_insert_access"
+  on public.entities
+  with check (
+    private.is_admin()
+    or owner_member_id = private.current_member_id()
+  );
+
+alter policy "entities_update_access"
+  on public.entities
+  using (
+    private.is_admin()
+    or owner_member_id = private.current_member_id()
+  )
+  with check (
+    private.is_admin()
+    or owner_member_id = private.current_member_id()
+  );
+
+alter policy "entities_admin_delete"
+  on public.entities
+  using (private.is_admin());
+
+alter policy "entity_relations_read_access"
+  on public.entity_relations
+  using (
+    private.is_admin()
+    or (
+      exists (
+        select 1
+        from public.entities source_entity
+        where source_entity.id = from_entity_id
+          and private.can_read_entity(
+            source_entity.published,
+            source_entity.visibility,
+            source_entity.owner_member_id
+          )
+      )
+      and exists (
+        select 1
+        from public.entities target_entity
+        where target_entity.id = to_entity_id
+          and private.can_read_entity(
+            target_entity.published,
+            target_entity.visibility,
+            target_entity.owner_member_id
+          )
+      )
+    )
+    or exists (
+      select 1
+      from public.entities source_entity
+      where source_entity.id = from_entity_id
+        and source_entity.owner_member_id = private.current_member_id()
+    )
+    or exists (
+      select 1
+      from public.entities target_entity
+      where target_entity.id = to_entity_id
+        and target_entity.owner_member_id = private.current_member_id()
+    )
+  );
+
+alter policy "entity_relations_insert_access"
+  on public.entity_relations
+  with check (
+    private.is_admin()
+    or exists (
+      select 1
+      from public.entities source_entity
+      where source_entity.id = from_entity_id
+        and source_entity.owner_member_id = private.current_member_id()
+    )
+  );
+
+alter policy "entity_relations_update_access"
+  on public.entity_relations
+  using (
+    private.is_admin()
+    or exists (
+      select 1
+      from public.entities source_entity
+      where source_entity.id = from_entity_id
+        and source_entity.owner_member_id = private.current_member_id()
+    )
+  )
+  with check (
+    private.is_admin()
+    or exists (
+      select 1
+      from public.entities source_entity
+      where source_entity.id = from_entity_id
+        and source_entity.owner_member_id = private.current_member_id()
+    )
+  );
+
+alter policy "entity_relations_admin_delete"
+  on public.entity_relations
+  using (private.is_admin());
+
+insert into storage.buckets (
+  id,
+  name,
+  public,
+  file_size_limit,
+  allowed_mime_types
+)
+values (
+  'member-media',
+  'member-media',
+  false,
+  104857600,
+  array[
+    'image/jpeg',
+    'image/png',
+    'image/webp',
+    'image/gif',
+    'video/mp4',
+    'video/webm',
+    'video/quicktime'
+  ]::text[]
+)
+on conflict (id) do update
+set public = false,
+    file_size_limit = excluded.file_size_limit,
+    allowed_mime_types = excluded.allowed_mime_types;
+
+create or replace function private.can_read_member_media_object(object_name text)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, storage, auth, private
+as $$
+  select
+    private.is_admin()
+    or (storage.foldername(object_name))[1] = (select auth.uid()::text)
+    or exists (
+      select 1
+      from public.entities entity_ref
+      where entity_ref.data->>'storage_bucket' = 'member-media'
+        and entity_ref.data->>'storage_path' = object_name
+        and private.can_read_entity(
+          entity_ref.published,
+          entity_ref.visibility,
+          entity_ref.owner_member_id
+        )
+    );
+$$;
+
+revoke all on function private.can_read_member_media_object(text)
+  from public;
+grant execute on function private.can_read_member_media_object(text)
+  to anon, authenticated;
+
+create policy "storage_member_media_read"
+  on storage.objects for select
+  using (
+    bucket_id = 'member-media'
+    and private.can_read_member_media_object(name)
+  );
+
+create policy "storage_member_media_insert"
+  on storage.objects for insert
+  to authenticated
+  with check (
+    bucket_id = 'member-media'
+    and private.is_active_member()
+    and (storage.foldername(name))[1] = (select auth.uid()::text)
+    and (storage.foldername(name))[2] in ('photos', 'videos')
+    and lower(storage.extension(name)) in (
+      'jpg',
+      'jpeg',
+      'png',
+      'webp',
+      'gif',
+      'mp4',
+      'webm',
+      'mov'
+    )
+  );
+
+create policy "storage_member_media_update"
+  on storage.objects for update
+  to authenticated
+  using (
+    bucket_id = 'member-media'
+    and (
+      private.is_admin()
+      or (storage.foldername(name))[1] = (select auth.uid()::text)
+    )
+  )
+  with check (
+    bucket_id = 'member-media'
+    and (
+      private.is_admin()
+      or (storage.foldername(name))[1] = (select auth.uid()::text)
+    )
+    and (storage.foldername(name))[2] in ('photos', 'videos')
+    and lower(storage.extension(name)) in (
+      'jpg',
+      'jpeg',
+      'png',
+      'webp',
+      'gif',
+      'mp4',
+      'webm',
+      'mov'
+    )
+  );
+
+create policy "storage_member_media_delete"
+  on storage.objects for delete
+  to authenticated
+  using (
+    bucket_id = 'member-media'
+    and (
+      private.is_admin()
+      or (storage.foldername(name))[1] = (select auth.uid()::text)
+    )
+  );
+
+with visibility_field as (
+  select $json$
+    {
+      "key": "visibility",
+      "label": "공개 범위",
+      "type": "select",
+      "source": "column",
+      "required": true,
+      "options": [
+        { "label": "전체 공개", "value": "public" },
+        { "label": "멤버 공개", "value": "members" },
+        { "label": "비공개", "value": "private" }
+      ]
+    }
+  $json$::jsonb as field
+)
+update public.entity_schemas schema_ref
+set fields = jsonb_insert(
+    schema_ref.fields,
+    array[
+      coalesce(
+        (
+          select (field_ref.ordinality - 1)::int
+          from jsonb_array_elements(schema_ref.fields)
+            with ordinality as field_ref(field, ordinality)
+          where field_ref.field->>'key' = 'published'
+          limit 1
+        ),
+        greatest(jsonb_array_length(schema_ref.fields) - 1, 0)
+      )::text
+    ],
+    visibility_field.field,
+    true
+  ),
+  updated_at = now()
+from visibility_field
+where schema_ref.kind = 'entity'
+  and schema_ref.table_name = 'entities'
+  and not exists (
+    select 1
+    from jsonb_array_elements(schema_ref.fields) as field_ref(field)
+    where field_ref.field->>'key' = 'visibility'
+  );
+
+insert into public.entity_schemas (
+  schema_key,
+  kind,
+  version,
+  label,
+  description,
+  table_name,
+  renderer_key,
+  fields,
+  relation_slots,
+  active,
+  semantic_kind,
+  semantic_group
+)
+values
+  (
+    'photo/member-upload/v1',
+    'entity',
+    1,
+    'Member photo',
+    'A photo uploaded by an approved Bremen member.',
+    'entities',
+    null,
+    $json$[
+      {"key":"slug","label":"Slug","type":"text","source":"column"},
+      {"key":"title","label":"Title","type":"text","source":"column","required":true},
+      {"key":"subtitle","label":"Subtitle","type":"text","source":"column"},
+      {"key":"summary","label":"Caption","type":"textarea","source":"column"},
+      {"key":"thumbnail_url","label":"Thumbnail URL","type":"image","source":"column"},
+      {"key":"sort_at","label":"Sort date","type":"datetime","source":"column","required":true},
+      {"key":"published","label":"Approved","type":"boolean","source":"column","required":true},
+      {"key":"visibility","label":"공개 범위","type":"select","source":"column","required":true,"options":[{"label":"전체 공개","value":"public"},{"label":"멤버 공개","value":"members"},{"label":"비공개","value":"private"}]},
+      {"key":"category","label":"Category","type":"select","source":"data","options":[{"label":"Performance","value":"performance"},{"label":"Daily","value":"daily"}]},
+      {"key":"aspect","label":"Aspect","type":"select","source":"data","options":[{"label":"Portrait","value":"portrait"},{"label":"Landscape","value":"landscape"}]},
+      {"key":"gallery_include","label":"Show in gallery","type":"boolean","source":"data"},
+      {"key":"taken_at","label":"Taken at","type":"date","source":"data"},
+      {"key":"storage_bucket","label":"Storage bucket","type":"text","source":"data","readOnly":true},
+      {"key":"storage_path","label":"Storage path","type":"text","source":"data","readOnly":true},
+      {"key":"media_type","label":"Media type","type":"text","source":"data","readOnly":true},
+      {"key":"original_filename","label":"Original filename","type":"text","source":"data","readOnly":true}
+    ]$json$::jsonb,
+    '{}'::text[],
+    true,
+    'photo',
+    'ugc'
+  ),
+  (
+    'video/member-upload/v1',
+    'entity',
+    1,
+    'Member video',
+    'A video link or upload submitted by an approved Bremen member.',
+    'entities',
+    null,
+    $json$[
+      {"key":"slug","label":"Slug","type":"text","source":"column"},
+      {"key":"title","label":"Title","type":"text","source":"column","required":true},
+      {"key":"subtitle","label":"Subtitle","type":"text","source":"column"},
+      {"key":"summary","label":"Description","type":"textarea","source":"column"},
+      {"key":"thumbnail_url","label":"Thumbnail URL","type":"image","source":"column"},
+      {"key":"sort_at","label":"Sort date","type":"datetime","source":"column","required":true},
+      {"key":"published","label":"Approved","type":"boolean","source":"column","required":true},
+      {"key":"visibility","label":"공개 범위","type":"select","source":"column","required":true,"options":[{"label":"전체 공개","value":"public"},{"label":"멤버 공개","value":"members"},{"label":"비공개","value":"private"}]},
+      {"key":"video_url","label":"Video URL","type":"url","source":"data"},
+      {"key":"artist","label":"Artist","type":"text","source":"data"},
+      {"key":"song","label":"Song","type":"text","source":"data"},
+      {"key":"team","label":"Team","type":"text","source":"data"},
+      {"key":"event_slug","label":"Event slug","type":"text","source":"data"},
+      {"key":"event_title","label":"Event title","type":"text","source":"data"},
+      {"key":"duration","label":"Duration","type":"text","source":"data"},
+      {"key":"storage_bucket","label":"Storage bucket","type":"text","source":"data","readOnly":true},
+      {"key":"storage_path","label":"Storage path","type":"text","source":"data","readOnly":true},
+      {"key":"media_type","label":"Media type","type":"text","source":"data","readOnly":true},
+      {"key":"original_filename","label":"Original filename","type":"text","source":"data","readOnly":true}
+    ]$json$::jsonb,
+    '{}'::text[],
+    true,
+    'video',
+    'ugc'
+  )
+on conflict (schema_key) do update
+set label = excluded.label,
+    description = excluded.description,
+    table_name = excluded.table_name,
+    renderer_key = excluded.renderer_key,
+    fields = excluded.fields,
+    relation_slots = excluded.relation_slots,
+    active = excluded.active,
+    semantic_kind = excluded.semantic_kind,
+    semantic_group = excluded.semantic_group,
+    updated_at = now();

--- a/supabase/migrations/20260515132140_drop_ugc_visibility_unused_indexes.sql
+++ b/supabase/migrations/20260515132140_drop_ugc_visibility_unused_indexes.sql
@@ -1,0 +1,7 @@
+-- Bremen - remove eager UGC visibility indexes flagged unused by advisors.
+--
+-- The visibility column is still part of the access model. Add targeted
+-- indexes later once member UGC query paths exist and real plans show need.
+
+drop index if exists public.entities_visibility_published_sort_idx;
+drop index if exists public.entities_owner_visibility_idx;

--- a/supabase/migrations/20260515133159_harden_public_storage_buckets.sql
+++ b/supabase/migrations/20260515133159_harden_public_storage_buckets.sql
@@ -1,0 +1,87 @@
+-- Bremen - harden public Storage buckets without changing their public asset role.
+--
+-- `images`, `photos`, `posters`, and `avatars` intentionally serve public
+-- assets. Keep them public, but constrain uploads by MIME type, file size, and
+-- object extension so public buckets cannot become arbitrary file stores.
+
+update storage.buckets
+set file_size_limit = case id
+    when 'avatars' then 5242880
+    else 20971520
+  end,
+  allowed_mime_types = array[
+    'image/jpeg',
+    'image/png',
+    'image/webp',
+    'image/gif'
+  ]::text[]
+where id in ('avatars', 'images', 'photos', 'posters');
+
+alter policy "storage_avatars_self_insert"
+  on storage.objects
+  to authenticated
+  with check (
+    bucket_id = 'avatars'
+    and (storage.foldername(name))[1] = (select auth.uid()::text)
+    and lower(storage.extension(name)) in ('jpg', 'jpeg', 'png', 'webp', 'gif')
+  );
+
+alter policy "storage_avatars_self_update"
+  on storage.objects
+  to authenticated
+  using (
+    bucket_id = 'avatars'
+    and (storage.foldername(name))[1] = (select auth.uid()::text)
+  )
+  with check (
+    bucket_id = 'avatars'
+    and (storage.foldername(name))[1] = (select auth.uid()::text)
+    and lower(storage.extension(name)) in ('jpg', 'jpeg', 'png', 'webp', 'gif')
+  );
+
+alter policy "storage_avatars_self_delete"
+  on storage.objects
+  to authenticated
+  using (
+    bucket_id = 'avatars'
+    and (storage.foldername(name))[1] = (select auth.uid()::text)
+  );
+
+alter policy "storage_admin_avatars"
+  on storage.objects
+  to authenticated
+  using (
+    bucket_id = 'avatars'
+    and private.is_admin()
+  )
+  with check (
+    bucket_id = 'avatars'
+    and private.is_admin()
+    and lower(storage.extension(name)) in ('jpg', 'jpeg', 'png', 'webp', 'gif')
+  );
+
+alter policy "storage_admin_images"
+  on storage.objects
+  to authenticated
+  using (
+    bucket_id = 'images'
+    and private.is_admin()
+  )
+  with check (
+    bucket_id = 'images'
+    and private.is_admin()
+    and lower(storage.extension(name)) in ('jpg', 'jpeg', 'png', 'webp', 'gif')
+  );
+
+alter policy "storage_admin_photos_posters"
+  on storage.objects
+  to authenticated
+  using (
+    bucket_id in ('photos', 'posters')
+    and private.is_admin()
+  )
+  with check (
+    bucket_id in ('photos', 'posters')
+    and private.is_admin()
+    and lower(storage.extension(name)) in ('jpg', 'jpeg', 'png', 'webp', 'gif')
+  );


### PR DESCRIPTION
## Summary
- Adds entity-level visibility for CMS-managed entities and exposes visibility in PONIX entity lists/details/forms.
- Registers member photo/video upload schemas as entity-backed UGC schemas.
- Adds private member-media Storage policies and hardens public image buckets with MIME, extension, role, and size limits.

## Verification
- pnpm run qa:cms-schema-registry -- --strict
- pnpm run qa:content-graph
- pnpm run qa:cms-db-first-loaders
- pnpm run qa:cms-native-controls
- pnpm run qa:schema-semantic-identity
- pnpm run qa:cms-legacy-bridge-boundary
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm run build
- Supabase MCP bucket/policy/advisor checks
- cmux smoke: /ponix/entities and member photo creation form

## Notes
- Applied migrations to Supabase: 20260515132021, 20260515132140, 20260515133159.
- Supabase security advisor still reports existing leaked password protection warning only.

Closes #182