### PR TITLE
Add member video submission flow

### DIFF
--- a/app/(site)/videos/actions.ts
+++ b/app/(site)/videos/actions.ts
@@ -1,0 +1,298 @@
+"use server"
+
+import { revalidatePath, updateTag } from "next/cache"
+
+import {
+  MEMBER_MEDIA_BUCKET,
+  MEMBER_VIDEO_SCHEMA_KEY,
+} from "@/lib/data/member-media"
+import { PUBLIC_CONTENT_CACHE_TAG } from "@/lib/data/public-cache"
+import { createClient } from "@/lib/supabase/server"
+import type { Database, Json } from "@/lib/supabase/types"
+
+type EntityInsert = Database["public"]["Tables"]["entities"]["Insert"]
+
+type VideoVisibility = "public" | "members" | "private"
+
+type CreateMemberVideoSubmissionInput = {
+  title: string
+  description: string
+  artist?: string
+  song?: string
+  team?: string
+  eventTitle?: string
+  duration?: string
+  visibility: string
+  videoUrl?: string
+  storagePath?: string
+  mediaType?: string
+  originalFilename?: string
+  fileSize?: number
+}
+
+type CreateMemberVideoSubmissionResult =
+  | {
+      ok: true
+      entityId: string
+      published: boolean
+      visibility: VideoVisibility
+    }
+  | {
+      ok: false
+      error: string
+    }
+
+const videoMimeTypes = new Set([
+  "video/mp4",
+  "video/webm",
+  "video/quicktime",
+])
+const videoExtensions = new Set(["mp4", "webm", "mov"])
+const visibilityValues = new Set<VideoVisibility>(["public", "members", "private"])
+
+function cleanText(value: string | undefined, maxLength: number) {
+  return (value ?? "").trim().replace(/\s+/g, " ").slice(0, maxLength)
+}
+
+function cleanLongText(value: string | undefined, maxLength: number) {
+  return (value ?? "").trim().slice(0, maxLength)
+}
+
+function slugPart(value: string) {
+  return value
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[^\w\s-]/g, "")
+    .trim()
+    .replace(/[\s_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48)
+}
+
+function extensionFromPath(path: string) {
+  return path.split(".").pop()?.toLowerCase() ?? ""
+}
+
+function validVideoPath(path: string, authUserId: string) {
+  const prefix = `${authUserId}/videos/`
+  if (!path.startsWith(prefix)) return false
+
+  const filename = path.slice(prefix.length)
+  if (!filename || filename.includes("/")) return false
+  if (!/^[a-zA-Z0-9._-]+$/.test(filename)) return false
+
+  return videoExtensions.has(extensionFromPath(path))
+}
+
+function validVisibility(value: string): VideoVisibility {
+  return visibilityValues.has(value as VideoVisibility)
+    ? (value as VideoVisibility)
+    : "private"
+}
+
+function validateVideoFile(input: CreateMemberVideoSubmissionInput) {
+  if (!input.storagePath) return null
+
+  if (!input.mediaType || !videoMimeTypes.has(input.mediaType)) {
+    return "mp4, webm, mov 영상만 올릴 수 있습니다."
+  }
+
+  if (!Number.isFinite(input.fileSize) || Number(input.fileSize) > 100 * 1024 * 1024) {
+    return "영상은 100MB 이하로 올려 주세요."
+  }
+
+  return null
+}
+
+function parseHttpUrl(value: string | undefined) {
+  const trimmed = (value ?? "").trim()
+  if (!trimmed) return null
+
+  try {
+    const url = new URL(trimmed)
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null
+    return url
+  } catch {
+    return null
+  }
+}
+
+function youtubeIdFromUrl(url: URL | null) {
+  if (!url) return null
+
+  const host = url.hostname.replace(/^www\./, "")
+  if (host === "youtu.be") {
+    return url.pathname.split("/").filter(Boolean)[0] ?? null
+  }
+
+  if (host === "youtube.com" || host === "m.youtube.com") {
+    if (url.pathname === "/watch") return url.searchParams.get("v")
+    const parts = url.pathname.split("/").filter(Boolean)
+    if (parts[0] === "shorts" || parts[0] === "embed") return parts[1] ?? null
+  }
+
+  return null
+}
+
+function youtubeThumbnailUrl(youtubeId: string | null) {
+  return youtubeId ? `https://i.ytimg.com/vi/${youtubeId}/hqdefault.jpg` : null
+}
+
+function jsonData(data: Record<string, Json>): Json {
+  return data
+}
+
+export async function createMemberVideoSubmissionAction(
+  input: CreateMemberVideoSubmissionInput,
+): Promise<CreateMemberVideoSubmissionResult> {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return { ok: false, error: "로그인 후 다시 시도해 주세요." }
+  }
+
+  const title = cleanText(input.title, 120)
+  const description = cleanLongText(input.description, 1000)
+  const visibility = validVisibility(input.visibility)
+  const url = parseHttpUrl(input.videoUrl)
+  const hasFile = Boolean(input.storagePath)
+  const hasUrl = Boolean(url)
+
+  if (!title) return { ok: false, error: "제목을 적어 주세요." }
+  if (!hasFile && !hasUrl) {
+    return { ok: false, error: "영상 파일을 선택하거나 영상 링크를 입력해 주세요." }
+  }
+  if (hasFile && hasUrl) {
+    return { ok: false, error: "파일 업로드와 링크 제출 중 하나만 선택해 주세요." }
+  }
+
+  const videoError = validateVideoFile(input)
+  if (videoError) return { ok: false, error: videoError }
+
+  if (input.storagePath && !validVideoPath(input.storagePath, user.id)) {
+    return { ok: false, error: "업로드 경로를 확인하지 못했습니다." }
+  }
+
+  const { data: member, error: memberError } = await supabase
+    .from("members")
+    .select("id, name, student_year, status, approved_at")
+    .eq("auth_user_id", user.id)
+    .maybeSingle()
+
+  if (memberError || !member) {
+    return { ok: false, error: "연결된 멤버 프로필을 찾지 못했습니다." }
+  }
+
+  if (!member.approved_at) {
+    return { ok: false, error: "멤버 확인이 끝난 뒤 영상을 제출할 수 있습니다." }
+  }
+
+  if (member.status !== "active") {
+    return { ok: false, error: "활동 상태 멤버만 영상을 제출할 수 있습니다." }
+  }
+
+  if (input.storagePath) {
+    const { error: storageError } = await supabase.storage
+      .from(MEMBER_MEDIA_BUCKET)
+      .createSignedUrl(input.storagePath, 60)
+
+    if (storageError) {
+      return { ok: false, error: "업로드된 파일을 확인하지 못했습니다." }
+    }
+  }
+
+  const { data: schema, error: schemaError } = await supabase
+    .from("entity_schemas")
+    .select("id")
+    .eq("schema_key", MEMBER_VIDEO_SCHEMA_KEY)
+    .eq("active", true)
+    .maybeSingle()
+
+  if (schemaError || !schema) {
+    return { ok: false, error: "영상 제출 형식이 아직 준비되지 않았습니다." }
+  }
+
+  const now = new Date().toISOString()
+  const baseSlug = slugPart(title) || `video-${Date.now().toString(36)}`
+  const youtubeId = youtubeIdFromUrl(url)
+  const canonicalYoutubeUrl = youtubeId
+    ? `https://www.youtube.com/watch?v=${youtubeId}`
+    : null
+  const data: Record<string, Json> = {
+    submitted_by_member_id: member.id,
+    submitted_at: now,
+    source: "member_upload",
+    submission_kind: input.storagePath ? "file" : "url",
+    visibility_request: visibility,
+  }
+
+  if (description) data.description = description
+  if (input.storagePath) {
+    data.storage_bucket = MEMBER_MEDIA_BUCKET
+    data.storage_path = input.storagePath
+    data.media_type = input.mediaType ?? ""
+    data.original_filename = (input.originalFilename ?? "").slice(0, 180)
+    data.file_size = input.fileSize ?? 0
+  }
+  if (url) {
+    data.video_url = canonicalYoutubeUrl ?? url.toString()
+  }
+  if (youtubeId) {
+    data.youtube_id = youtubeId
+    data.youtube_url = canonicalYoutubeUrl ?? url?.toString() ?? ""
+  }
+
+  const artist = cleanText(input.artist, 120)
+  const song = cleanText(input.song, 160)
+  const team = cleanText(input.team, 120)
+  const eventTitle = cleanText(input.eventTitle, 140)
+  const duration = cleanText(input.duration, 32)
+
+  if (artist) data.artist = artist
+  if (song) data.song = song
+  if (team) data.team = team
+  if (eventTitle) data.event_title = eventTitle
+  if (duration) data.duration = duration
+
+  const insert: EntityInsert = {
+    schema_id: schema.id,
+    slug: `member-video-${member.student_year}-${baseSlug}-${crypto.randomUUID().slice(0, 8)}`,
+    title,
+    subtitle: `${member.student_year}학번 · ${member.name}`,
+    summary: description || null,
+    thumbnail_url: youtubeThumbnailUrl(youtubeId),
+    owner_member_id: member.id,
+    published: false,
+    visibility,
+    sort_at: now,
+    data: jsonData(data),
+  }
+
+  const { data: entity, error: entityError } = await supabase
+    .from("entities")
+    .insert(insert)
+    .select("id, published, visibility")
+    .single()
+
+  if (entityError || !entity) {
+    if (input.storagePath) {
+      await supabase.storage.from(MEMBER_MEDIA_BUCKET).remove([input.storagePath])
+    }
+    return { ok: false, error: "영상 기록을 저장하지 못했습니다." }
+  }
+
+  revalidatePath("/videos")
+  revalidatePath("/ponix/entities")
+  revalidatePath(`/ponix/entities/${entity.id}`)
+  updateTag(PUBLIC_CONTENT_CACHE_TAG)
+
+  return {
+    ok: true,
+    entityId: entity.id,
+    published: entity.published,
+    visibility: entity.visibility as VideoVisibility,
+  }
+}

