### PR TITLE
Add member-only media surface

### DIFF
--- a/app/(site)/members/media/page.tsx
+++ b/app/(site)/members/media/page.tsx
@@ -1,0 +1,68 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { redirect } from "next/navigation"
+
+import { MemberMediaRoom } from "@/components/member-media-room"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  loadMemberMediaViewer,
+  loadMemberRoomMedia,
+} from "@/lib/data/member-room-media"
+import { createClient } from "@/lib/supabase/server"
+
+export const metadata: Metadata = {
+  title: "멤버 공개 기록 | 브레멘 Bremen",
+  description: "브레멘 활동 멤버에게만 공개된 사진과 영상.",
+}
+
+export default async function MemberMediaPage() {
+  const supabase = await createClient()
+  const viewer = await loadMemberMediaViewer(supabase)
+
+  if (viewer.state === "anonymous") {
+    redirect("/login?next=/members/media")
+  }
+
+  if (viewer.state === "blocked") {
+    return (
+      <main className="mx-auto grid min-h-[calc(100vh-4rem)] max-w-3xl place-items-center px-6 py-20 md:px-8">
+        <Card className="w-full rounded-md border bg-card/95 shadow-xl">
+          <CardHeader>
+            <p className="caps mb-3 text-muted-foreground">Members only</p>
+            <CardTitle className="font-serif-kr text-3xl leading-tight md:text-4xl">
+              멤버 공개 기록을 열 수 없습니다
+            </CardTitle>
+            <CardDescription className="text-base leading-relaxed">
+              {viewer.reason}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-wrap gap-3">
+            <Button asChild className="rounded-full">
+              <Link href="/mypage">내 정보 확인</Link>
+            </Button>
+            <Button asChild variant="outline" className="rounded-full">
+              <Link href="/members">멤버 페이지</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </main>
+    )
+  }
+
+  const media = await loadMemberRoomMedia(supabase, viewer.member)
+
+  return (
+    <MemberMediaRoom
+      viewer={media.viewer}
+      photos={media.photos}
+      videos={media.videos}
+    />
+  )
+}

--- a/app/(site)/photos/actions.ts
+++ b/app/(site)/photos/actions.ts
@@ -11,12 +11,14 @@ import { createClient } from "@/lib/supabase/server"
 import type { Database, Json } from "@/lib/supabase/types"
 
 type EntityInsert = Database["public"]["Tables"]["entities"]["Insert"]
