### PR TITLE
Polish member guestbook operations UX

### DIFF
--- a/app/(site)/members/[id]/actions.ts
+++ b/app/(site)/members/[id]/actions.ts
@@ -75,6 +75,7 @@ export async function createGuestbookEntryAction(formData: FormData) {
   }
 
   revalidatePath(`/members/${memberId}`)
+  revalidatePath("/ponix/guestbook")
   redirect(
     memberPath(memberId, {
       guestbook_message: "방명록에 남겼습니다.",
@@ -111,6 +112,7 @@ export async function deleteGuestbookEntryAction(formData: FormData) {
   }
 
   revalidatePath(`/members/${memberId}`)
+  revalidatePath("/ponix/guestbook")
   redirect(
     memberPath(memberId, {
       guestbook_message: "방명록 글을 지웠습니다.",

--- a/components/member-guestbook-controls.tsx
+++ b/components/member-guestbook-controls.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+import { useId, useState } from "react"
+import { Trash2 } from "lucide-react"
+
+import {
+  createGuestbookEntryAction,
+  deleteGuestbookEntryAction,
+} from "@/app/(site)/members/[id]/actions"
+import { FormSubmitButton } from "@/components/form-submit-button"
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import { cn } from "@/lib/utils"
+
+const GUESTBOOK_BODY_LIMIT = 500
+
+export function MemberGuestbookComposer({
+  profileMemberId,
+}: {
+  profileMemberId: string
+}) {
+  const [body, setBody] = useState("")
+  const textareaId = useId()
+  const length = body.length
+  const remaining = GUESTBOOK_BODY_LIMIT - length
+  const canSubmit = body.trim().length > 0
+
+  return (
+    <form
+      action={createGuestbookEntryAction}
+      className="rounded-md border bg-muted/25 p-4"
+    >
+      <input type="hidden" name="member_id" value={profileMemberId} />
+      <Textarea
+        id={textareaId}
+        name="body"
+        value={body}
+        maxLength={GUESTBOOK_BODY_LIMIT}
+        required
+        rows={4}
+        placeholder="함께 남기고 싶은 짧은 안부를 적어주세요."
+        className="resize-none bg-background/80"
+        aria-describedby={`${textareaId}-hint ${textareaId}-count`}
+        onChange={(event) => setBody(event.target.value)}
+      />
+      <div className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-1">
+          <p
+            id={`${textareaId}-hint`}
+            className="text-xs leading-relaxed text-muted-foreground"
+          >
+            멤버에게 보이는 공간입니다. 짧고 편하게 남겨주세요.
+          </p>
+          <p
+            id={`${textareaId}-count`}
+            className={cn(
+              "text-xs text-muted-foreground",
+              remaining <= 40 && "text-foreground",
+            )}
+            aria-live="polite"
+          >
+            {length}/{GUESTBOOK_BODY_LIMIT}
+          </p>
+        </div>
+        <FormSubmitButton
+          className="rounded-full"
+          pendingLabel="남기는 중..."
+          disabled={!canSubmit}
+        >
+          Leave a note
+        </FormSubmitButton>
+      </div>
+    </form>
+  )
+}
+
+export function DeleteGuestbookEntryDialog({
+  profileMemberId,
+  entryId,
+  entryBody,
+  authorName,
+}: {
+  profileMemberId: string
+  entryId: string
+  entryBody: string
+  authorName: string
+}) {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button
+          type="button"
+          size="icon"
+          variant="ghost"
+          className="size-8 rounded-full text-muted-foreground hover:text-destructive"
+          aria-label="방명록 글 삭제"
+        >
+          <Trash2 className="size-4" />
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>이 방명록 글을 삭제할까요?</AlertDialogTitle>
+          <AlertDialogDescription>
+            삭제하면 멤버 프로필과 관리자 방명록 목록에서 바로 사라집니다.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <div className="space-y-2 rounded-xl border bg-muted/30 p-4">
+          <p className="text-xs font-medium text-muted-foreground">
+            {authorName}
+          </p>
+          <p className="max-h-44 overflow-y-auto whitespace-pre-wrap text-sm leading-relaxed text-muted-foreground">
+            {entryBody}
+          </p>
+        </div>
+        <AlertDialogFooter>
+          <AlertDialogCancel>취소</AlertDialogCancel>
+          <form action={deleteGuestbookEntryAction}>
+            <input type="hidden" name="member_id" value={profileMemberId} />
+            <input type="hidden" name="entry_id" value={entryId} />
+            <FormSubmitButton
+              variant="destructive"
+              pendingLabel="삭제 중..."
+              className="w-full sm:w-auto"
+            >
+              삭제
+            </FormSubmitButton>
+          </form>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/components/member-guestbook.tsx
+++ b/components/member-guestbook.tsx
@@ -1,11 +1,10 @@
-import { MessageCircle, Trash2 } from "lucide-react"
+import { MessageCircle } from "lucide-react"
 
 import {
-  createGuestbookEntryAction,
-  deleteGuestbookEntryAction,
-} from "@/app/(site)/members/[id]/actions"
-import { FormSubmitButton } from "@/components/form-submit-button"
-import { Alert, AlertDescription } from "@/components/ui/alert"
+  DeleteGuestbookEntryDialog,
+  MemberGuestbookComposer,
+} from "@/components/member-guestbook-controls"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Badge } from "@/components/ui/badge"
 import {
   Card,
@@ -14,7 +13,6 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
-import { Textarea } from "@/components/ui/textarea"
 import type {
   GuestbookViewer,
   MemberGuestbookEntry,
@@ -57,6 +55,9 @@ export function MemberGuestbook({
 }: MemberGuestbookProps) {
   const canWrite = Boolean(viewer?.approved_at)
   const isAdmin = viewer?.role === "admin"
+  const guestbookGateCopy = viewer
+    ? "멤버 확인이 끝나면 방명록을 남길 수 있습니다."
+    : "멤버 프로필 연결이 끝나면 방명록을 남길 수 있습니다."
 
   return (
     <Card className="gap-0 overflow-hidden rounded-md border bg-card/95 py-0 shadow-xl">
@@ -83,33 +84,18 @@ export function MemberGuestbook({
             variant={error ? "destructive" : "default"}
             className={cn(!error && "bg-muted/40")}
           >
+            <AlertTitle>
+              {error ? "처리하지 못했습니다" : "방명록이 업데이트되었습니다"}
+            </AlertTitle>
             <AlertDescription>{error ?? message}</AlertDescription>
           </Alert>
         )}
 
         {canWrite ? (
-          <form action={createGuestbookEntryAction} className="rounded-md border bg-muted/25 p-4">
-            <input type="hidden" name="member_id" value={profileMemberId} />
-            <Textarea
-              name="body"
-              maxLength={500}
-              required
-              rows={4}
-              placeholder="함께 남기고 싶은 짧은 안부를 적어주세요."
-              className="resize-none bg-background/80"
-            />
-            <div className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-              <p className="text-xs leading-relaxed text-muted-foreground">
-                멤버에게 보이는 공간입니다. 500자 안에서 남길 수 있습니다.
-              </p>
-              <FormSubmitButton className="rounded-full" pendingLabel="남기는 중...">
-                Leave a note
-              </FormSubmitButton>
-            </div>
-          </form>
+          <MemberGuestbookComposer profileMemberId={profileMemberId} />
         ) : (
           <div className="rounded-md border border-dashed bg-muted/25 px-4 py-5 text-sm text-muted-foreground">
-            멤버 확인이 끝난 뒤 방명록을 남길 수 있습니다.
+            {guestbookGateCopy}
           </div>
         )}
 
@@ -118,6 +104,9 @@ export function MemberGuestbook({
             {entries.map((entry) => {
               const canDelete =
                 isAdmin || Boolean(viewer && viewer.id === entry.author_member_id)
+              const isOwnEntry = Boolean(
+                viewer && viewer.id === entry.author_member_id,
+              )
 
               return (
                 <li
@@ -126,28 +115,27 @@ export function MemberGuestbook({
                 >
                   <div className="flex items-start justify-between gap-4">
                     <div className="min-w-0">
-                      <p className="font-serif-kr text-lg leading-tight">
-                        {entry.author?.name ?? "브레멘 멤버"}
-                      </p>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <p className="font-serif-kr text-lg leading-tight">
+                          {entry.author?.name ?? "브레멘 멤버"}
+                        </p>
+                        {isOwnEntry && (
+                          <Badge variant="secondary" className="rounded-full">
+                            내가 남긴 글
+                          </Badge>
+                        )}
+                      </div>
                       <p className="mt-1 text-xs text-muted-foreground">
                         {authorLine(entry)} · {formatEntryDate(entry.created_at)}
                       </p>
                     </div>
                     {canDelete && (
-                      <form action={deleteGuestbookEntryAction}>
-                        <input type="hidden" name="member_id" value={profileMemberId} />
-                        <input type="hidden" name="entry_id" value={entry.id} />
-                        <FormSubmitButton
-                          type="submit"
-                          size="icon"
-                          variant="ghost"
-                          className="size-8 rounded-full text-muted-foreground hover:text-destructive"
-                          pendingLabel=""
-                          aria-label="방명록 글 삭제"
-                        >
-                          <Trash2 className="size-4" />
-                        </FormSubmitButton>
-                      </form>
+                      <DeleteGuestbookEntryDialog
+                        profileMemberId={profileMemberId}
+                        entryId={entry.id}
+                        entryBody={entry.body}
+                        authorName={entry.author?.name ?? "브레멘 멤버"}
+                      />
                     )}
                   </div>
                   <p className="mt-4 whitespace-pre-wrap text-sm leading-relaxed text-muted-foreground">


### PR DESCRIPTION
Closes #194

## Summary
- Adds a focused client composer for member guestbook writing with live character count and disabled empty submit state.
- Replaces one-click member-page guestbook deletion with a shadcn AlertDialog confirmation.
- Revalidates both the member profile route and /ponix/guestbook after public guestbook create/delete actions.

## Verification
- pnpm exec tsc --noEmit
- pnpm run lint
- git diff --check
- pnpm run build
- local next start curl smoke for /members, /members/[id], /photos, and /ponix/guestbook auth redirect

## Not tested
- Authenticated guestbook mutation in browser was not run to avoid creating live guestbook data without a reversible test user flow.