--- a/components/member-video-submit-dialog.tsx
+++ b/components/member-video-submit-dialog.tsx
@@ -1,0 +1,612 @@
+"use client"
+
+import { FilmSlate, LinkSimple, UploadSimple, X } from "@phosphor-icons/react"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import {
+  useEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type FormEvent,
+} from "react"
+
+import { createMemberVideoSubmissionAction } from "@/app/(site)/videos/actions"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Progress } from "@/components/ui/progress"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Textarea } from "@/components/ui/textarea"
+import { MEMBER_MEDIA_BUCKET } from "@/lib/data/member-media"
+import { createClient } from "@/lib/supabase/client"
+
+type AccessState =
+  | {
+      state: "idle" | "loading"
+    }
+  | {
+      state: "anonymous"
+    }
+  | {
+      state: "blocked"
+      message: string
+    }
+  | {
+      state: "ready"
+      authUserId: string
+      memberLabel: string
+    }
+
+type SubmitState =
+  | {
+      kind: "idle"
+    }
+  | {
+      kind: "uploading"
+      label: string
+    }
+  | {
+      kind: "success"
+      message: string
+    }
+  | {
+      kind: "error"
+      message: string
+    }
+
+const videoMimeTypes = new Set([
+  "video/mp4",
+  "video/webm",
+  "video/quicktime",
+])
+const videoExtensions = new Set(["mp4", "webm", "mov"])
+
+function extensionFromFile(file: File) {
+  const extension = file.name.split(".").pop()?.toLowerCase()
+
+  if (extension && videoExtensions.has(extension)) return extension
+  if (file.type === "video/mp4") return "mp4"
+  if (file.type === "video/webm") return "webm"
+  if (file.type === "video/quicktime") return "mov"
+  return "mp4"
+}
+
+function titleFromFilename(filename: string) {
+  return filename.replace(/\.[^.]+$/, "").replace(/[-_]+/g, " ").trim()
+}
+
+function formatBytes(value: number) {
+  if (value >= 1024 * 1024) return `${(value / 1024 / 1024).toFixed(1)} MB`
+  if (value >= 1024) return `${Math.round(value / 1024)} KB`
+  return `${value} B`
+}
+
+function validateVideoFile(file: File) {
+  if (!videoMimeTypes.has(file.type)) {
+    return "mp4, webm, mov 영상만 올릴 수 있습니다."
+  }
+
+  if (file.size > 100 * 1024 * 1024) {
+    return "영상은 100MB 이하로 올려 주세요."
+  }
+
+  return null
+}
+
+function isHttpUrl(value: string) {
+  try {
+    const url = new URL(value)
+    return url.protocol === "http:" || url.protocol === "https:"
+  } catch {
+    return false
+  }
+}
+
+export function MemberVideoSubmitDialog() {
+  const router = useRouter()
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [open, setOpen] = useState(false)
+  const [access, setAccess] = useState<AccessState>({ state: "idle" })
+  const [sourceMode, setSourceMode] = useState<"url" | "file">("url")
+  const [visibility, setVisibility] = useState("public")
+  const [title, setTitle] = useState("")
+  const [description, setDescription] = useState("")
+  const [artist, setArtist] = useState("")
+  const [song, setSong] = useState("")
+  const [team, setTeam] = useState("")
+  const [eventTitle, setEventTitle] = useState("")
+  const [duration, setDuration] = useState("")
+  const [videoUrl, setVideoUrl] = useState("")
+  const [file, setFile] = useState<File | null>(null)
+  const [submitState, setSubmitState] = useState<SubmitState>({ kind: "idle" })
+
+  const isUploading = submitState.kind === "uploading"
+  const formDisabled = isUploading || access.state !== "ready"
+
+  useEffect(() => {
+    if (!open) return
+
+    let cancelled = false
+
+    async function resolveAccess() {
+      setAccess({ state: "loading" })
+      const supabase = createClient()
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
+
+      if (cancelled) return
+      if (!user) {
+        setAccess({ state: "anonymous" })
+        return
+      }
+
+      const { data: member, error } = await supabase
+        .from("members")
+        .select("name, student_year, status, approved_at")
+        .eq("auth_user_id", user.id)
+        .maybeSingle()
+
+      if (cancelled) return
+
+      if (error || !member) {
+        setAccess({
+          state: "blocked",
+          message: "가입 정보와 연결된 멤버 프로필을 찾지 못했습니다.",
+        })
+        return
+      }
+
+      if (!member.approved_at) {
+        setAccess({
+          state: "blocked",
+          message: "멤버 확인이 끝난 뒤 영상을 제출할 수 있습니다.",
+        })
+        return
+      }
+
+      if (member.status !== "active") {
+        setAccess({
+          state: "blocked",
+          message: "활동 상태 멤버만 영상을 제출할 수 있습니다.",
+        })
+        return
+      }
+
+      setAccess({
+        state: "ready",
+        authUserId: user.id,
+        memberLabel: `${member.student_year}학번 · ${member.name}`,
+      })
+    }
+
+    resolveAccess()
+
+    return () => {
+      cancelled = true
+    }
+  }, [open])
+
+  function resetForm() {
+    setSourceMode("url")
+    setVisibility("public")
+    setTitle("")
+    setDescription("")
+    setArtist("")
+    setSong("")
+    setTeam("")
+    setEventTitle("")
+    setDuration("")
+    setVideoUrl("")
+    setFile(null)
+    setSubmitState({ kind: "idle" })
+    if (fileInputRef.current) fileInputRef.current.value = ""
+  }
+
+  function handleOpenChange(nextOpen: boolean) {
+    setOpen(nextOpen)
+    if (!nextOpen) {
+      resetForm()
+      setAccess({ state: "idle" })
+    }
+  }
+
+  function handleFileChange(event: ChangeEvent<HTMLInputElement>) {
+    const nextFile = event.currentTarget.files?.[0] ?? null
+    setFile(nextFile)
+
+    if (nextFile && !title.trim()) {
+      setTitle(titleFromFilename(nextFile.name))
+    }
+  }
+
+  function clearFile() {
+    setFile(null)
+    if (fileInputRef.current) fileInputRef.current.value = ""
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+
+    if (access.state !== "ready") {
+      setSubmitState({
+        kind: "error",
+        message: "영상을 제출할 수 있는 멤버 계정으로 로그인해 주세요.",
+      })
+      return
+    }
+
+    const cleanTitle = title.trim()
+    if (!cleanTitle) {
+      setSubmitState({ kind: "error", message: "제목을 적어 주세요." })
+      return
+    }
+
+    let storagePath: string | undefined
+    const supabase = createClient()
+
+    if (sourceMode === "url") {
+      if (!videoUrl.trim() || !isHttpUrl(videoUrl.trim())) {
+        setSubmitState({
+          kind: "error",
+          message: "공유 가능한 영상 링크를 입력해 주세요.",
+        })
+        return
+      }
+    } else {
+      if (!file) {
+        setSubmitState({ kind: "error", message: "올릴 영상 파일을 선택해 주세요." })
+        return
+      }
+
+      const fileError = validateVideoFile(file)
+      if (fileError) {
+        setSubmitState({ kind: "error", message: fileError })
+        return
+      }
+
+      const extension = extensionFromFile(file)
+      storagePath = `${access.authUserId}/videos/${crypto.randomUUID()}.${extension}`
+
+      setSubmitState({ kind: "uploading", label: "영상 파일을 올리는 중..." })
+
+      const { error: uploadError } = await supabase.storage
+        .from(MEMBER_MEDIA_BUCKET)
+        .upload(storagePath, file, {
+          cacheControl: "3600",
+          contentType: file.type,
+          upsert: false,
+        })
+
+      if (uploadError) {
+        setSubmitState({
+          kind: "error",
+          message:
+            uploadError.message ||
+            "영상 파일을 올리지 못했습니다. 잠시 뒤 다시 시도해 주세요.",
+        })
+        return
+      }
+    }
+
+    setSubmitState({ kind: "uploading", label: "영상 기록을 저장하는 중..." })
+
+    const result = await createMemberVideoSubmissionAction({
+      title: cleanTitle,
+      description,
+      artist,
+      song,
+      team,
+      eventTitle,
+      duration,
+      visibility,
+      videoUrl: sourceMode === "url" ? videoUrl : undefined,
+      storagePath,
+      mediaType: sourceMode === "file" ? file?.type : undefined,
+      originalFilename: sourceMode === "file" ? file?.name : undefined,
+      fileSize: sourceMode === "file" ? file?.size : undefined,
+    })
+
+    if (!result.ok) {
+      if (storagePath) {
+        await supabase.storage.from(MEMBER_MEDIA_BUCKET).remove([storagePath])
+      }
+      setSubmitState({ kind: "error", message: result.error })
+      return
+    }
+
+    resetForm()
+    setSubmitState({
+      kind: "success",
+      message: result.published
+        ? "영상이 아카이브에 반영되었습니다."
+        : "영상이 제출되었습니다. 확인이 끝나면 선택한 공개 범위로 보입니다.",
+    })
+    router.refresh()
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button size="lg" variant="outline" className="rounded-full px-6">
+          <FilmSlate weight="light" className="size-4" />
+          영상 제출
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-h-[min(92vh,54rem)] max-w-4xl overflow-y-auto p-0">
+        <div className="grid md:grid-cols-[0.85fr_1.15fr]">
+          <div className="border-b bg-muted/50 p-6 md:border-b-0 md:border-r md:p-8">
+            <DialogHeader>
+              <p className="caps text-muted-foreground">Video Submission</p>
+              <DialogTitle className="font-serif italic text-4xl">
+                Add a recording
+              </DialogTitle>
+              <DialogDescription className="text-base leading-relaxed">
+                브레멘의 영상 기록을 아카이브에 남깁니다.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="mt-8 rounded-md border bg-background/70 p-4 text-sm leading-relaxed text-muted-foreground">
+              {access.state === "loading" && "멤버 정보를 확인하는 중입니다."}
+              {access.state === "anonymous" && (
+                <>
+                  로그인한 활동 멤버만 영상을 제출할 수 있습니다.
+                  <Button asChild className="mt-4 w-full" variant="outline">
+                    <Link href="/login?next=/videos">Sign In</Link>
+                  </Button>
+                </>
+              )}
+              {access.state === "blocked" && access.message}
+              {access.state === "ready" && (
+                <>
+                  <span className="caps mb-2 block text-foreground">
+                    {access.memberLabel}
+                  </span>
+                  제출한 영상은 바로 공개되지 않습니다. 확인이 끝나면 선택한 공개
+                  범위에 맞춰 아카이브에 반영됩니다.
+                </>
+              )}
+            </div>
+          </div>
+
+          <form onSubmit={handleSubmit} className="space-y-5 p-6 md:p-8">
+            <Tabs
+              value={sourceMode}
+              onValueChange={(value) => setSourceMode(value as "url" | "file")}
+            >
+              <TabsList className="grid w-full grid-cols-2">
+                <TabsTrigger value="url" disabled={isUploading}>
+                  영상 링크
+                </TabsTrigger>
+                <TabsTrigger value="file" disabled={isUploading}>
+                  파일 업로드
+                </TabsTrigger>
+              </TabsList>
+              <TabsContent value="url" className="mt-4 space-y-2">
+                <Label htmlFor="member-video-url">Video URL</Label>
+                <div className="relative">
+                  <LinkSimple
+                    weight="light"
+                    className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+                  />
+                  <Input
+                    id="member-video-url"
+                    value={videoUrl}
+                    onChange={(event) => setVideoUrl(event.currentTarget.value)}
+                    placeholder="YouTube, Vimeo, 공유 가능한 영상 링크"
+                    className="h-11 bg-background/70 pl-9"
+                    disabled={formDisabled || sourceMode !== "url"}
+                  />
+                </div>
+              </TabsContent>
+              <TabsContent value="file" className="mt-4 space-y-2">
+                <Label htmlFor="member-video-file">Video File</Label>
+                <div className="rounded-md border bg-background/70 p-3">
+                  <input
+                    ref={fileInputRef}
+                    id="member-video-file"
+                    type="file"
+                    accept="video/mp4,video/webm,video/quicktime"
+                    className="sr-only"
+                    onChange={handleFileChange}
+                    disabled={formDisabled || sourceMode !== "file"}
+                  />
+                  <div className="flex items-center gap-3">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="h-9 shrink-0 rounded-full"
+                      onClick={() => fileInputRef.current?.click()}
+                      disabled={formDisabled || sourceMode !== "file"}
+                    >
+                      <FilmSlate weight="light" className="size-4" />
+                      Choose Video
+                    </Button>
+                    <p className="min-w-0 flex-1 truncate text-sm text-muted-foreground">
+                      {file ? `${file.name} · ${formatBytes(file.size)}` : "No file selected"}
+                    </p>
+                    {file && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-sm"
+                        className="shrink-0 rounded-full"
+                        aria-label="Clear selected video"
+                        onClick={clearFile}
+                        disabled={isUploading}
+                      >
+                        <X weight="light" className="size-4" />
+                      </Button>
+                    )}
+                  </div>
+                </div>
+                <p className="text-xs leading-relaxed text-muted-foreground">
+                  mp4, webm, mov · 최대 100MB
+                </p>
+              </TabsContent>
+            </Tabs>
+
+            <div className="grid gap-4 sm:grid-cols-[1fr_12rem]">
+              <div className="space-y-2">
+                <Label htmlFor="member-video-title">Title</Label>
+                <Input
+                  id="member-video-title"
+                  value={title}
+                  onChange={(event) => setTitle(event.currentTarget.value)}
+                  placeholder="빨간 피터, 새터 리허설..."
+                  className="h-11 bg-background/70"
+                  maxLength={120}
+                  disabled={formDisabled}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="member-video-visibility">공개 범위</Label>
+                <Select
+                  value={visibility}
+                  onValueChange={setVisibility}
+                  disabled={formDisabled}
+                >
+                  <SelectTrigger
+                    id="member-video-visibility"
+                    className="h-11 bg-background/70"
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="public">전체 공개</SelectItem>
+                    <SelectItem value="members">멤버 공개</SelectItem>
+                    <SelectItem value="private">비공개</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="member-video-description">Description</Label>
+              <Textarea
+                id="member-video-description"
+                value={description}
+                onChange={(event) => setDescription(event.currentTarget.value)}
+                placeholder="영상에 함께 남길 짧은 설명"
+                className="min-h-24 bg-background/70"
+                maxLength={1000}
+                disabled={formDisabled}
+              />
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="member-video-artist">Artist</Label>
+                <Input
+                  id="member-video-artist"
+                  value={artist}
+                  onChange={(event) => setArtist(event.currentTarget.value)}
+                  placeholder="쏜애플"
+                  className="h-11 bg-background/70"
+                  maxLength={120}
+                  disabled={formDisabled}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="member-video-song">Song</Label>
+                <Input
+                  id="member-video-song"
+                  value={song}
+                  onChange={(event) => setSong(event.currentTarget.value)}
+                  placeholder="빨간 피터"
+                  className="h-11 bg-background/70"
+                  maxLength={160}
+                  disabled={formDisabled}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="member-video-team">Team</Label>
+                <Input
+                  id="member-video-team"
+                  value={team}
+                  onChange={(event) => setTeam(event.currentTarget.value)}
+                  placeholder="팀명 또는 무대"
+                  className="h-11 bg-background/70"
+                  maxLength={120}
+                  disabled={formDisabled}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="member-video-event">Event</Label>
+                <Input
+                  id="member-video-event"
+                  value={eventTitle}
+                  onChange={(event) => setEventTitle(event.currentTarget.value)}
+                  placeholder="2026 신환공"
+                  className="h-11 bg-background/70"
+                  maxLength={140}
+                  disabled={formDisabled}
+                />
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="member-video-duration">Duration</Label>
+              <Input
+                id="member-video-duration"
+                value={duration}
+                onChange={(event) => setDuration(event.currentTarget.value)}
+                placeholder="4:44"
+                className="h-11 bg-background/70"
+                maxLength={32}
+                disabled={formDisabled}
+              />
+            </div>
+
+            {submitState.kind === "uploading" && (
+              <div className="space-y-2 rounded-md border bg-muted/40 px-4 py-3">
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <UploadSimple className="size-4" />
+                  {submitState.label}
+                </div>
+                <Progress value={sourceMode === "file" ? 66 : 45} />
+              </div>
+            )}
+
+            {submitState.kind === "success" && (
+              <p className="rounded-md border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-950">
+                {submitState.message}
+              </p>
+            )}
+
+            {submitState.kind === "error" && (
+              <p className="rounded-md border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+                {submitState.message}
+              </p>
+            )}
+
+            <Button
+              type="submit"
+              size="lg"
+              className="w-full"
+              disabled={formDisabled}
+            >
+              {isUploading ? "Submitting..." : "Submit recording"}
+            </Button>
+          </form>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/videos-section.tsx
+++ b/components/videos-section.tsx
@@ -16,6 +16,7 @@ import {
   type AdminSectionControl,
 } from "@/components/admin-section-frame"
 import { ContentImage } from "@/components/content-image"
+import { MemberVideoSubmitDialog } from "@/components/member-video-submit-dialog"
 import {
   Command,
   CommandEmpty,
@@ -63,6 +64,7 @@ import {
 
 const ALL_EVENTS = "all"
 const PAGE_SIZE = 24
+const YOUTUBE_ID_PATTERN = /^[a-zA-Z0-9_-]{11}$/
 
 type SortOption = "recent" | "popular" | "title"
 
@@ -74,11 +76,13 @@ type EventOption = {
 }
 
 function videoThumbnailUrl(video: Video, quality: "max" | "mq") {
-  return video.thumbnailUrl ?? youtubeThumbnailUrl(video.id, quality)
+  if (video.thumbnailUrl) return video.thumbnailUrl
+  return YOUTUBE_ID_PATTERN.test(video.id) ? youtubeThumbnailUrl(video.id, quality) : null
 }
 
 function videoWatchUrl(video: Video) {
-  return video.watchUrl ?? watchUrl(video.id)
+  if (video.watchUrl) return video.watchUrl
+  return YOUTUBE_ID_PATTERN.test(video.id) ? watchUrl(video.id) : "#"
 }
 
 function videoEventLabel(video: Video) {
@@ -148,6 +152,8 @@ function VideoCard({
   video: Video
   index: number
 }) {
+  const thumbnail = videoThumbnailUrl(video, "mq")
+
   return (
     <Reveal as="li" delay={(index % PAGE_SIZE) * 35} className="h-full">
       <a
@@ -157,13 +163,22 @@ function VideoCard({
         className="lift-card group flex h-full flex-col overflow-hidden rounded-md border bg-card shadow-sm hover:shadow-xl"
       >
         <div className="relative aspect-video overflow-hidden bg-muted">
-          <ContentImage
-            src={videoThumbnailUrl(video, "mq")}
-            alt={video.raw_title}
-            fill
-            sizes="(max-width: 768px) 100vw, 33vw"
-            className="object-cover transition-transform duration-700 group-hover:scale-[1.04]"
-          />
+          {thumbnail ? (
+            <ContentImage
+              src={thumbnail}
+              alt={video.raw_title}
+              fill
+              sizes="(max-width: 768px) 100vw, 33vw"
+              className="object-cover transition-transform duration-700 group-hover:scale-[1.04]"
+            />
+          ) : (
+            <div className="absolute inset-0 grid place-items-center bg-gradient-to-br from-stone-100 via-stone-50 to-amber-50">
+              <Play
+                weight="fill"
+                className="size-10 text-foreground/25 transition-transform duration-700 group-hover:scale-110"
+              />
+            </div>
+          )}
           <span className="absolute bottom-2 right-2 caps tabular-nums rounded-sm bg-background/90 px-2 py-0.5 backdrop-blur-sm">
             {video.duration}
           </span>
@@ -206,6 +221,8 @@ function VideoCard({
 }
 
 function FeaturedVideoCard({ video }: { video: Video }) {
+  const thumbnail = videoThumbnailUrl(video, "max")
+
   return (
     <Reveal className="h-full">
       <a
@@ -216,13 +233,22 @@ function FeaturedVideoCard({ video }: { video: Video }) {
         className="tilt-card group flex h-full flex-col overflow-hidden rounded-md border bg-card shadow-sm hover:shadow-xl"
       >
         <div className="relative aspect-[16/10] overflow-hidden bg-muted">
-          <ContentImage
-            src={videoThumbnailUrl(video, "max")}
-            alt={video.raw_title}
-            fill
-            sizes="(max-width: 1024px) 100vw, 60vw"
-            className="object-cover transition-transform duration-700 group-hover:scale-[1.04]"
-          />
+          {thumbnail ? (
+            <ContentImage
+              src={thumbnail}
+              alt={video.raw_title}
+              fill
+              sizes="(max-width: 1024px) 100vw, 60vw"
+              className="object-cover transition-transform duration-700 group-hover:scale-[1.04]"
+            />
+          ) : (
+            <div className="absolute inset-0 grid place-items-center bg-gradient-to-br from-stone-100 via-stone-50 to-amber-50">
+              <Play
+                weight="fill"
+                className="size-12 text-foreground/25 transition-transform duration-700 group-hover:scale-110"
+              />
+            </div>
+          )}
           <div className="absolute inset-0 bg-gradient-to-t from-background/90 via-background/20 to-transparent" />
           <span className="absolute bottom-4 right-4 caps tabular-nums rounded-sm bg-background/90 px-2 py-0.5 backdrop-blur-sm">
             {video.duration}
@@ -257,6 +283,8 @@ function FeaturedVideoCard({ video }: { video: Video }) {
 }
 
 function PickRow({ video, index }: { video: Video; index: number }) {
+  const thumbnail = videoThumbnailUrl(video, "mq")
+
   return (
     <Reveal delay={index * 80}>
       <a
@@ -266,13 +294,19 @@ function PickRow({ video, index }: { video: Video; index: number }) {
         className="group flex items-start gap-4 border-b py-4 transition-colors hover:border-foreground"
       >
         <div className="relative h-20 w-32 shrink-0 overflow-hidden rounded-sm bg-muted">
-          <ContentImage
-            src={videoThumbnailUrl(video, "mq")}
-            alt={video.raw_title}
-            fill
-            sizes="128px"
-            className="object-cover"
-          />
+          {thumbnail ? (
+            <ContentImage
+              src={thumbnail}
+              alt={video.raw_title}
+              fill
+              sizes="128px"
+              className="object-cover"
+            />
+          ) : (
+            <div className="absolute inset-0 grid place-items-center bg-gradient-to-br from-stone-100 to-amber-50">
+              <Play weight="fill" className="size-6 text-foreground/25" />
+            </div>
+          )}
         </div>
         <div className="min-w-0">
           <p className="caps mb-2">
@@ -735,15 +769,18 @@ export function VideosSection({
         titleKr={pageConfig.title}
         description={pageConfig.description}
         actions={
-          <a
-            href="https://www.youtube.com/@postech_bremen"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="group inline-flex items-baseline gap-3 border-b pb-2 transition-colors hover:border-foreground"
-          >
-            <span className="font-serif italic text-xl">Visit the channel</span>
-            <ArrowUpRight weight="light" className="h-4 w-4 transition-transform group-hover:translate-x-1 group-hover:-translate-y-1" />
-          </a>
+          <div className="flex flex-wrap items-center gap-3">
+            <MemberVideoSubmitDialog />
+            <a
+              href="https://www.youtube.com/@postech_bremen"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group inline-flex items-baseline gap-3 border-b pb-2 transition-colors hover:border-foreground"
+            >
+              <span className="font-serif italic text-xl">Visit the channel</span>
+              <ArrowUpRight weight="light" className="h-4 w-4 transition-transform group-hover:translate-x-1 group-hover:-translate-y-1" />
+            </a>
+          </div>
         }
       />
 

--- a/lib/data/content-graph.ts
+++ b/lib/data/content-graph.ts
@@ -7,6 +7,7 @@ import {
 import {
   MEMBER_MEDIA_BUCKET,
   MEMBER_PHOTO_SCHEMA_KEY,
+  MEMBER_VIDEO_SCHEMA_KEY,
 } from "@/lib/data/member-media"
 import {
   buildHomeOverview,
@@ -1247,6 +1248,100 @@ function mergePhotoGalleryItems(
   ]
 }
 
+async function signedMemberMediaObjectUrl(
+  supabase: PublicSupabaseClient,
+  entity: ContentEntityRow,
+) {
+  const data = jsonObject(entity.data)
+  const bucket = stringValue(data, "storage_bucket")
+  const path = stringValue(data, "storage_path")
+
+  if (bucket !== MEMBER_MEDIA_BUCKET || !path) return null
+
+  const { data: signed, error } = await supabase.storage
+    .from(MEMBER_MEDIA_BUCKET)
+    .createSignedUrl(path, 60 * 60)
+
+  if (error) return null
+  return signed.signedUrl
+}
+
+function memberUploadVideoFromEntity(
+  entity: ContentEntityRow,
+  resolvedWatchUrl: string | null,
+): Video | null {
+  const data = jsonObject(entity.data)
+  const youtubeId = stringValue(data, "youtube_id")
+  const videoUrl = stringValue(data, "video_url")
+  const watchHref = resolvedWatchUrl ?? videoUrl
+
+  if (!youtubeId && !watchHref) return null
+
+  const parsedTitle = parseVideoTitle(entity.title)
+
+  return {
+    id: youtubeId ?? entity.id,
+    thumbnailUrl: entity.thumbnail_url ?? undefined,
+    watchUrl: youtubeId
+      ? stringValue(data, "youtube_url") ?? videoUrl ?? undefined
+      : (watchHref ?? undefined),
+    artist: stringValue(data, "artist") ?? parsedTitle.artist,
+    song: stringValue(data, "song") ?? parsedTitle.song,
+    raw_title: entity.title,
+    team: stringValue(data, "team") ?? parsedTitle.team,
+    event: stringValue(data, "event_slug") ?? "member-upload",
+    eventLabel: stringValue(data, "event_title") ?? "멤버 제출",
+    duration: stringValue(data, "duration") ?? "video",
+    views: numberValue(data, "views") ?? 0,
+    highlight: false,
+  }
+}
+
+async function loadPublishedMemberUploadVideos() {
+  if (!hasSupabaseEnv()) return []
+
+  const supabase = createPublicClient()
+  const { data: schema, error: schemaError } = await supabase
+    .from("entity_schemas")
+    .select("id")
+    .eq("schema_key", MEMBER_VIDEO_SCHEMA_KEY)
+    .eq("active", true)
+    .maybeSingle()
+
+  if (schemaError || !schema) return []
+
+  const { data: entities, error: entitiesError } = await supabase
+    .from("entities")
+    .select(CONTENT_ENTITY_SELECT)
+    .eq("schema_id", schema.id)
+    .eq("published", true)
+    .eq("visibility", "public")
+    .order("sort_at", { ascending: false })
+    .limit(80)
+
+  if (entitiesError || !entities?.length) return []
+
+  const videos = await Promise.all(
+    (entities as ContentEntityRow[]).map(async (entity) => {
+      const signedUrl = await signedMemberMediaObjectUrl(supabase, entity)
+      return memberUploadVideoFromEntity(entity, signedUrl)
+    }),
+  )
+
+  return videos.filter((video): video is Video => Boolean(video))
+}
+
+function mergeVideoArchiveItems(
+  curatedVideos: Video[],
+  memberVideos: Video[],
+) {
+  const videoIds = new Set(curatedVideos.map((video) => video.id))
+  return [
+    ...curatedVideos,
+    ...memberVideos.filter((video) => !videoIds.has(video.id)),
+  ]
+}
+
 function homeStatType(value: string | null): HomeCurationStatItem["type"] {
   if (value === "image" || value === "color") return value
   return "text"
@@ -1575,8 +1670,12 @@ async function loadVideoPageUncached(): Promise<VideoPageContent | null> {
     sectionItems(page, "videos-popular"),
     performanceSlugById,
   )
+  const memberVideos = await loadPublishedMemberUploadVideos()
   const libraryVideos = sortVideoArchive(
-    videosFromSectionItems(sectionItems(page, "videos-library"), performanceSlugById),
+    mergeVideoArchiveItems(
+      videosFromSectionItems(sectionItems(page, "videos-library"), performanceSlugById),
+      memberVideos,
+    ),
   )
 
   return {

--- a/lib/data/videos.ts
+++ b/lib/data/videos.ts
@@ -1,6 +1,7 @@
 export type EventKey = string
 
 export type Video = {
+  /** YouTube id for channel imports, entity id for direct member uploads. */
   id: string
   /** Display thumbnail. Prefer Supabase Storage when available. */
   thumbnailUrl?: string


### PR DESCRIPTION
Closes #196

## Summary
- Adds `/videos` member submission UI with shadcn Dialog/Tabs/Select controls.
- Supports video links and direct browser Storage uploads to `member-media/{auth.uid()}/videos/...`.
- Creates `video/member-upload/v1` entities with owner, metadata, selected visibility, and unpublished moderation state.
- Loads approved public member-uploaded video entities into the videos library and renders non-YouTube cards without broken thumbnails.

## Verification
- pnpm exec tsc --noEmit
- pnpm run lint
- git diff --check
- pnpm run qa:legacy-media-table-readiness
- pnpm run qa:schema-mirror-removal-readiness
- pnpm run qa:content-graph
- pnpm run qa:cms-schema-registry
- pnpm run qa:cms-db-first-loaders
- pnpm run qa:cms-legacy-bridge-boundary
- pnpm run build
- local next start /videos browser smoke and empty-submit validation

## Not tested
- Real member video entity/file creation was skipped to avoid live UGC mutations without a reversible test fixture.