+type PhotoVisibility = "public" | "members"
 
 type CreateMemberPhotoSubmissionInput = {
   title: string
   caption: string
   category?: string
   aspect?: string
+  visibility?: string
   storagePath: string
   mediaType: string
   originalFilename: string
@@ -40,6 +42,7 @@ const photoMimeTypes = new Set([
   "image/gif",
 ])
 const photoExtensions = new Set(["jpg", "jpeg", "png", "webp", "gif"])
+const visibilityValues = new Set<PhotoVisibility>(["public", "members"])
 
 function cleanText(value: string, maxLength: number) {
   return value.trim().replace(/\s+/g, " ").slice(0, maxLength)
@@ -83,6 +86,12 @@ function validatePhoto(input: CreateMemberPhotoSubmissionInput) {
   return null
 }
 
+function validVisibility(value: string | undefined) {
+  return visibilityValues.has(value as PhotoVisibility)
+    ? (value as PhotoVisibility)
+    : "public"
+}
+
 function jsonData(data: Record<string, Json>): Json {
   return data
 }
@@ -101,6 +110,7 @@ export async function createMemberPhotoSubmissionAction(
 
   const title = cleanText(input.title, 120)
   const caption = input.caption.trim().slice(0, 1000)
+  const visibility = validVisibility(input.visibility)
   const photoError = validatePhoto(input)
 
   if (!title) return { ok: false, error: "제목을 적어 주세요." }
@@ -173,7 +183,7 @@ export async function createMemberPhotoSubmissionAction(
     thumbnail_url: null,
     owner_member_id: member.id,
     published: true,
-    visibility: "public",
+    visibility,
     sort_at: now,
     data: jsonData(data),
   }
@@ -190,6 +200,7 @@ export async function createMemberPhotoSubmissionAction(
   }
 
   revalidatePath("/photos")
+  revalidatePath("/members/media")
   revalidatePath("/ponix/entities")
   revalidatePath(`/ponix/entities/${entity.id}`)
   updateTag(PUBLIC_CONTENT_CACHE_TAG)

--- a/app/(site)/videos/actions.ts
+++ b/app/(site)/videos/actions.ts
@@ -285,6 +285,7 @@ export async function createMemberVideoSubmissionAction(
   }
 
   revalidatePath("/videos")
+  revalidatePath("/members/media")
   revalidatePath("/ponix/entities")
   revalidatePath(`/ponix/entities/${entity.id}`)
   updateTag(PUBLIC_CONTENT_CACHE_TAG)

--- a/app/ponix/photos/actions.ts
+++ b/app/ponix/photos/actions.ts
@@ -41,6 +41,11 @@ function safeMemberMediaPhotoPath(path: string | null) {
   )
 }
 
+function publicationState(value: string) {
+  if (value === "public" || value === "members") return value
+  return "hidden"
+}
+
 async function memberPhotoSchemaId() {
   const supabase = await createClient()
   const { data: schema, error } = await supabase
@@ -56,6 +61,7 @@ async function memberPhotoSchemaId() {
 
 function revalidateMemberPhotoSurfaces(entityId?: string) {
   revalidatePath("/photos")
+  revalidatePath("/members/media")
   revalidatePath("/ponix/photos")
   revalidatePath("/ponix/entities")
   updateTag(PUBLIC_CONTENT_CACHE_TAG)
@@ -68,7 +74,7 @@ function revalidateMemberPhotoSurfaces(entityId?: string) {
 
 export async function updateMemberPhotoVisibilityAction(formData: FormData) {
   const entityId = stringField(formData, "entity_id")
-  const mode = stringField(formData, "mode")
+  const state = publicationState(stringField(formData, "state"))
 
   if (!entityId) {
     redirectWithParams({ error: "관리할 사진을 찾지 못했습니다." })
@@ -82,9 +88,9 @@ export async function updateMemberPhotoVisibilityAction(formData: FormData) {
   }
 
   const update =
-    mode === "public"
-      ? { published: true, visibility: "public" }
-      : { published: false, visibility: "private" }
+    state === "hidden"
+      ? { published: false, visibility: "private" }
+      : { published: true, visibility: state }
 
   const supabase = await createClient()
   const { error } = await supabase
@@ -99,7 +105,7 @@ export async function updateMemberPhotoVisibilityAction(formData: FormData) {
 
   revalidateMemberPhotoSurfaces(entityId)
   redirectWithParams({
-    saved: mode === "public" ? "published" : "hidden",
+    saved: state === "public" ? "published" : state,
   })
 }
 

--- a/app/ponix/photos/page.tsx
+++ b/app/ponix/photos/page.tsx
@@ -44,6 +44,13 @@ function savedCopy(value?: string) {
     }
   }
 
+  if (value === "members") {
+    return {
+      title: "사진을 멤버 공개로 저장했습니다",
+      description: "사진 탭에서는 제외하고, 멤버 공개 기록에 보이도록 정리했습니다.",
+    }
+  }
+
   if (value === "deleted") {
     return {
       title: "사진을 삭제했습니다",
@@ -102,7 +109,7 @@ export default async function PonixPhotosPage({
       <CmsStatGrid>
         <CmsStatTile label="업로드" value={stats.total} detail="멤버가 올린 사진" accent />
         <CmsStatTile label="공개" value={stats.publicCount} detail="사진 탭에 보이는 사진" />
-        <CmsStatTile label="숨김" value={stats.hiddenCount} detail="공개 화면에서 제외" />
+        <CmsStatTile label="멤버 공개" value={stats.membersCount} detail="활동 멤버에게 보이는 사진" />
         <CmsStatTile
           label="최근"
           value={stats.latestAt ? "New" : "-"}

--- a/app/ponix/photos/photo-operations-list.tsx
+++ b/app/ponix/photos/photo-operations-list.tsx
@@ -2,7 +2,7 @@
 
 import { useDeferredValue, useState } from "react"
 import Link from "next/link"
-import { Eye, EyeOff, ImageIcon, Search, Trash2, X } from "lucide-react"
+import { Globe2, ImageIcon, Lock, Search, Trash2, Users, X } from "lucide-react"
 
 import {
   deleteMemberPhotoAction,
@@ -24,6 +24,13 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
   Table,
   TableBody,
   TableCell,
@@ -34,11 +41,19 @@ import {
 import type { CmsMemberPhoto } from "@/lib/cms/member-photos"
 import { cn } from "@/lib/utils"
 
-type Filter = "all" | "public" | "hidden"
+type Filter = "all" | "public" | "members" | "hidden"
+type PublicationState = "public" | "members" | "hidden"
 
 const filterLabels: Record<Filter, string> = {
   all: "전체",
   public: "공개",
+  members: "멤버 공개",
+  hidden: "숨김",
+}
+
+const stateLabels: Record<PublicationState, string> = {
+  public: "전체 공개",
+  members: "멤버 공개",
   hidden: "숨김",
 }
 
@@ -49,8 +64,9 @@ export function PhotoOperationsList({ photos }: { photos: CmsMemberPhoto[] }) {
   const filteredPhotos = photos.filter((photo) => {
     const visible =
       filter === "all" ||
-      (filter === "public" && isPublicPhoto(photo)) ||
-      (filter === "hidden" && !isPublicPhoto(photo))
+      (filter === "public" && publicationState(photo) === "public") ||
+      (filter === "members" && publicationState(photo) === "members") ||
+      (filter === "hidden" && publicationState(photo) === "hidden")
 
     return visible && photoSearchText(photo).includes(deferredQuery)
   })
@@ -246,15 +262,15 @@ export function PhotoOperationsList({ photos }: { photos: CmsMemberPhoto[] }) {
 }
 
 function PhotoStatusBadges({ photo }: { photo: CmsMemberPhoto }) {
-  const publicPhoto = isPublicPhoto(photo)
+  const state = publicationState(photo)
 
   return (
     <div className="flex flex-col items-start gap-2">
       <Badge
-        variant={publicPhoto ? "default" : "outline"}
-        className={cn("rounded-full", !publicPhoto && "text-muted-foreground")}
+        variant={state === "public" ? "default" : "outline"}
+        className={cn("rounded-full", state !== "public" && "text-muted-foreground")}
       >
-        {publicPhoto ? "사진 탭 공개" : "숨김"}
+        {state === "public" ? "사진 탭 공개" : stateLabels[state]}
       </Badge>
       <Badge variant="outline" className="rounded-full text-muted-foreground">
         {photo.visibility === "public"
@@ -268,29 +284,46 @@ function PhotoStatusBadges({ photo }: { photo: CmsMemberPhoto }) {
 }
 
 function VisibilityForm({ photo }: { photo: CmsMemberPhoto }) {
-  const publicPhoto = isPublicPhoto(photo)
+  const [state, setState] = useState<PublicationState>(publicationState(photo))
 
   return (
-    <form action={updateMemberPhotoVisibilityAction}>
+    <form
+      action={updateMemberPhotoVisibilityAction}
+      className="flex flex-wrap items-center gap-2"
+    >
       <input type="hidden" name="entity_id" value={photo.id} />
-      <input type="hidden" name="mode" value={publicPhoto ? "hidden" : "public"} />
+      <input type="hidden" name="state" value={state} />
+      <Select
+        value={state}
+        onValueChange={(value) => setState(value as PublicationState)}
+      >
+        <SelectTrigger
+          size="sm"
+          className="h-9 min-w-36 rounded-full bg-background"
+        >
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="public">
+            <Globe2 className="size-4" />
+            전체 공개
+          </SelectItem>
+          <SelectItem value="members">
+            <Users className="size-4" />
+            멤버 공개
+          </SelectItem>
+          <SelectItem value="hidden">
+            <Lock className="size-4" />
+            숨김
+          </SelectItem>
+        </SelectContent>
+      </Select>
       <FormSubmitButton
-        variant={publicPhoto ? "outline" : "default"}
         size="sm"
-        pendingLabel={publicPhoto ? "숨기는 중..." : "공개 중..."}
+        pendingLabel="저장 중..."
         className="rounded-full"
       >
-        {publicPhoto ? (
-          <>
-            <EyeOff className="size-4" />
-            숨기기
-          </>
-        ) : (
-          <>
-            <Eye className="size-4" />
-            공개하기
-          </>
-        )}
+        상태 저장
       </FormSubmitButton>
     </form>
   )
@@ -353,8 +386,10 @@ function DeletePhotoDialog({ photo }: { photo: CmsMemberPhoto }) {
   )
 }
 
-function isPublicPhoto(photo: CmsMemberPhoto) {
-  return photo.published && photo.visibility === "public"
+function publicationState(photo: CmsMemberPhoto): PublicationState {
+  if (photo.published && photo.visibility === "public") return "public"
+  if (photo.published && photo.visibility === "members") return "members"
+  return "hidden"
 }
 
 function memberMeta(owner: CmsMemberPhoto["owner"]) {

--- a/app/ponix/videos/actions.ts
+++ b/app/ponix/videos/actions.ts
@@ -62,6 +62,7 @@ async function memberVideoSchemaId() {
 
 function revalidateMemberVideoSurfaces(entityId?: string) {
   revalidatePath("/videos")
+  revalidatePath("/members/media")
   revalidatePath("/ponix/videos")
   revalidatePath("/ponix/entities")
   updateTag(PUBLIC_CONTENT_CACHE_TAG)

--- a/components/member-media-room.tsx
+++ b/components/member-media-room.tsx
@@ -1,0 +1,331 @@
+"use client"
+
+import Link from "next/link"
+import {
+  ArrowUpRight,
+  FilmSlate,
+  ImageSquare,
+  LockKey,
+  Play,
+} from "@phosphor-icons/react"
+
+import { ContentImage } from "@/components/content-image"
+import {
+  EditorialMetricCard,
+  EditorialSectionHead,
+  PageHero,
+  PageSection,
+} from "@/components/editorial"
+import { Reveal } from "@/components/reveal"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import type {
+  MemberMediaViewer,
+  MemberRoomPhoto,
+  MemberRoomVideo,
+} from "@/lib/data/member-room-media"
+import { cn } from "@/lib/utils"
+
+type MemberMediaRoomProps = {
+  viewer: MemberMediaViewer
+  photos: MemberRoomPhoto[]
+  videos: MemberRoomVideo[]
+}
+
+const photoTone: Record<MemberRoomPhoto["category"], string> = {
+  공연: "from-stone-100 via-amber-50 to-stone-200",
+  일상: "from-zinc-100 via-white to-stone-100",
+}
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat("ko-KR", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(new Date(value))
+}
+
+function ownerLabel(owner: MemberRoomPhoto["owner"] | MemberRoomVideo["owner"]) {
+  if (!owner) return "Bremen member"
+  return [
+    owner.student_year ? `${owner.student_year}학번` : null,
+    owner.name,
+    owner.instrument,
+  ]
+    .filter(Boolean)
+    .join(" · ")
+}
+
+function videoTitle(video: MemberRoomVideo) {
+  return video.song || video.title
+}
+
+function videoMeta(video: MemberRoomVideo) {
+  return [video.artist, video.team, video.eventTitle, video.duration]
+    .filter(Boolean)
+    .join(" · ")
+}
+
+function PhotoCard({ photo, index }: { photo: MemberRoomPhoto; index: number }) {
+  const portrait = photo.aspect === "portrait"
+
+  return (
+    <Reveal as="li" delay={(index % 12) * 45} className="mb-5 break-inside-avoid">
+      <article
+        className={cn(
+          "lift-card group relative overflow-hidden rounded-md border bg-gradient-to-br shadow-sm hover:shadow-xl",
+          portrait ? "min-h-[25rem] md:min-h-[31rem]" : "min-h-[18rem] md:min-h-[21rem]",
+          photoTone[photo.category],
+        )}
+      >
+        {photo.thumbnailUrl ? (
+          <>
+            <ContentImage
+              src={photo.thumbnailUrl}
+              alt={photo.title}
+              fill
+              sizes="(max-width: 640px) 100vw, (max-width: 1280px) 50vw, 33vw"
+              className="object-cover transition-transform duration-700 group-hover:scale-[1.04]"
+            />
+            <div className="absolute inset-0 bg-gradient-to-t from-background/90 via-background/10 to-transparent" />
+          </>
+        ) : (
+          <div className="absolute inset-0 grid place-items-center">
+            <ImageSquare className="size-12 text-foreground/25" />
+          </div>
+        )}
+        <div className="absolute right-4 top-4 flex flex-wrap justify-end gap-2">
+          <Badge className="rounded-full bg-background/88 text-foreground backdrop-blur">
+            {photo.category}
+          </Badge>
+          <Badge variant="outline" className="rounded-full bg-background/70 backdrop-blur">
+            Members
+          </Badge>
+        </div>
+        <div className="absolute inset-x-0 bottom-0 px-5 pb-5 pt-20">
+          <p className="caps text-foreground/55">{ownerLabel(photo.owner)}</p>
+          <h3 className="mt-2 font-serif-kr text-xl leading-snug md:text-2xl">
+            {photo.title}
+          </h3>
+          {photo.caption && (
+            <p className="mt-2 line-clamp-2 text-sm leading-relaxed text-muted-foreground">
+              {photo.caption}
+            </p>
+          )}
+          <p className="mt-4 caps tabular-nums text-foreground/55">
+            {formatDate(photo.submittedAt)}
+          </p>
+        </div>
+      </article>
+    </Reveal>
+  )
+}
+
+function VideoCard({ video, index }: { video: MemberRoomVideo; index: number }) {
+  const content = (
+    <article className="lift-card group flex h-full flex-col overflow-hidden rounded-md border bg-card shadow-sm hover:shadow-xl">
+      <div className="relative aspect-video overflow-hidden bg-muted">
+        {video.thumbnailUrl ? (
+          <ContentImage
+            src={video.thumbnailUrl}
+            alt={video.title}
+            fill
+            sizes="(max-width: 768px) 100vw, 33vw"
+            className="object-cover transition-transform duration-700 group-hover:scale-[1.04]"
+          />
+        ) : (
+          <div className="absolute inset-0 grid place-items-center bg-gradient-to-br from-stone-100 via-stone-50 to-amber-50">
+            <FilmSlate className="size-10 text-foreground/25" />
+          </div>
+        )}
+        <div className="absolute inset-0 bg-gradient-to-t from-background/88 via-background/8 to-transparent" />
+        <div className="absolute bottom-3 left-3 flex items-center gap-2">
+          <span className="grid size-9 place-items-center rounded-full bg-background/90 backdrop-blur">
+            <Play weight="fill" className="size-4" />
+          </span>
+          {video.duration && (
+            <span className="caps rounded-full bg-background/90 px-2.5 py-1 tabular-nums backdrop-blur">
+              {video.duration}
+            </span>
+          )}
+        </div>
+      </div>
+      <div className="flex grow flex-col p-5 md:p-6">
+        <p className="caps text-accent">{ownerLabel(video.owner)}</p>
+        <h3 className="mt-3 font-serif-kr text-xl leading-snug md:text-2xl">
+          {videoTitle(video)}
+        </h3>
+        {videoMeta(video) && (
+          <p className="mt-2 line-clamp-1 text-sm italic text-muted-foreground">
+            {videoMeta(video)}
+          </p>
+        )}
+        {video.description && (
+          <p className="mt-3 line-clamp-2 text-sm leading-relaxed text-muted-foreground">
+            {video.description}
+          </p>
+        )}
+        <div className="mt-auto flex items-end justify-between gap-4 pt-7">
+          <p className="caps max-w-[70%] truncate text-muted-foreground">
+            {video.sourceLabel}
+          </p>
+          <span className="inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors group-hover:text-foreground">
+            Open
+            <ArrowUpRight weight="light" className="size-4" />
+          </span>
+        </div>
+      </div>
+    </article>
+  )
+
+  return (
+    <Reveal as="li" delay={(index % 12) * 45} className="h-full">
+      {video.watchUrl ? (
+        <a href={video.watchUrl} target="_blank" rel="noopener noreferrer" className="block h-full">
+          {content}
+        </a>
+      ) : (
+        content
+      )}
+    </Reveal>
+  )
+}
+
+function EmptyState({ kind }: { kind: "photo" | "video" }) {
+  return (
+    <div className="grid min-h-80 place-items-center rounded-md border bg-muted/30 px-6 py-16 text-center">
+      <div className="max-w-md">
+        <p className="font-serif text-4xl italic">
+          {kind === "photo" ? "No private photos yet" : "No private videos yet"}
+        </p>
+        <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
+          {kind === "photo"
+            ? "멤버 공개로 올라온 사진이 생기면 이곳에서 먼저 볼 수 있습니다."
+            : "멤버 공개로 승인된 영상이 생기면 이곳에서 함께 볼 수 있습니다."}
+        </p>
+      </div>
+    </div>
+  )
+}
+
+export function MemberMediaRoom({
+  viewer,
+  photos,
+  videos,
+}: MemberMediaRoomProps) {
+  const total = photos.length + videos.length
+  const latest = [...photos, ...videos].sort((left, right) =>
+    right.submittedAt.localeCompare(left.submittedAt),
+  )[0]
+
+  return (
+    <main className="relative min-h-[calc(100vh-4rem)] overflow-hidden">
+      <div className="pointer-events-none absolute inset-0 -z-10">
+        <div className="absolute right-[-12rem] top-14 h-[30rem] w-[30rem] rounded-full bg-accent/10 blur-3xl" />
+        <div className="absolute left-[-9rem] top-[28rem] h-80 w-80 rounded-full bg-muted blur-3xl" />
+      </div>
+
+      <div className="mx-auto max-w-6xl px-6 py-16 md:px-8 md:py-24">
+        <PageHero
+          eyebrow="Members only"
+          titleEn="Back room"
+          titleKr="멤버 공개 기록"
+          description={
+            <>
+              공개 채널에 올리기엔 사적인 장면들, 그래도 브레멘 안에서는 함께
+              보고 싶은 사진과 영상을 모았습니다.
+            </>
+          }
+          actions={
+            <div className="flex flex-wrap gap-3">
+              <Button asChild variant="outline" className="rounded-full">
+                <Link href="/photos">사진 탭</Link>
+              </Button>
+              <Button asChild variant="outline" className="rounded-full">
+                <Link href="/videos">영상 탭</Link>
+              </Button>
+            </div>
+          }
+          metrics={
+            <>
+              <EditorialMetricCard
+                label="For"
+                value={viewer.student_year ? `${viewer.student_year}` : "Bremen"}
+                unit={viewer.student_year ? "학번" : undefined}
+                detail={`${viewer.name} 계정으로 보고 있습니다.`}
+                tone="accent"
+                tilt="-0.5deg"
+              />
+              <EditorialMetricCard
+                label="Records"
+                value={total.toString()}
+                detail="멤버에게만 열린 사진과 영상"
+                tilt="0.7deg"
+              />
+              <EditorialMetricCard
+                label="Latest"
+                value={latest ? "New" : "-"}
+                detail={latest ? formatDate(latest.submittedAt) : "아직 기록 없음"}
+                tilt="-0.2deg"
+              />
+            </>
+          }
+        />
+
+        <PageSection className="mb-0">
+          <Reveal offset={24} blur={10}>
+            <EditorialSectionHead
+              eyebrow="Private archive"
+              en="Inside cuts"
+              kr="활동 멤버에게만 보이는 기록"
+              action={
+                <div className="inline-flex items-center gap-2 rounded-full border bg-card px-3 py-2 text-xs text-muted-foreground shadow-sm">
+                  <LockKey weight="fill" className="size-4 text-accent" />
+                  Signed URLs
+                </div>
+              }
+            />
+          </Reveal>
+
+          <Tabs defaultValue="photos" className="gap-8">
+            <TabsList className="h-11 rounded-full border bg-card p-1">
+              <TabsTrigger value="photos" className="rounded-full px-5">
+                <ImageSquare className="size-4" />
+                사진 {photos.length}
+              </TabsTrigger>
+              <TabsTrigger value="videos" className="rounded-full px-5">
+                <FilmSlate className="size-4" />
+                영상 {videos.length}
+              </TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="photos">
+              {photos.length ? (
+                <ul className="columns-1 gap-5 sm:columns-2 xl:columns-3">
+                  {photos.map((photo, index) => (
+                    <PhotoCard key={photo.id} photo={photo} index={index} />
+                  ))}
+                </ul>
+              ) : (
+                <EmptyState kind="photo" />
+              )}
+            </TabsContent>
+
+            <TabsContent value="videos">
+              {videos.length ? (
+                <ul className="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3">
+                  {videos.map((video, index) => (
+                    <VideoCard key={video.id} video={video} index={index} />
+                  ))}
+                </ul>
+              ) : (
+                <EmptyState kind="video" />
+              )}
+            </TabsContent>
+          </Tabs>
+        </PageSection>
+      </div>
+    </main>
+  )
+}

--- a/components/member-photo-upload-dialog.tsx
+++ b/components/member-photo-upload-dialog.tsx
@@ -126,6 +126,7 @@ export function MemberPhotoUploadDialog({
   const [access, setAccess] = useState<AccessState>({ state: "idle" })
   const [category, setCategory] = useState("daily")
   const [aspect, setAspect] = useState("portrait")
+  const [visibility, setVisibility] = useState("public")
   const [title, setTitle] = useState("")
   const [caption, setCaption] = useState("")
   const [file, setFile] = useState<File | null>(null)
@@ -133,6 +134,7 @@ export function MemberPhotoUploadDialog({
   const [publishedPhoto, setPublishedPhoto] = useState<{
     entityId: string
     title: string
+    visibility: string
   } | null>(null)
 
   const isUploading = uploadState.kind === "uploading"
@@ -219,6 +221,7 @@ export function MemberPhotoUploadDialog({
   function resetForm() {
     setCategory("daily")
     setAspect("portrait")
+    setVisibility("public")
     setTitle("")
     setCaption("")
     setFile(null)
@@ -293,6 +296,7 @@ export function MemberPhotoUploadDialog({
       caption,
       category,
       aspect,
+      visibility,
       storagePath,
       mediaType: file.type,
       originalFilename: file.name,
@@ -308,13 +312,17 @@ export function MemberPhotoUploadDialog({
     const published = {
       entityId: result.entityId,
       title: cleanTitle,
+      visibility,
     }
 
     resetForm()
     setPublishedPhoto(published)
     setUploadState({
       kind: "success",
-      message: `"${cleanTitle}"이 사진 탭에 올라갔습니다.`,
+      message:
+        visibility === "members"
+          ? `"${cleanTitle}"이 멤버 공개 기록에 올라갔습니다.`
+          : `"${cleanTitle}"이 사진 탭에 올라갔습니다.`,
     })
     onPublished?.(published)
     router.refresh()
@@ -356,8 +364,11 @@ export function MemberPhotoUploadDialog({
                   <span className="caps mb-2 block text-foreground">
                     {access.memberLabel}
                   </span>
-                  올린 사진은 공개 갤러리에 바로 표시됩니다. 나중에 숨기거나
-                  정리할 필요가 생기면 PONIX에서 조정합니다.
+                  전체 공개는 사진 탭에 바로 보이고, 멤버 공개는 활동 멤버만
+                  볼 수 있는 기록으로 남습니다.
+                  <Button asChild className="mt-4 w-full" variant="outline">
+                    <Link href="/members/media">멤버 공개 기록 보기</Link>
+                  </Button>
                 </>
               )}
             </div>
@@ -427,6 +438,29 @@ export function MemberPhotoUploadDialog({
             </div>
 
             <div className="space-y-2">
+              <Label htmlFor="member-photo-visibility">Visibility</Label>
+              <Select
+                value={visibility}
+                onValueChange={setVisibility}
+                disabled={formDisabled}
+              >
+                <SelectTrigger
+                  id="member-photo-visibility"
+                  className="h-11 bg-background/70"
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="public">전체 공개</SelectItem>
+                  <SelectItem value="members">멤버 공개</SelectItem>
+                </SelectContent>
+              </Select>
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                멤버 공개는 로그인한 활동 멤버에게만 보입니다.
+              </p>
+            </div>
+
+            <div className="space-y-2">
               <Label htmlFor="member-photo-file">Photo</Label>
               <div className="rounded-md border bg-background/70 p-3">
                 <input
@@ -493,9 +527,20 @@ export function MemberPhotoUploadDialog({
                   <div className="min-w-0">
                     <p className="font-medium">{uploadState.message}</p>
                     <p className="mt-1 text-xs leading-relaxed text-emerald-900/75">
-                      갤러리 맨 위에서 방금 올린 사진을 확인할 수 있습니다.
+                      {publishedPhoto?.visibility === "members"
+                        ? "멤버 공개 기록에서 방금 올린 사진을 확인할 수 있습니다."
+                        : "갤러리 맨 위에서 방금 올린 사진을 확인할 수 있습니다."}
                     </p>
-                    {publishedPhoto && (
+                    {publishedPhoto?.visibility === "members" ? (
+                      <Button
+                        asChild
+                        variant="outline"
+                        size="sm"
+                        className="mt-3 rounded-full border-emerald-300 bg-white/70 text-emerald-950 hover:bg-white"
+                      >
+                        <Link href="/members/media">멤버 공개 기록 열기</Link>
+                      </Button>
+                    ) : publishedPhoto ? (
                       <Button
                         type="button"
                         variant="outline"
@@ -508,7 +553,7 @@ export function MemberPhotoUploadDialog({
                       >
                         갤러리에서 보기
                       </Button>
-                    )}
+                    ) : null}
                   </div>
                 </div>
               </div>

--- a/components/member-video-submit-dialog.tsx
+++ b/components/member-video-submit-dialog.tsx
@@ -379,6 +379,9 @@ export function MemberVideoSubmitDialog() {
                   </span>
                   제출한 영상은 바로 공개되지 않습니다. 확인이 끝나면 선택한 공개
                   범위에 맞춰 아카이브에 반영됩니다.
+                  <Button asChild className="mt-4 w-full" variant="outline">
+                    <Link href="/members/media">멤버 공개 기록 보기</Link>
+                  </Button>
                 </>
               )}
             </div>

--- a/components/photos-section.tsx
+++ b/components/photos-section.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import Link from "next/link"
 import { useEffect, useState } from "react"
 import { CaretLeft, CaretRight } from "@phosphor-icons/react/dist/ssr"
 import {
@@ -319,12 +320,17 @@ export function PhotosSection({
         titleKr={page.title}
         description={page.description}
         actions={
-          <MemberPhotoUploadDialog
-            onPublished={({ entityId }) => {
-              setSelectedCategoryForNewPhoto()
-              setHighlightedPhotoId(entityId)
-            }}
-          />
+          <div className="flex flex-wrap gap-3">
+            <MemberPhotoUploadDialog
+              onPublished={({ entityId }) => {
+                setSelectedCategoryForNewPhoto()
+                setHighlightedPhotoId(entityId)
+              }}
+            />
+            <Button asChild variant="outline" size="lg" className="rounded-full px-6">
+              <Link href="/members/media">멤버 공개 기록</Link>
+            </Button>
+          </div>
         }
       />
 

--- a/components/videos-section.tsx
+++ b/components/videos-section.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import Link from "next/link"
 import { useSearchParams } from "next/navigation"
 import { Suspense, useDeferredValue, useState, type CSSProperties } from "react"
 import {
@@ -771,6 +772,9 @@ export function VideosSection({
         actions={
           <div className="flex flex-wrap items-center gap-3">
             <MemberVideoSubmitDialog />
+            <Button asChild variant="outline" size="lg" className="rounded-full px-6">
+              <Link href="/members/media">멤버 공개 기록</Link>
+            </Button>
             <a
               href="https://www.youtube.com/@postech_bremen"
               target="_blank"

--- a/lib/cms/member-photos.ts
+++ b/lib/cms/member-photos.ts
@@ -36,6 +36,7 @@ export type CmsMemberPhoto = {
 export type CmsMemberPhotoStats = {
   total: number
   publicCount: number
+  membersCount: number
   hiddenCount: number
   latestAt: string | null
 }
@@ -107,6 +108,7 @@ export async function loadCmsMemberPhotos(): Promise<{
       stats: {
         total: 0,
         publicCount: 0,
+        membersCount: 0,
         hiddenCount: 0,
         latestAt: null,
       },
@@ -129,6 +131,7 @@ export async function loadCmsMemberPhotos(): Promise<{
       stats: {
         total: 0,
         publicCount: 0,
+        membersCount: 0,
         hiddenCount: 0,
         latestAt: null,
       },
@@ -195,8 +198,11 @@ export async function loadCmsMemberPhotos(): Promise<{
       publicCount: photos.filter(
         (photo) => photo.published && photo.visibility === "public",
       ).length,
+      membersCount: photos.filter(
+        (photo) => photo.published && photo.visibility === "members",
+      ).length,
       hiddenCount: photos.filter(
-        (photo) => !photo.published || photo.visibility !== "public",
+        (photo) => !photo.published || photo.visibility === "private",
       ).length,
       latestAt: photos[0]?.sortAt ?? null,
     },

--- a/lib/data/member-room-media.ts
+++ b/lib/data/member-room-media.ts
@@ -1,0 +1,274 @@
+import {
+  MEMBER_MEDIA_BUCKET,
+  MEMBER_PHOTO_SCHEMA_KEY,
+  MEMBER_VIDEO_SCHEMA_KEY,
+} from "@/lib/data/member-media"
+import { createClient } from "@/lib/supabase/server"
+import type { Database, Json } from "@/lib/supabase/types"
+
+type SupabaseServerClient = Awaited<ReturnType<typeof createClient>>
+type EntityRow = Pick<
+  Database["public"]["Tables"]["entities"]["Row"],
+  | "id"
+  | "schema_id"
+  | "title"
+  | "subtitle"
+  | "summary"
+  | "thumbnail_url"
+  | "owner_member_id"
+  | "sort_at"
+  | "data"
+>
+type MemberRow = Database["public"]["Tables"]["members"]["Row"]
+
+export type MemberMediaViewer = Pick<
+  MemberRow,
+  "id" | "name" | "student_year" | "status" | "role" | "approved_at"
+>
+
+type MediaOwner = Pick<
+  MemberRow,
+  "id" | "name" | "student_year" | "instrument" | "status"
+>
+
+export type MemberRoomPhoto = {
+  id: string
+  title: string
+  caption: string | null
+  category: "공연" | "일상"
+  aspect: "portrait" | "landscape"
+  thumbnailUrl: string | null
+  submittedAt: string
+  owner: MediaOwner | null
+}
+
+export type MemberRoomVideo = {
+  id: string
+  title: string
+  description: string | null
+  thumbnailUrl: string | null
+  watchUrl: string | null
+  sourceLabel: string
+  artist: string | null
+  song: string | null
+  team: string | null
+  eventTitle: string | null
+  duration: string | null
+  submittedAt: string
+  owner: MediaOwner | null
+}
+
+export type MemberRoomMedia = {
+  viewer: MemberMediaViewer
+  photos: MemberRoomPhoto[]
+  videos: MemberRoomVideo[]
+}
+
+function isRecord(value: Json | unknown): value is Record<string, Json> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value)
+}
+
+function jsonObject(value: Json): Record<string, Json> {
+  return isRecord(value) ? value : {}
+}
+
+function stringValue(data: Record<string, Json>, key: string) {
+  const value = data[key]
+  return typeof value === "string" && value.trim() ? value : null
+}
+
+function categoryLabel(value: string | null): MemberRoomPhoto["category"] {
+  return value === "performance" ? "공연" : "일상"
+}
+
+function aspectLabel(value: string | null): MemberRoomPhoto["aspect"] {
+  return value === "landscape" ? "landscape" : "portrait"
+}
+
+function youtubeThumbnailUrl(youtubeId: string | null) {
+  return youtubeId ? `https://i.ytimg.com/vi/${youtubeId}/hqdefault.jpg` : null
+}
+
+async function signedMemberMediaUrl(
+  supabase: SupabaseServerClient,
+  bucket: string | null,
+  path: string | null,
+) {
+  if (bucket !== MEMBER_MEDIA_BUCKET || !path) return null
+
+  const { data, error } = await supabase.storage
+    .from(MEMBER_MEDIA_BUCKET)
+    .createSignedUrl(path, 60 * 60)
+
+  if (error) return null
+  return data.signedUrl
+}
+
+function safeDate(value: string | null, fallback: string) {
+  return value ?? fallback
+}
+
+function videoSourceLabel(data: Record<string, Json>) {
+  const filename = stringValue(data, "original_filename")
+  const youtubeId = stringValue(data, "youtube_id")
+
+  if (filename) return filename
+  if (youtubeId) return "YouTube link"
+  return "Video link"
+}
+
+export async function loadMemberMediaViewer(supabase: SupabaseServerClient) {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) return { state: "anonymous" as const }
+
+  const { data: member, error } = await supabase
+    .from("members")
+    .select("id, name, student_year, status, role, approved_at")
+    .eq("auth_user_id", user.id)
+    .maybeSingle()
+
+  if (error || !member?.approved_at) {
+    return {
+      state: "blocked" as const,
+      reason: "브레멘 멤버 확인이 끝난 계정으로 로그인해 주세요.",
+    }
+  }
+
+  if (member.status !== "active" && member.role !== "admin") {
+    return {
+      state: "blocked" as const,
+      reason: "멤버 공개 기록은 현재 활동 멤버에게 열려 있습니다.",
+    }
+  }
+
+  return {
+    state: "ready" as const,
+    member,
+  }
+}
+
+export async function loadMemberRoomMedia(
+  supabase: SupabaseServerClient,
+  viewer: MemberMediaViewer,
+): Promise<MemberRoomMedia> {
+  const { data: schemas, error: schemaError } = await supabase
+    .from("entity_schemas")
+    .select("id, schema_key")
+    .in("schema_key", [MEMBER_PHOTO_SCHEMA_KEY, MEMBER_VIDEO_SCHEMA_KEY])
+    .eq("active", true)
+
+  if (schemaError || !schemas?.length) {
+    return { viewer, photos: [], videos: [] }
+  }
+
+  const schemaKeyById = new Map(
+    schemas.map((schema) => [schema.id, schema.schema_key] as const),
+  )
+  const schemaIds = [...schemaKeyById.keys()]
+
+  const { data: entities, error } = await supabase
+    .from("entities")
+    .select(
+      "id, schema_id, title, subtitle, summary, thumbnail_url, owner_member_id, sort_at, data",
+    )
+    .in("schema_id", schemaIds)
+    .eq("published", true)
+    .eq("visibility", "members")
+    .order("sort_at", { ascending: false })
+    .limit(200)
+
+  if (error || !entities?.length) {
+    return { viewer, photos: [], videos: [] }
+  }
+
+  const ownerIds = [
+    ...new Set(
+      entities
+        .map((entity) => entity.owner_member_id)
+        .filter((id): id is string => Boolean(id)),
+    ),
+  ]
+  const { data: owners } = ownerIds.length
+    ? await supabase
+        .from("members")
+        .select("id, name, student_year, instrument, status")
+        .in("id", ownerIds)
+    : { data: [] }
+  const ownerById = new Map(
+    (owners ?? []).map((owner) => [owner.id, owner] as const),
+  )
+
+  const photos: MemberRoomPhoto[] = []
+  const videos: MemberRoomVideo[] = []
+
+  await Promise.all(
+    (entities as EntityRow[]).map(async (entity) => {
+      const schemaKey = schemaKeyById.get(entity.schema_id)
+      const data = jsonObject(entity.data)
+      const storageBucket = stringValue(data, "storage_bucket")
+      const storagePath = stringValue(data, "storage_path")
+      const owner = entity.owner_member_id
+        ? (ownerById.get(entity.owner_member_id) ?? null)
+        : null
+
+      if (schemaKey === MEMBER_PHOTO_SCHEMA_KEY) {
+        const signedUrl = await signedMemberMediaUrl(
+          supabase,
+          storageBucket,
+          storagePath,
+        )
+
+        photos.push({
+          id: entity.id,
+          title: entity.title,
+          caption: entity.summary,
+          category: categoryLabel(stringValue(data, "category")),
+          aspect: aspectLabel(stringValue(data, "aspect")),
+          thumbnailUrl: signedUrl ?? entity.thumbnail_url,
+          submittedAt: safeDate(stringValue(data, "submitted_at"), entity.sort_at),
+          owner,
+        })
+        return
+      }
+
+      if (schemaKey === MEMBER_VIDEO_SCHEMA_KEY) {
+        const signedUrl = await signedMemberMediaUrl(
+          supabase,
+          storageBucket,
+          storagePath,
+        )
+        const youtubeUrl = stringValue(data, "youtube_url")
+        const videoUrl = stringValue(data, "video_url")
+        const youtubeId = stringValue(data, "youtube_id")
+
+        videos.push({
+          id: entity.id,
+          title: entity.title,
+          description: entity.summary ?? stringValue(data, "description"),
+          thumbnailUrl: entity.thumbnail_url ?? youtubeThumbnailUrl(youtubeId),
+          watchUrl: signedUrl ?? youtubeUrl ?? videoUrl,
+          sourceLabel: videoSourceLabel(data),
+          artist: stringValue(data, "artist"),
+          song: stringValue(data, "song"),
+          team: stringValue(data, "team"),
+          eventTitle: stringValue(data, "event_title"),
+          duration: stringValue(data, "duration"),
+          submittedAt: safeDate(stringValue(data, "submitted_at"), entity.sort_at),
+          owner,
+        })
+      }
+    }),
+  )
+
+  const byDateDesc = <T extends { submittedAt: string }>(left: T, right: T) =>
+    right.submittedAt.localeCompare(left.submittedAt)
+
+  return {
+    viewer,
+    photos: photos.sort(byDateDesc),
+    videos: videos.sort(byDateDesc),
+  }
+}


### PR DESCRIPTION
Closes #200

## Summary

- Add `/members/media` as a member-only media room for approved `visibility = members` photo/video entities.
- Serve private `member-media` objects through signed URL flows and keep public `/photos` and `/videos` cacheable.
- Add member-public visibility to photo upload and PONIX photo operations.
- Add member-only media links from photo/video contribution surfaces.

## Supabase Impact

- No migration.
- No RLS/storage policy changes.
- Uses existing `entities`, `entity_schemas`, `members`, and `member-media`.

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `git diff --check`
- `pnpm run qa:cms-native-controls`
- `pnpm run qa:cms-db-first-loaders`
- `pnpm run qa:content-graph`
- `pnpm run qa:cms-schema-registry`
- `pnpm run qa:legacy-media-table-readiness`
- `pnpm run qa:schema-mirror-removal-readiness`
- `pnpm run qa:schema-semantic-identity`
- `pnpm run build`
- Local smoke: `/members/media` emits login redirect for anonymous access, `/photos` 200, `/videos` 200, member-only links present, browser console errors none.

## Not Tested

- Live member-only upload and moderation mutations were not executed to avoid creating production UGC fixtures.
