### PR TITLE
Move member video UGC into the gallery feed

### DIFF
--- a/app/(site)/videos/actions.ts
+++ b/app/(site)/videos/actions.ts
@@ -284,7 +284,7 @@ export async function createMemberVideoSubmissionAction(
     return { ok: false, error: "영상 기록을 저장하지 못했습니다." }
   }
 
-  revalidatePath("/videos")
+  revalidatePath("/photos")
   revalidatePath("/members/media")
   revalidatePath("/ponix/entities")
   revalidatePath(`/ponix/entities/${entity.id}`)

--- a/app/ponix/videos/actions.ts
+++ b/app/ponix/videos/actions.ts
@@ -61,7 +61,7 @@ async function memberVideoSchemaId() {
 }
 
 function revalidateMemberVideoSurfaces(entityId?: string) {
-  revalidatePath("/videos")
+  revalidatePath("/photos")
   revalidatePath("/members/media")
   revalidatePath("/ponix/videos")
   revalidatePath("/ponix/entities")

--- a/components/member-video-submit-dialog.tsx
+++ b/components/member-video-submit-dialog.tsx
@@ -335,7 +335,7 @@ export function MemberVideoSubmitDialog() {
     setSubmitState({
       kind: "success",
       message: result.published
-        ? "영상이 아카이브에 반영되었습니다."
+        ? "영상이 갤러리에 반영되었습니다."
         : "영상이 제출되었습니다. 확인이 끝나면 선택한 공개 범위로 보입니다.",
     })
     router.refresh()
@@ -346,7 +346,7 @@ export function MemberVideoSubmitDialog() {
       <DialogTrigger asChild>
         <Button size="lg" variant="outline" className="rounded-full px-6">
           <FilmSlate weight="light" className="size-4" />
-          영상 제출
+          영상 올리기
         </Button>
       </DialogTrigger>
       <DialogContent className="max-h-[min(92vh,54rem)] max-w-4xl overflow-y-auto p-0">
@@ -355,10 +355,10 @@ export function MemberVideoSubmitDialog() {
             <DialogHeader>
               <p className="caps text-muted-foreground">Video Submission</p>
               <DialogTitle className="font-serif italic text-4xl">
-                Add a recording
+                Add a clip
               </DialogTitle>
               <DialogDescription className="text-base leading-relaxed">
-                브레멘의 영상 기록을 아카이브에 남깁니다.
+                공연 뒤풀이, 연습실, 무대의 짧은 순간을 갤러리에 남깁니다.
               </DialogDescription>
             </DialogHeader>
             <div className="mt-8 rounded-md border bg-background/70 p-4 text-sm leading-relaxed text-muted-foreground">
@@ -367,7 +367,7 @@ export function MemberVideoSubmitDialog() {
                 <>
                   로그인한 활동 멤버만 영상을 제출할 수 있습니다.
                   <Button asChild className="mt-4 w-full" variant="outline">
-                    <Link href="/login?next=/videos">Sign In</Link>
+                    <Link href="/login?next=/photos">Sign In</Link>
                   </Button>
                 </>
               )}
@@ -378,7 +378,7 @@ export function MemberVideoSubmitDialog() {
                     {access.memberLabel}
                   </span>
                   제출한 영상은 바로 공개되지 않습니다. 확인이 끝나면 선택한 공개
-                  범위에 맞춰 아카이브에 반영됩니다.
+                  범위에 맞춰 갤러리에 반영됩니다.
                   <Button asChild className="mt-4 w-full" variant="outline">
                     <Link href="/members/media">멤버 공개 기록 보기</Link>
                   </Button>
@@ -605,7 +605,7 @@ export function MemberVideoSubmitDialog() {
               className="w-full"
               disabled={formDisabled}
             >
-              {isUploading ? "Submitting..." : "Submit recording"}
+              {isUploading ? "Submitting..." : "Submit clip"}
             </Button>
           </form>
         </div>

--- a/components/photos-section.tsx
+++ b/components/photos-section.tsx
@@ -2,13 +2,14 @@
 
 import Link from "next/link"
 import { useEffect, useState } from "react"
-import { CaretLeft, CaretRight } from "@phosphor-icons/react/dist/ssr"
+import { CaretLeft, CaretRight, Play } from "@phosphor-icons/react/dist/ssr"
 import {
   AdminSectionFrame,
   type AdminSectionControl,
 } from "@/components/admin-section-frame"
 import { ContentImage } from "@/components/content-image"
 import { MemberPhotoUploadDialog } from "@/components/member-photo-upload-dialog"
+import { MemberVideoSubmitDialog } from "@/components/member-video-submit-dialog"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -83,9 +84,12 @@ export function PhotoGallerySurface({
     selectedCategory === "전체"
       ? sourcePhotos
       : sourcePhotos.filter((photo) => photo.category === selectedCategory)
+  const lightboxPhotos = filteredPhotos.filter(
+    (photo) => (photo.kind ?? "photo") === "photo",
+  )
 
   const open = lightboxIndex !== null
-  const current = open ? filteredPhotos[lightboxIndex] : null
+  const current = open ? lightboxPhotos[lightboxIndex] : null
 
   useEffect(() => {
     if (!highlightedPhotoId) return
@@ -112,12 +116,14 @@ export function PhotoGallerySurface({
 
   const next = () =>
     setLightboxIndex((prev) =>
-      prev !== null ? (prev + 1) % filteredPhotos.length : null,
+      prev !== null && lightboxPhotos.length
+        ? (prev + 1) % lightboxPhotos.length
+        : null,
     )
   const prev = () =>
     setLightboxIndex((prev) =>
-      prev !== null
-        ? (prev - 1 + filteredPhotos.length) % filteredPhotos.length
+      prev !== null && lightboxPhotos.length
+        ? (prev - 1 + lightboxPhotos.length) % lightboxPhotos.length
         : null,
     )
 
@@ -176,6 +182,67 @@ export function PhotoGallerySurface({
         <ul className="columns-1 gap-5 sm:columns-2 xl:columns-3">
           {filteredPhotos.map((photo, index) => {
             const numberLabel = String(index + 1).padStart(2, "0")
+            const isVideo = photo.kind === "video"
+            const lightboxPhotoIndex = lightboxPhotos.findIndex(
+              (item) => item.id === photo.id,
+            )
+            const cardClassName = cn(
+              "lift-card group relative block w-full overflow-hidden rounded-md border text-left shadow-sm hover:shadow-xl",
+              "bg-gradient-to-br",
+              pinHeight(photo, index),
+              photoTone[photo.category] ?? "from-stone-100 via-stone-50 to-white",
+              highlightedPhotoId === photo.id &&
+                "ring-4 ring-accent/55 ring-offset-4 ring-offset-background",
+            )
+            const cardBody = (
+              <>
+                {highlightedPhotoId === photo.id && (
+                  <div className="absolute left-4 top-4 z-10 rounded-full border border-accent/25 bg-background/90 px-3 py-1 text-xs font-medium text-foreground shadow-sm backdrop-blur">
+                    방금 올라온 사진
+                  </div>
+                )}
+                {photo.thumbnailUrl && (
+                  <ContentImage
+                    src={photo.thumbnailUrl}
+                    alt={photo.title}
+                    fill
+                    sizes="(max-width: 640px) 100vw, (max-width: 1280px) 50vw, 33vw"
+                    className="object-cover transition-transform duration-700 group-hover:scale-[1.04]"
+                  />
+                )}
+                {photo.thumbnailUrl && (
+                  <div className="absolute inset-0 bg-gradient-to-t from-background/88 via-background/8 to-transparent" />
+                )}
+                <div className="absolute -right-8 -top-8 h-28 w-28 rounded-full bg-background/50 blur-2xl transition-transform duration-700 group-hover:scale-125" />
+                {isVideo && (
+                  <div className="absolute left-4 top-4 z-10 inline-flex items-center gap-2 rounded-full border border-background/60 bg-foreground px-3 py-1 text-xs font-medium text-background shadow-sm">
+                    <Play weight="fill" className="size-3" />
+                    {photo.duration ?? "Video"}
+                  </div>
+                )}
+                <div className="absolute right-4 top-4 rounded-full bg-background/80 px-2.5 py-1 backdrop-blur-sm">
+                  <p className="caps text-[0.62rem] text-foreground/70">
+                    {isVideo ? "영상" : photo.category}
+                  </p>
+                </div>
+                <div className="absolute bottom-8 left-5 font-serif italic text-6xl text-foreground/14 transition-transform duration-700 group-hover:scale-[1.06] md:text-8xl">
+                  №{numberLabel}
+                </div>
+                <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-background via-background/78 to-transparent px-4 pb-4 pt-16">
+                  <p className="caps text-foreground/55">
+                    {isVideo ? "Video" : photo.category}
+                  </p>
+                  <p className="mt-1 font-serif-kr text-base leading-snug md:text-lg">
+                    {photo.title}
+                  </p>
+                  {isVideo && photo.caption && (
+                    <p className="mt-2 line-clamp-2 text-sm leading-relaxed text-muted-foreground">
+                      {photo.caption}
+                    </p>
+                  )}
+                </div>
+              </>
+            )
 
             return (
               <Reveal
@@ -184,49 +251,25 @@ export function PhotoGallerySurface({
                 delay={index * 55}
                 className="mb-5 break-inside-avoid"
               >
-                <button
-                  data-photo-card={photo.id}
-                  onClick={() => setLightboxIndex(index)}
-                  className={cn(
-                    "lift-card group relative w-full overflow-hidden rounded-md border text-left shadow-sm hover:shadow-xl",
-                    "bg-gradient-to-br",
-                    pinHeight(photo, index),
-                    photoTone[photo.category] ?? "from-stone-100 via-stone-50 to-white",
-                    highlightedPhotoId === photo.id &&
-                      "ring-4 ring-accent/55 ring-offset-4 ring-offset-background",
-                  )}
-                >
-                  {highlightedPhotoId === photo.id && (
-                    <div className="absolute left-4 top-4 z-10 rounded-full border border-accent/25 bg-background/90 px-3 py-1 text-xs font-medium text-foreground shadow-sm backdrop-blur">
-                      방금 올라온 사진
-                    </div>
-                  )}
-                  {photo.thumbnailUrl && (
-                    <ContentImage
-                      src={photo.thumbnailUrl}
-                      alt={photo.title}
-                      fill
-                      sizes="(max-width: 640px) 100vw, (max-width: 1280px) 50vw, 33vw"
-                      className="object-cover transition-transform duration-700 group-hover:scale-[1.04]"
-                    />
-                  )}
-                  {photo.thumbnailUrl && (
-                    <div className="absolute inset-0 bg-gradient-to-t from-background/88 via-background/8 to-transparent" />
-                  )}
-                  <div className="absolute -right-8 -top-8 h-28 w-28 rounded-full bg-background/50 blur-2xl transition-transform duration-700 group-hover:scale-125" />
-                  <div className="absolute right-4 top-4 rounded-full bg-background/80 px-2.5 py-1 backdrop-blur-sm">
-                    <p className="caps text-[0.62rem] text-foreground/70">{photo.category}</p>
-                  </div>
-                  <div className="absolute bottom-8 left-5 font-serif italic text-6xl text-foreground/14 transition-transform duration-700 group-hover:scale-[1.06] md:text-8xl">
-                    №{numberLabel}
-                  </div>
-                  <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-background via-background/78 to-transparent px-4 pb-4 pt-16">
-                    <p className="caps text-foreground/55">{photo.category}</p>
-                    <p className="mt-1 font-serif-kr text-base leading-snug md:text-lg">
-                      {photo.title}
-                    </p>
-                  </div>
-                </button>
+                {isVideo ? (
+                  <a
+                    data-photo-card={photo.id}
+                    href={photo.href ?? undefined}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={cardClassName}
+                  >
+                    {cardBody}
+                  </a>
+                ) : (
+                  <button
+                    data-photo-card={photo.id}
+                    onClick={() => setLightboxIndex(lightboxPhotoIndex)}
+                    className={cardClassName}
+                  >
+                    {cardBody}
+                  </button>
+                )}
               </Reveal>
             )
           })}
@@ -292,7 +335,7 @@ export function PhotoGallerySurface({
                 </div>
                 <p className="caps tabular-nums">
                   {String(lightboxIndex! + 1).padStart(2, "0")} /{" "}
-                  {String(filteredPhotos.length).padStart(2, "0")}
+                  {String(lightboxPhotos.length).padStart(2, "0")}
                 </p>
               </div>
             </div>
@@ -327,6 +370,7 @@ export function PhotosSection({
                 setHighlightedPhotoId(entityId)
               }}
             />
+            <MemberVideoSubmitDialog />
             <Button asChild variant="outline" size="lg" className="rounded-full px-6">
               <Link href="/members/media">멤버 공개 기록</Link>
             </Button>

--- a/components/videos-section.tsx
+++ b/components/videos-section.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import Link from "next/link"
 import { useSearchParams } from "next/navigation"
 import { Suspense, useDeferredValue, useState, type CSSProperties } from "react"
 import {
@@ -17,7 +16,6 @@ import {
   type AdminSectionControl,
 } from "@/components/admin-section-frame"
 import { ContentImage } from "@/components/content-image"
-import { MemberVideoSubmitDialog } from "@/components/member-video-submit-dialog"
 import {
   Command,
   CommandEmpty,
@@ -771,10 +769,6 @@ export function VideosSection({
         description={pageConfig.description}
         actions={
           <div className="flex flex-wrap items-center gap-3">
-            <MemberVideoSubmitDialog />
-            <Button asChild variant="outline" size="lg" className="rounded-full px-6">
-              <Link href="/members/media">멤버 공개 기록</Link>
-            </Button>
             <a
               href="https://www.youtube.com/@postech_bremen"
               target="_blank"

--- a/lib/data/content-graph.ts
+++ b/lib/data/content-graph.ts
@@ -18,6 +18,7 @@ import type { Database, Json } from "@/lib/supabase/types"
 import { createPublicClient } from "@/lib/supabase/public"
 import {
   eventByKey,
+  thumbnailUrl as youtubeThumbnailUrl,
   type EventKey,
   type Video,
 } from "@/lib/data/videos"
@@ -155,11 +156,15 @@ export type PerformanceUpdateItem = {
 
 export type PhotoArchiveItem = {
   id: string
+  kind?: "photo" | "video"
   title: string
   caption: string | null
   category: "공연" | "일상"
   aspect: "portrait" | "landscape"
   thumbnailUrl: string | null
+  href?: string | null
+  duration?: string | null
+  sortAt?: string | null
 }
 
 export type HistoryMilestoneItem = {
@@ -1174,11 +1179,13 @@ function photoFromEntity(entity: ContentEntityRow): PhotoArchiveItem | null {
 
   return {
     id: entity.id,
+    kind: "photo",
     title: entity.title,
     caption: entity.summary,
     category: photoCategoryLabel(stringValue(data, "category")),
     aspect: photoAspect(stringValue(data, "aspect")),
     thumbnailUrl: entity.thumbnail_url,
+    sortAt: entity.sort_at,
   }
 }
 
@@ -1240,11 +1247,16 @@ async function loadPublishedMemberUploadPhotos() {
 function mergePhotoGalleryItems(
   curatedPhotos: PhotoArchiveItem[],
   memberPhotos: PhotoArchiveItem[],
+  memberVideos: PhotoArchiveItem[],
 ) {
-  const memberPhotoIds = new Set(memberPhotos.map((photo) => photo.id))
+  const memberMedia = [...memberPhotos, ...memberVideos].sort((left, right) =>
+    String(right.sortAt ?? "").localeCompare(String(left.sortAt ?? "")),
+  )
+  const memberMediaIds = new Set(memberMedia.map((photo) => photo.id))
+
   return [
-    ...memberPhotos,
-    ...curatedPhotos.filter((photo) => !memberPhotoIds.has(photo.id)),
+    ...memberMedia,
+    ...curatedPhotos.filter((photo) => !memberMediaIds.has(photo.id)),
   ]
 }
 
@@ -1266,38 +1278,50 @@ async function signedMemberMediaObjectUrl(
   return signed.signedUrl
 }
 
-function memberUploadVideoFromEntity(
+function memberUploadVideoGalleryItemFromEntity(
   entity: ContentEntityRow,
   resolvedWatchUrl: string | null,
-): Video | null {
+): PhotoArchiveItem | null {
   const data = jsonObject(entity.data)
   const youtubeId = stringValue(data, "youtube_id")
   const videoUrl = stringValue(data, "video_url")
-  const watchHref = resolvedWatchUrl ?? videoUrl
+  const watchHref =
+    resolvedWatchUrl ??
+    stringValue(data, "youtube_url") ??
+    videoUrl ??
+    (youtubeId ? `https://www.youtube.com/watch?v=${youtubeId}` : null)
 
   if (!youtubeId && !watchHref) return null
 
-  const parsedTitle = parseVideoTitle(entity.title)
+  const hasPerformanceContext = Boolean(
+    stringValue(data, "artist") ||
+      stringValue(data, "song") ||
+      stringValue(data, "team") ||
+      stringValue(data, "event_title"),
+  )
 
   return {
-    id: youtubeId ?? entity.id,
-    thumbnailUrl: entity.thumbnail_url ?? undefined,
-    watchUrl: youtubeId
-      ? stringValue(data, "youtube_url") ?? videoUrl ?? undefined
-      : (watchHref ?? undefined),
-    artist: stringValue(data, "artist") ?? parsedTitle.artist,
-    song: stringValue(data, "song") ?? parsedTitle.song,
-    raw_title: entity.title,
-    team: stringValue(data, "team") ?? parsedTitle.team,
-    event: stringValue(data, "event_slug") ?? "member-upload",
-    eventLabel: stringValue(data, "event_title") ?? "멤버 제출",
-    duration: stringValue(data, "duration") ?? "video",
-    views: numberValue(data, "views") ?? 0,
-    highlight: false,
+    id: entity.id,
+    kind: "video",
+    title: entity.title,
+    caption:
+      entity.summary ??
+      stringValue(data, "event_title") ??
+      stringValue(data, "team"),
+    category: photoCategoryLabel(
+      stringValue(data, "category") ??
+        (hasPerformanceContext ? "performance" : "daily"),
+    ),
+    aspect: "landscape",
+    thumbnailUrl:
+      entity.thumbnail_url ?? (youtubeId ? youtubeThumbnailUrl(youtubeId, "hq") : null),
+    href: watchHref,
+    duration: stringValue(data, "duration"),
+    sortAt: entity.sort_at,
   }
 }
 
-async function loadPublishedMemberUploadVideos() {
+async function loadPublishedMemberUploadGalleryVideos() {
   if (!hasSupabaseEnv()) return []
 
   const supabase = createPublicClient()
@@ -1324,22 +1348,11 @@ async function loadPublishedMemberUploadVideos() {
   const videos = await Promise.all(
     (entities as ContentEntityRow[]).map(async (entity) => {
       const signedUrl = await signedMemberMediaObjectUrl(supabase, entity)
-      return memberUploadVideoFromEntity(entity, signedUrl)
+      return memberUploadVideoGalleryItemFromEntity(entity, signedUrl)
     }),
   )
 
-  return videos.filter((video): video is Video => Boolean(video))
-}
-
-function mergeVideoArchiveItems(
-  curatedVideos: Video[],
-  memberVideos: Video[],
-) {
-  const videoIds = new Set(curatedVideos.map((video) => video.id))
-  return [
-    ...curatedVideos,
-    ...memberVideos.filter((video) => !videoIds.has(video.id)),
-  ]
+  return videos.filter((video): video is PhotoArchiveItem => Boolean(video))
 }
 
 function homeStatType(value: string | null): HomeCurationStatItem["type"] {
@@ -1670,12 +1683,8 @@ async function loadVideoPageUncached(): Promise<VideoPageContent | null> {
     sectionItems(page, "videos-popular"),
     performanceSlugById,
   )
-  const memberVideos = await loadPublishedMemberUploadVideos()
   const libraryVideos = sortVideoArchive(
-    mergeVideoArchiveItems(
-      videosFromSectionItems(sectionItems(page, "videos-library"), performanceSlugById),
-      memberVideos,
-    ),
+    videosFromSectionItems(sectionItems(page, "videos-library"), performanceSlugById),
   )
 
   return {
@@ -1766,14 +1775,20 @@ export async function loadDraftPreviewPage(
   }
 
   if (page.page.slug === "photos") {
+    const curatedPhotos = sectionItems(page, "photos-gallery")
+      .map((item) => photoFromEntity(item.entity))
+      .filter((photo): photo is PhotoArchiveItem => Boolean(photo))
+    const [memberPhotos, memberVideos] = await Promise.all([
+      loadPublishedMemberUploadPhotos(),
+      loadPublishedMemberUploadGalleryVideos(),
+    ])
+
     return {
       kind: "photos",
       graph: page,
       page: contentPage,
       sections,
-      photos: sectionItems(page, "photos-gallery")
-        .map((item) => photoFromEntity(item.entity))
-        .filter((photo): photo is PhotoArchiveItem => Boolean(photo)),
+      photos: mergePhotoGalleryItems(curatedPhotos, memberPhotos, memberVideos),
     }
   }
 
@@ -1842,18 +1857,22 @@ async function loadPhotoPageUncached(): Promise<PhotoPageContent | null> {
   const curatedPhotos = sectionItems(page, "photos-gallery")
     .map((item) => photoFromEntity(item.entity))
     .filter((photo): photo is PhotoArchiveItem => Boolean(photo))
-  const memberPhotos = await loadPublishedMemberUploadPhotos()
+  const [memberPhotos, memberVideos] = await Promise.all([
+    loadPublishedMemberUploadPhotos(),
+    loadPublishedMemberUploadGalleryVideos(),
+  ])
 
   return {
     page: contentPageFromGraph(page.page),
     sections: page.sections.map((section) => contentSectionFromGraph(section)),
-    photos: mergePhotoGalleryItems(curatedPhotos, memberPhotos),
+    photos: mergePhotoGalleryItems(curatedPhotos, memberPhotos, memberVideos),
   }
 }
 
 async function loadPhotoArchiveUncached() {
   const page = await loadPhotoPage()
-  return page?.photos.length ? page.photos : null
+  const photos = page?.photos.filter((photo) => (photo.kind ?? "photo") === "photo") ?? []
+  return photos.length ? photos : null
 }
 
 async function loadHistoryPageUncached(): Promise<HistoryPageContent | null> {


### PR DESCRIPTION
## Summary

- Keeps `/videos` focused on curated YouTube/archive recordings by removing member-upload video merging and CTAs from the video page.
- Loads public `video/member-upload/v1` entities into the `/photos` gallery feed as playable media cards alongside photos.
- Moves the member video submission CTA/copy to the gallery flow and revalidates `/photos` after video submission/moderation changes.

Closes #202

## Supabase impact

- No schema, RLS, Auth, Storage policy, or migration change.
- Reuses existing `entity_schemas`, `entities`, and `member-media` bucket contracts.

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `pnpm run qa:content-graph`
- `pnpm run qa:legacy-media-table-readiness`
- `pnpm run qa:cms-db-first-loaders`
- `git diff --check`
- `pnpm run build`
- Local smoke: `/photos`, `/videos`, `/members/media` returned 200 on local Next dev server.
- Built HTML check: `영상 올리기` exists on `/photos`; `영상 올리기` and `멤버 공개 기록` do not exist on `/videos`.

## Not tested

- Authenticated real member upload flow was not exercised end-to-end in-browser.