### PR TITLE
Allow gallery photo uploads to publish

### DIFF
--- a/docs/supabase-setup.md
+++ b/docs/supabase-setup.md
@@ -209,7 +209,11 @@ upload, then call a server action to create the entity row. Do not proxy direct
 photo/video file bodies through a Server Action unless the file size is known to
 stay below the configured body limit. Photos submitted from `/photos` are
 published immediately for active approved members; moderation happens afterward
-through the entity's `published` and `visibility` fields.
+through the entity's `published` and `visibility` fields. The
+`capture_owned_content()` trigger allows that immediate publish path only for
+`photo/member-upload/v1` inserts with `visibility = 'public'` and
+`gallery_include = true`; other member-owned entities still cannot be
+self-published.
 
 Public Storage buckets still exist for assets that are meant to be public:
 

--- a/supabase/migrations/20260516084833_allow_member_photo_upload_publication.sql
+++ b/supabase/migrations/20260516084833_allow_member_photo_upload_publication.sql
@@ -1,0 +1,46 @@
+-- Bremen - allow approved member photo uploads to publish from the gallery.
+--
+-- The owned-content trigger protects generic member-owned entities from being
+-- self-published. Photo tab uploads are the intentionally approved exception:
+-- active members may create public photo/member-upload/v1 gallery items.
+
+create or replace function public.capture_owned_content()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, auth, private
+as $$
+declare
+  schema_key text;
+  is_public_member_photo boolean;
+begin
+  if (select auth.uid()) is not null and not private.is_admin() then
+    if tg_op = 'INSERT' then
+      select entity_schemas.schema_key
+        into schema_key
+      from public.entity_schemas
+      where entity_schemas.id = new.schema_id;
+
+      is_public_member_photo :=
+        schema_key = 'photo/member-upload/v1'
+        and private.is_active_member()
+        and new.visibility = 'public'
+        and new.data->>'gallery_include' = 'true';
+
+      new.owner_member_id = coalesce(new.owner_member_id, private.current_member_id());
+      new.published = is_public_member_photo;
+    else
+      new.owner_member_id = old.owner_member_id;
+
+      if old.published = false and new.published = true then
+        new.published = false;
+      end if;
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+revoke execute on function public.capture_owned_content()
+  from anon, authenticated, public;


### PR DESCRIPTION
## Summary
- Update the owned-content trigger so active approved members can publish only public photo/member-upload/v1 gallery inserts.
- Keep generic member-owned entities protected from self-publication.
- Document the trigger-level exception for /photos uploads.

## Production migration
- Applied via Supabase MCP after maintainer approval.
- Migration version: 20260516084833_allow_member_photo_upload_publication

## Verification
- stop-list grep on migration
- pnpm run qa:cms-schema-registry -- --strict
- pnpm run qa:schema-semantic-identity
- Supabase pg_get_functiondef verification
- Supabase performance advisors clean
- Supabase security advisor only existing leaked-password warning

## Not tested
- Real production photo upload E2E, because it creates a production Storage object and entity row.

Closes #189