### PR TITLE
Make member uploads feel like gallery compose

### DIFF
--- a/components/member-photo-upload-dialog.tsx
+++ b/components/member-photo-upload-dialog.tsx
@@ -5,6 +5,7 @@ import Link from "next/link"
 import { useRouter } from "next/navigation"
 import {
   useEffect,
+  useMemo,
   useRef,
   useState,
   type ChangeEvent,
@@ -15,9 +16,9 @@ import { createMemberPhotoSubmissionAction } from "@/app/(site)/photos/actions"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
+  DialogClose,
   DialogContent,
   DialogDescription,
-  DialogHeader,
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog"
@@ -32,8 +33,10 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 import { MEMBER_MEDIA_BUCKET } from "@/lib/data/member-media"
 import { createClient } from "@/lib/supabase/client"
+import { cn } from "@/lib/utils"
 
 type AccessState =
   | {
@@ -139,6 +142,7 @@ export function MemberPhotoUploadDialog({
 
   const isUploading = uploadState.kind === "uploading"
   const formDisabled = isUploading || access.state !== "ready"
+  const previewUrl = useMemo(() => (file ? URL.createObjectURL(file) : null), [file])
 
   useEffect(() => {
     if (!open) return
@@ -203,6 +207,12 @@ export function MemberPhotoUploadDialog({
       cancelled = true
     }
   }, [open])
+
+  useEffect(() => {
+    return () => {
+      if (previewUrl) URL.revokeObjectURL(previewUrl)
+    }
+  }, [previewUrl])
 
   function handleFileChange(event: ChangeEvent<HTMLInputElement>) {
     const nextFile = event.currentTarget.files?.[0] ?? null
@@ -336,158 +346,212 @@ export function MemberPhotoUploadDialog({
           사진 올리기
         </Button>
       </DialogTrigger>
-      <DialogContent className="max-h-[min(92vh,52rem)] max-w-3xl overflow-y-auto p-0">
-        <div className="grid md:grid-cols-[0.85fr_1.15fr]">
-          <div className="border-b bg-muted/50 p-6 md:border-b-0 md:border-r md:p-8">
-            <DialogHeader>
-              <p className="caps text-muted-foreground">Gallery Upload</p>
-              <DialogTitle className="font-serif italic text-4xl">
-                Add a photo
-              </DialogTitle>
-              <DialogDescription className="text-base leading-relaxed">
-                브레멘의 순간을 사진 탭에 바로 남깁니다.
+      <DialogContent
+        showCloseButton={false}
+        className="w-[min(96vw,68rem)] max-w-5xl overflow-hidden rounded-3xl p-0 sm:max-w-5xl"
+      >
+        <form onSubmit={handleSubmit} className="flex max-h-[92vh] flex-col">
+          <div className="flex h-14 items-center justify-between border-b px-4 md:px-5">
+            <div>
+              <p className="caps text-muted-foreground">Gallery Compose</p>
+              <DialogTitle className="text-base font-medium">새 사진</DialogTitle>
+              <DialogDescription className="sr-only">
+                사진을 선택하고 캡션과 공개 범위를 정해 갤러리에 올립니다.
               </DialogDescription>
-            </DialogHeader>
-            <div className="mt-8 rounded-md border bg-background/70 p-4 text-sm leading-relaxed text-muted-foreground">
-              {access.state === "loading" && "멤버 정보를 확인하는 중입니다."}
-              {access.state === "anonymous" && (
-                <>
-                  로그인한 활동 멤버만 사진을 올릴 수 있습니다.
-                  <Button asChild className="mt-4 w-full" variant="outline">
-                    <Link href="/login?next=/photos">Sign In</Link>
-                  </Button>
-                </>
-              )}
-              {access.state === "blocked" && access.message}
-              {access.state === "ready" && (
-                <>
-                  <span className="caps mb-2 block text-foreground">
-                    {access.memberLabel}
-                  </span>
-                  전체 공개는 사진 탭에 바로 보이고, 멤버 공개는 활동 멤버만
-                  볼 수 있는 기록으로 남습니다.
-                  <Button asChild className="mt-4 w-full" variant="outline">
-                    <Link href="/members/media">멤버 공개 기록 보기</Link>
-                  </Button>
-                </>
-              )}
+            </div>
+            <div className="flex items-center gap-1">
+              <Button
+                type="submit"
+                variant="ghost"
+                className="rounded-full px-4 font-medium text-accent-foreground"
+                disabled={formDisabled}
+              >
+                {isUploading ? "공유 중" : "공유"}
+              </Button>
+              <DialogClose asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  className="rounded-full"
+                  aria-label="닫기"
+                >
+                  <X weight="light" className="size-4" />
+                </Button>
+              </DialogClose>
             </div>
           </div>
 
-          <form onSubmit={handleSubmit} className="space-y-5 p-6 md:p-8">
-            <div className="space-y-2">
-              <Label htmlFor="member-photo-title">Title</Label>
-              <Input
-                id="member-photo-title"
-                value={title}
-                onChange={(event) => setTitle(event.currentTarget.value)}
-                placeholder="새터 리허설, 공연 끝난 밤..."
-                className="h-11 bg-background/70"
-                maxLength={120}
+          <div className="grid min-h-0 flex-1 overflow-y-auto md:grid-cols-[minmax(0,1.08fr)_25rem] md:overflow-hidden">
+            <div className="flex min-h-[24rem] items-center justify-center bg-stone-950 p-4 md:min-h-[38rem] md:p-8">
+              <input
+                ref={fileInputRef}
+                id="member-photo-file"
+                type="file"
+                accept="image/jpeg,image/png,image/webp,image/gif"
+                className="sr-only"
+                onChange={handleFileChange}
                 disabled={formDisabled}
               />
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="member-photo-caption">Caption</Label>
-              <Textarea
-                id="member-photo-caption"
-                value={caption}
-                onChange={(event) => setCaption(event.currentTarget.value)}
-                placeholder="짧게 남기고 싶은 말"
-                className="min-h-28 bg-background/70"
-                maxLength={1000}
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
                 disabled={formDisabled}
-              />
-            </div>
-
-            <div className="grid gap-4 sm:grid-cols-2">
-              <div className="space-y-2">
-                <Label htmlFor="member-photo-category">Category</Label>
-                <Select
-                  value={category}
-                  onValueChange={setCategory}
-                  disabled={formDisabled}
-                >
-                  <SelectTrigger id="member-photo-category" className="h-11 bg-background/70">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="daily">일상</SelectItem>
-                    <SelectItem value="performance">공연</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="member-photo-aspect">Frame</Label>
-                <Select
-                  value={aspect}
-                  onValueChange={setAspect}
-                  disabled={formDisabled}
-                >
-                  <SelectTrigger id="member-photo-aspect" className="h-11 bg-background/70">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="portrait">세로</SelectItem>
-                    <SelectItem value="landscape">가로</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="member-photo-visibility">Visibility</Label>
-              <Select
-                value={visibility}
-                onValueChange={setVisibility}
-                disabled={formDisabled}
+                className={cn(
+                  "group relative flex w-full max-w-[32rem] items-center justify-center overflow-hidden rounded-[2rem] border border-white/10 bg-stone-900 text-left shadow-2xl transition",
+                  aspect === "landscape" ? "aspect-[4/3]" : "aspect-[4/5]",
+                  !previewUrl && "border-dashed border-white/20 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.14),transparent_42%),linear-gradient(145deg,rgba(255,255,255,0.08),rgba(255,255,255,0.02))]",
+                  !formDisabled && "hover:border-white/40",
+                )}
               >
-                <SelectTrigger
-                  id="member-photo-visibility"
-                  className="h-11 bg-background/70"
-                >
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="public">전체 공개</SelectItem>
-                  <SelectItem value="members">멤버 공개</SelectItem>
-                </SelectContent>
-              </Select>
-              <p className="text-xs leading-relaxed text-muted-foreground">
-                멤버 공개는 로그인한 활동 멤버에게만 보입니다.
-              </p>
+                {previewUrl ? (
+                  // blob URL preview cannot use next/image.
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={previewUrl}
+                    alt="선택한 사진 미리보기"
+                    className="h-full w-full object-cover transition-transform duration-700 group-hover:scale-[1.02]"
+                  />
+                ) : (
+                  <div className="flex flex-col items-center gap-4 text-center text-white">
+                    <div className="grid size-20 place-items-center rounded-3xl bg-white/10 ring-1 ring-white/15">
+                      <ImageSquare weight="light" className="size-10" />
+                    </div>
+                    <div>
+                      <p className="font-serif italic text-3xl">Drop a moment</p>
+                      <p className="mt-2 text-sm text-white/60">
+                        클릭해서 사진을 고릅니다.
+                      </p>
+                    </div>
+                  </div>
+                )}
+                {file && (
+                  <span className="absolute bottom-4 left-4 rounded-full bg-black/55 px-3 py-1 text-xs text-white/80 backdrop-blur">
+                    {file.name} · {formatBytes(file.size)}
+                  </span>
+                )}
+              </button>
             </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="member-photo-file">Photo</Label>
-              <div className="rounded-md border bg-background/70 p-3">
-                <input
-                  ref={fileInputRef}
-                  id="member-photo-file"
-                  type="file"
-                  accept="image/jpeg,image/png,image/webp,image/gif"
-                  className="sr-only"
-                  onChange={handleFileChange}
-                  disabled={formDisabled}
-                />
-                <div className="flex items-center gap-3">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    className="h-9 shrink-0 rounded-full"
-                    onClick={() => fileInputRef.current?.click()}
-                    disabled={formDisabled}
-                  >
-                    <ImageSquare weight="light" className="size-4" />
-                    Choose Photo
-                  </Button>
-                  <p className="min-w-0 flex-1 truncate text-sm text-muted-foreground">
-                    {file ? `${file.name} · ${formatBytes(file.size)}` : "No file selected"}
+            <div className="flex min-h-0 flex-col border-t bg-background md:border-l md:border-t-0">
+              <div className="flex items-center gap-3 border-b px-5 py-4">
+                <div className="grid size-10 place-items-center rounded-full bg-foreground font-serif italic text-background">
+                  B
+                </div>
+                <div className="min-w-0">
+                  <p className="text-sm font-medium">
+                    {access.state === "ready" ? access.memberLabel : "Bremen member"}
                   </p>
-                  {file && (
+                  <p className="text-xs text-muted-foreground">
+                    {access.state === "loading" && "멤버 정보를 확인하는 중"}
+                    {access.state === "anonymous" && "로그인이 필요합니다"}
+                    {access.state === "blocked" && access.message}
+                    {access.state === "ready" && "사진 탭에 남길 순간을 정리합니다"}
+                  </p>
+                </div>
+              </div>
+
+              <div className="min-h-0 flex-1 space-y-5 overflow-y-auto p-5">
+                {access.state === "anonymous" && (
+                  <Button asChild className="w-full rounded-full" variant="outline">
+                    <Link href="/login?next=/photos">Sign In</Link>
+                  </Button>
+                )}
+
+                <div className="space-y-2">
+                  <Label htmlFor="member-photo-title">Title</Label>
+                  <Input
+                    id="member-photo-title"
+                    value={title}
+                    onChange={(event) => setTitle(event.currentTarget.value)}
+                    placeholder="새터 리허설, 공연 끝난 밤..."
+                    className="h-11 rounded-2xl bg-background"
+                    maxLength={120}
+                    disabled={formDisabled}
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="member-photo-caption">Caption</Label>
+                  <Textarea
+                    id="member-photo-caption"
+                    value={caption}
+                    onChange={(event) => setCaption(event.currentTarget.value)}
+                    placeholder="무슨 장면이었나요?"
+                    className="min-h-32 resize-none rounded-2xl bg-background"
+                    maxLength={1000}
+                    disabled={formDisabled}
+                  />
+                </div>
+
+                <div className="grid gap-4">
+                  <div className="space-y-2">
+                    <Label>분류</Label>
+                    <ToggleGroup
+                      type="single"
+                      value={category}
+                      onValueChange={(value) => value && setCategory(value)}
+                      variant="outline"
+                      className="grid w-full grid-cols-2 rounded-full"
+                      disabled={formDisabled}
+                    >
+                      <ToggleGroupItem value="daily" className="rounded-l-full">
+                        일상
+                      </ToggleGroupItem>
+                      <ToggleGroupItem value="performance" className="rounded-r-full">
+                        공연
+                      </ToggleGroupItem>
+                    </ToggleGroup>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label>프레임</Label>
+                    <ToggleGroup
+                      type="single"
+                      value={aspect}
+                      onValueChange={(value) => value && setAspect(value)}
+                      variant="outline"
+                      className="grid w-full grid-cols-2 rounded-full"
+                      disabled={formDisabled}
+                    >
+                      <ToggleGroupItem value="portrait" className="rounded-l-full">
+                        Portrait
+                      </ToggleGroupItem>
+                      <ToggleGroupItem value="landscape" className="rounded-r-full">
+                        Landscape
+                      </ToggleGroupItem>
+                    </ToggleGroup>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="member-photo-visibility">공개 범위</Label>
+                    <Select
+                      value={visibility}
+                      onValueChange={setVisibility}
+                      disabled={formDisabled}
+                    >
+                      <SelectTrigger
+                        id="member-photo-visibility"
+                        className="h-11 rounded-2xl bg-background"
+                      >
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="public">전체 공개</SelectItem>
+                        <SelectItem value="members">멤버 공개</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <p className="text-xs leading-relaxed text-muted-foreground">
+                      멤버 공개는 로그인한 활동 멤버에게만 보입니다.
+                    </p>
+                  </div>
+                </div>
+
+                {file && (
+                  <div className="flex items-center justify-between gap-3 rounded-2xl border bg-muted/35 px-4 py-3">
+                    <p className="min-w-0 truncate text-sm text-muted-foreground">
+                      {file.name} · {formatBytes(file.size)}
+                    </p>
                     <Button
                       type="button"
                       variant="ghost"
@@ -499,82 +563,70 @@ export function MemberPhotoUploadDialog({
                     >
                       <X weight="light" className="size-4" />
                     </Button>
-                  )}
-                </div>
-              </div>
-              <p className="text-xs leading-relaxed text-muted-foreground">
-                jpg, png, webp, gif · 최대 20MB
-              </p>
-            </div>
-
-            {uploadState.kind === "uploading" && (
-              <div className="space-y-2 rounded-md border bg-muted/40 px-4 py-3">
-                <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                  <UploadSimple className="size-4" />
-                  {uploadState.label}
-                </div>
-                <Progress value={66} />
-              </div>
-            )}
-
-            {uploadState.kind === "success" && (
-              <div className="rounded-md border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-950">
-                <div className="flex items-start gap-2">
-                  <CheckCircle
-                    weight="fill"
-                    className="mt-0.5 size-4 shrink-0 text-emerald-700"
-                  />
-                  <div className="min-w-0">
-                    <p className="font-medium">{uploadState.message}</p>
-                    <p className="mt-1 text-xs leading-relaxed text-emerald-900/75">
-                      {publishedPhoto?.visibility === "members"
-                        ? "멤버 공개 기록에서 방금 올린 사진을 확인할 수 있습니다."
-                        : "갤러리 맨 위에서 방금 올린 사진을 확인할 수 있습니다."}
-                    </p>
-                    {publishedPhoto?.visibility === "members" ? (
-                      <Button
-                        asChild
-                        variant="outline"
-                        size="sm"
-                        className="mt-3 rounded-full border-emerald-300 bg-white/70 text-emerald-950 hover:bg-white"
-                      >
-                        <Link href="/members/media">멤버 공개 기록 열기</Link>
-                      </Button>
-                    ) : publishedPhoto ? (
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        className="mt-3 rounded-full border-emerald-300 bg-white/70 text-emerald-950 hover:bg-white"
-                        onClick={() => {
-                          onPublished?.(publishedPhoto)
-                          setOpen(false)
-                        }}
-                      >
-                        갤러리에서 보기
-                      </Button>
-                    ) : null}
                   </div>
-                </div>
+                )}
+
+                {uploadState.kind === "uploading" && (
+                  <div className="space-y-2 rounded-2xl border bg-muted/40 px-4 py-3">
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <UploadSimple className="size-4" />
+                      {uploadState.label}
+                    </div>
+                    <Progress value={66} />
+                  </div>
+                )}
+
+                {uploadState.kind === "success" && (
+                  <div className="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-950">
+                    <div className="flex items-start gap-2">
+                      <CheckCircle
+                        weight="fill"
+                        className="mt-0.5 size-4 shrink-0 text-emerald-700"
+                      />
+                      <div className="min-w-0">
+                        <p className="font-medium">{uploadState.message}</p>
+                        <p className="mt-1 text-xs leading-relaxed text-emerald-900/75">
+                          {publishedPhoto?.visibility === "members"
+                            ? "멤버 공개 기록에서 방금 올린 사진을 확인할 수 있습니다."
+                            : "갤러리 맨 위에서 방금 올린 사진을 확인할 수 있습니다."}
+                        </p>
+                        {publishedPhoto?.visibility === "members" ? (
+                          <Button
+                            asChild
+                            variant="outline"
+                            size="sm"
+                            className="mt-3 rounded-full border-emerald-300 bg-white/70 text-emerald-950 hover:bg-white"
+                          >
+                            <Link href="/members/media">멤버 공개 기록 열기</Link>
+                          </Button>
+                        ) : publishedPhoto ? (
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            className="mt-3 rounded-full border-emerald-300 bg-white/70 text-emerald-950 hover:bg-white"
+                            onClick={() => {
+                              onPublished?.(publishedPhoto)
+                              setOpen(false)
+                            }}
+                          >
+                            갤러리에서 보기
+                          </Button>
+                        ) : null}
+                      </div>
+                    </div>
+                  </div>
+                )}
+
+                {uploadState.kind === "error" && (
+                  <p className="rounded-2xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+                    {uploadState.message}
+                  </p>
+                )}
               </div>
-            )}
-
-            {uploadState.kind === "error" && (
-              <p className="rounded-md border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-                {uploadState.message}
-              </p>
-            )}
-
-            <Button
-              type="submit"
-              size="lg"
-              className="w-full"
-              disabled={formDisabled}
-            >
-              {isUploading ? "Publishing..." : "Publish to Gallery"}
-            </Button>
-          </form>
-        </div>
+            </div>
+          </div>
+        </form>
       </DialogContent>
     </Dialog>
   )

--- a/components/member-video-submit-dialog.tsx
+++ b/components/member-video-submit-dialog.tsx
@@ -1,10 +1,18 @@
 "use client"
 
-import { FilmSlate, LinkSimple, UploadSimple, X } from "@phosphor-icons/react"
+import {
+  CaretDown,
+  CheckCircle,
+  FilmSlate,
+  LinkSimple,
+  UploadSimple,
+  X,
+} from "@phosphor-icons/react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import {
   useEffect,
+  useMemo,
   useRef,
   useState,
   type ChangeEvent,
@@ -14,10 +22,15 @@ import {
 import { createMemberVideoSubmissionAction } from "@/app/(site)/videos/actions"
 import { Button } from "@/components/ui/button"
 import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible"
+import {
   Dialog,
+  DialogClose,
   DialogContent,
   DialogDescription,
-  DialogHeader,
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog"
@@ -35,6 +48,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Textarea } from "@/components/ui/textarea"
 import { MEMBER_MEDIA_BUCKET } from "@/lib/data/member-media"
 import { createClient } from "@/lib/supabase/client"
+import { cn } from "@/lib/utils"
 
 type AccessState =
   | {
@@ -118,12 +132,42 @@ function isHttpUrl(value: string) {
   }
 }
 
+function youtubeIdFromUrl(value: string) {
+  try {
+    const url = new URL(value)
+    const host = url.hostname.replace(/^www\./, "")
+
+    if (host === "youtu.be") {
+      return url.pathname.split("/").filter(Boolean)[0] ?? null
+    }
+
+    if (host === "youtube.com" || host === "m.youtube.com") {
+      if (url.pathname === "/watch") return url.searchParams.get("v")
+
+      const parts = url.pathname.split("/").filter(Boolean)
+      if (parts[0] === "shorts" || parts[0] === "embed") {
+        return parts[1] ?? null
+      }
+    }
+  } catch {
+    return null
+  }
+
+  return null
+}
+
+function youtubeThumbnailFromUrl(value: string) {
+  const id = youtubeIdFromUrl(value)
+  return id ? `https://i.ytimg.com/vi/${id}/hqdefault.jpg` : null
+}
+
 export function MemberVideoSubmitDialog() {
   const router = useRouter()
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [open, setOpen] = useState(false)
   const [access, setAccess] = useState<AccessState>({ state: "idle" })
   const [sourceMode, setSourceMode] = useState<"url" | "file">("url")
+  const [advancedOpen, setAdvancedOpen] = useState(false)
   const [visibility, setVisibility] = useState("public")
   const [title, setTitle] = useState("")
   const [description, setDescription] = useState("")
@@ -138,6 +182,8 @@ export function MemberVideoSubmitDialog() {
 
   const isUploading = submitState.kind === "uploading"
   const formDisabled = isUploading || access.state !== "ready"
+  const urlPreview = sourceMode === "url" ? youtubeThumbnailFromUrl(videoUrl) : null
+  const previewUrl = useMemo(() => (file ? URL.createObjectURL(file) : null), [file])
 
   useEffect(() => {
     if (!open) return
@@ -203,8 +249,15 @@ export function MemberVideoSubmitDialog() {
     }
   }, [open])
 
+  useEffect(() => {
+    return () => {
+      if (previewUrl) URL.revokeObjectURL(previewUrl)
+    }
+  }, [previewUrl])
+
   function resetForm() {
     setSourceMode("url")
+    setAdvancedOpen(false)
     setVisibility("public")
     setTitle("")
     setDescription("")
@@ -341,6 +394,10 @@ export function MemberVideoSubmitDialog() {
     router.refresh()
   }
 
+  const hasFilePreview = sourceMode === "file" && Boolean(previewUrl)
+  const hasUrlPreview = sourceMode === "url" && Boolean(urlPreview)
+  const canPickFile = sourceMode === "file" && !formDisabled
+
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
@@ -349,266 +406,363 @@ export function MemberVideoSubmitDialog() {
           영상 올리기
         </Button>
       </DialogTrigger>
-      <DialogContent className="max-h-[min(92vh,54rem)] max-w-4xl overflow-y-auto p-0">
-        <div className="grid md:grid-cols-[0.85fr_1.15fr]">
-          <div className="border-b bg-muted/50 p-6 md:border-b-0 md:border-r md:p-8">
-            <DialogHeader>
-              <p className="caps text-muted-foreground">Video Submission</p>
-              <DialogTitle className="font-serif italic text-4xl">
-                Add a clip
-              </DialogTitle>
-              <DialogDescription className="text-base leading-relaxed">
-                공연 뒤풀이, 연습실, 무대의 짧은 순간을 갤러리에 남깁니다.
+      <DialogContent
+        showCloseButton={false}
+        className="w-[min(96vw,68rem)] max-w-5xl overflow-hidden rounded-3xl p-0 sm:max-w-5xl"
+      >
+        <form onSubmit={handleSubmit} className="flex max-h-[92vh] flex-col">
+          <div className="flex h-14 items-center justify-between border-b px-4 md:px-5">
+            <div>
+              <p className="caps text-muted-foreground">Gallery Compose</p>
+              <DialogTitle className="text-base font-medium">새 영상</DialogTitle>
+              <DialogDescription className="sr-only">
+                영상 링크나 파일을 선택하고 캡션과 공개 범위를 정해 갤러리에 남깁니다.
               </DialogDescription>
-            </DialogHeader>
-            <div className="mt-8 rounded-md border bg-background/70 p-4 text-sm leading-relaxed text-muted-foreground">
-              {access.state === "loading" && "멤버 정보를 확인하는 중입니다."}
-              {access.state === "anonymous" && (
-                <>
-                  로그인한 활동 멤버만 영상을 제출할 수 있습니다.
-                  <Button asChild className="mt-4 w-full" variant="outline">
-                    <Link href="/login?next=/photos">Sign In</Link>
-                  </Button>
-                </>
-              )}
-              {access.state === "blocked" && access.message}
-              {access.state === "ready" && (
-                <>
-                  <span className="caps mb-2 block text-foreground">
-                    {access.memberLabel}
-                  </span>
-                  제출한 영상은 바로 공개되지 않습니다. 확인이 끝나면 선택한 공개
-                  범위에 맞춰 갤러리에 반영됩니다.
-                  <Button asChild className="mt-4 w-full" variant="outline">
-                    <Link href="/members/media">멤버 공개 기록 보기</Link>
-                  </Button>
-                </>
-              )}
+            </div>
+            <div className="flex items-center gap-1">
+              <Button
+                type="submit"
+                variant="ghost"
+                className="rounded-full px-4 font-medium"
+                disabled={formDisabled}
+              >
+                {isUploading ? "제출 중" : "제출"}
+              </Button>
+              <DialogClose asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  className="rounded-full"
+                  aria-label="닫기"
+                >
+                  <X weight="light" className="size-4" />
+                </Button>
+              </DialogClose>
             </div>
           </div>
 
-          <form onSubmit={handleSubmit} className="space-y-5 p-6 md:p-8">
-            <Tabs
-              value={sourceMode}
-              onValueChange={(value) => setSourceMode(value as "url" | "file")}
-            >
-              <TabsList className="grid w-full grid-cols-2">
-                <TabsTrigger value="url" disabled={isUploading}>
-                  영상 링크
-                </TabsTrigger>
-                <TabsTrigger value="file" disabled={isUploading}>
-                  파일 업로드
-                </TabsTrigger>
-              </TabsList>
-              <TabsContent value="url" className="mt-4 space-y-2">
-                <Label htmlFor="member-video-url">Video URL</Label>
-                <div className="relative">
-                  <LinkSimple
-                    weight="light"
-                    className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+          <div className="grid min-h-0 flex-1 overflow-y-auto md:grid-cols-[minmax(0,1.08fr)_25rem] md:overflow-hidden">
+            <div className="flex min-h-[24rem] items-center justify-center bg-stone-950 p-4 md:min-h-[38rem] md:p-8">
+              <input
+                ref={fileInputRef}
+                id="member-video-file"
+                type="file"
+                accept="video/mp4,video/webm,video/quicktime"
+                className="sr-only"
+                onChange={handleFileChange}
+                disabled={formDisabled || sourceMode !== "file"}
+              />
+              <button
+                type="button"
+                onClick={() => {
+                  if (canPickFile) fileInputRef.current?.click()
+                }}
+                disabled={sourceMode === "file" ? formDisabled : true}
+                className={cn(
+                  "group relative flex aspect-[4/5] w-full max-w-[32rem] items-center justify-center overflow-hidden rounded-[2rem] border border-white/10 bg-stone-900 text-left shadow-2xl md:aspect-[4/3]",
+                  !hasFilePreview &&
+                    !hasUrlPreview &&
+                    "border-dashed border-white/20 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.14),transparent_42%),linear-gradient(145deg,rgba(255,255,255,0.08),rgba(255,255,255,0.02))]",
+                  canPickFile && "transition hover:border-white/40",
+                )}
+              >
+                {hasFilePreview && previewUrl ? (
+                  <video
+                    src={previewUrl}
+                    controls
+                    muted
+                    className="h-full w-full object-cover"
                   />
-                  <Input
-                    id="member-video-url"
-                    value={videoUrl}
-                    onChange={(event) => setVideoUrl(event.currentTarget.value)}
-                    placeholder="YouTube, Vimeo, 공유 가능한 영상 링크"
-                    className="h-11 bg-background/70 pl-9"
-                    disabled={formDisabled || sourceMode !== "url"}
+                ) : hasUrlPreview && urlPreview ? (
+                  // YouTube thumbnail URL is remote and user-entered, so keep it as a plain image.
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={urlPreview}
+                    alt="영상 링크 미리보기"
+                    className="h-full w-full object-cover transition-transform duration-700 group-hover:scale-[1.02]"
                   />
+                ) : (
+                  <div className="flex flex-col items-center gap-4 text-center text-white">
+                    <div className="grid size-20 place-items-center rounded-3xl bg-white/10 ring-1 ring-white/15">
+                      {sourceMode === "url" ? (
+                        <LinkSimple weight="light" className="size-10" />
+                      ) : (
+                        <FilmSlate weight="light" className="size-10" />
+                      )}
+                    </div>
+                    <div>
+                      <p className="font-serif italic text-3xl">Add a clip</p>
+                      <p className="mt-2 max-w-64 text-sm text-white/60">
+                        {sourceMode === "url"
+                          ? "오른쪽에 공유 링크를 붙이면 미리보기가 잡힙니다."
+                          : "클릭해서 영상 파일을 고릅니다."}
+                      </p>
+                    </div>
+                  </div>
+                )}
+                {file && sourceMode === "file" && (
+                  <span className="absolute bottom-4 left-4 rounded-full bg-black/55 px-3 py-1 text-xs text-white/80 backdrop-blur">
+                    {file.name} · {formatBytes(file.size)}
+                  </span>
+                )}
+              </button>
+            </div>
+
+            <div className="flex min-h-0 flex-col border-t bg-background md:border-l md:border-t-0">
+              <div className="flex items-center gap-3 border-b px-5 py-4">
+                <div className="grid size-10 place-items-center rounded-full bg-foreground font-serif italic text-background">
+                  B
                 </div>
-              </TabsContent>
-              <TabsContent value="file" className="mt-4 space-y-2">
-                <Label htmlFor="member-video-file">Video File</Label>
-                <div className="rounded-md border bg-background/70 p-3">
-                  <input
-                    ref={fileInputRef}
-                    id="member-video-file"
-                    type="file"
-                    accept="video/mp4,video/webm,video/quicktime"
-                    className="sr-only"
-                    onChange={handleFileChange}
-                    disabled={formDisabled || sourceMode !== "file"}
-                  />
-                  <div className="flex items-center gap-3">
+                <div className="min-w-0">
+                  <p className="text-sm font-medium">
+                    {access.state === "ready" ? access.memberLabel : "Bremen member"}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {access.state === "loading" && "멤버 정보를 확인하는 중"}
+                    {access.state === "anonymous" && "로그인이 필요합니다"}
+                    {access.state === "blocked" && access.message}
+                    {access.state === "ready" && "갤러리에 남길 영상을 정리합니다"}
+                  </p>
+                </div>
+              </div>
+
+              <div className="min-h-0 flex-1 space-y-5 overflow-y-auto p-5">
+                {access.state === "anonymous" && (
+                  <Button asChild className="w-full rounded-full" variant="outline">
+                    <Link href="/login?next=/photos">Sign In</Link>
+                  </Button>
+                )}
+
+                <Tabs
+                  value={sourceMode}
+                  onValueChange={(value) => setSourceMode(value as "url" | "file")}
+                >
+                  <TabsList className="grid w-full grid-cols-2 rounded-full">
+                    <TabsTrigger value="url" className="rounded-full" disabled={isUploading}>
+                      링크
+                    </TabsTrigger>
+                    <TabsTrigger value="file" className="rounded-full" disabled={isUploading}>
+                      파일
+                    </TabsTrigger>
+                  </TabsList>
+                  <TabsContent value="url" className="mt-4 space-y-2">
+                    <Label htmlFor="member-video-url">Video URL</Label>
+                    <div className="relative">
+                      <LinkSimple
+                        weight="light"
+                        className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+                      />
+                      <Input
+                        id="member-video-url"
+                        value={videoUrl}
+                        onChange={(event) => setVideoUrl(event.currentTarget.value)}
+                        placeholder="YouTube, Vimeo, 공유 가능한 영상 링크"
+                        className="h-11 rounded-2xl bg-background pl-9"
+                        disabled={formDisabled || sourceMode !== "url"}
+                      />
+                    </div>
+                  </TabsContent>
+                  <TabsContent value="file" className="mt-4 space-y-2">
                     <Button
                       type="button"
                       variant="outline"
-                      size="sm"
-                      className="h-9 shrink-0 rounded-full"
+                      className="w-full rounded-full"
                       onClick={() => fileInputRef.current?.click()}
                       disabled={formDisabled || sourceMode !== "file"}
                     >
                       <FilmSlate weight="light" className="size-4" />
-                      Choose Video
+                      영상 파일 선택
                     </Button>
-                    <p className="min-w-0 flex-1 truncate text-sm text-muted-foreground">
-                      {file ? `${file.name} · ${formatBytes(file.size)}` : "No file selected"}
+                    <p className="text-xs leading-relaxed text-muted-foreground">
+                      mp4, webm, mov · 최대 100MB
                     </p>
-                    {file && (
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon-sm"
-                        className="shrink-0 rounded-full"
-                        aria-label="Clear selected video"
-                        onClick={clearFile}
-                        disabled={isUploading}
-                      >
-                        <X weight="light" className="size-4" />
-                      </Button>
-                    )}
-                  </div>
-                </div>
-                <p className="text-xs leading-relaxed text-muted-foreground">
-                  mp4, webm, mov · 최대 100MB
-                </p>
-              </TabsContent>
-            </Tabs>
+                  </TabsContent>
+                </Tabs>
 
-            <div className="grid gap-4 sm:grid-cols-[1fr_12rem]">
-              <div className="space-y-2">
-                <Label htmlFor="member-video-title">Title</Label>
-                <Input
-                  id="member-video-title"
-                  value={title}
-                  onChange={(event) => setTitle(event.currentTarget.value)}
-                  placeholder="빨간 피터, 새터 리허설..."
-                  className="h-11 bg-background/70"
-                  maxLength={120}
-                  disabled={formDisabled}
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="member-video-visibility">공개 범위</Label>
-                <Select
-                  value={visibility}
-                  onValueChange={setVisibility}
-                  disabled={formDisabled}
-                >
-                  <SelectTrigger
-                    id="member-video-visibility"
-                    className="h-11 bg-background/70"
+                <div className="space-y-2">
+                  <Label htmlFor="member-video-title">Title</Label>
+                  <Input
+                    id="member-video-title"
+                    value={title}
+                    onChange={(event) => setTitle(event.currentTarget.value)}
+                    placeholder="빨간 피터, 새터 리허설..."
+                    className="h-11 rounded-2xl bg-background"
+                    maxLength={120}
+                    disabled={formDisabled}
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="member-video-description">Caption</Label>
+                  <Textarea
+                    id="member-video-description"
+                    value={description}
+                    onChange={(event) => setDescription(event.currentTarget.value)}
+                    placeholder="무슨 장면이었나요?"
+                    className="min-h-32 resize-none rounded-2xl bg-background"
+                    maxLength={1000}
+                    disabled={formDisabled}
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="member-video-visibility">공개 범위</Label>
+                  <Select
+                    value={visibility}
+                    onValueChange={setVisibility}
+                    disabled={formDisabled}
                   >
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="public">전체 공개</SelectItem>
-                    <SelectItem value="members">멤버 공개</SelectItem>
-                    <SelectItem value="private">비공개</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="member-video-description">Description</Label>
-              <Textarea
-                id="member-video-description"
-                value={description}
-                onChange={(event) => setDescription(event.currentTarget.value)}
-                placeholder="영상에 함께 남길 짧은 설명"
-                className="min-h-24 bg-background/70"
-                maxLength={1000}
-                disabled={formDisabled}
-              />
-            </div>
-
-            <div className="grid gap-4 sm:grid-cols-2">
-              <div className="space-y-2">
-                <Label htmlFor="member-video-artist">Artist</Label>
-                <Input
-                  id="member-video-artist"
-                  value={artist}
-                  onChange={(event) => setArtist(event.currentTarget.value)}
-                  placeholder="쏜애플"
-                  className="h-11 bg-background/70"
-                  maxLength={120}
-                  disabled={formDisabled}
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="member-video-song">Song</Label>
-                <Input
-                  id="member-video-song"
-                  value={song}
-                  onChange={(event) => setSong(event.currentTarget.value)}
-                  placeholder="빨간 피터"
-                  className="h-11 bg-background/70"
-                  maxLength={160}
-                  disabled={formDisabled}
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="member-video-team">Team</Label>
-                <Input
-                  id="member-video-team"
-                  value={team}
-                  onChange={(event) => setTeam(event.currentTarget.value)}
-                  placeholder="팀명 또는 무대"
-                  className="h-11 bg-background/70"
-                  maxLength={120}
-                  disabled={formDisabled}
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="member-video-event">Event</Label>
-                <Input
-                  id="member-video-event"
-                  value={eventTitle}
-                  onChange={(event) => setEventTitle(event.currentTarget.value)}
-                  placeholder="2026 신환공"
-                  className="h-11 bg-background/70"
-                  maxLength={140}
-                  disabled={formDisabled}
-                />
-              </div>
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="member-video-duration">Duration</Label>
-              <Input
-                id="member-video-duration"
-                value={duration}
-                onChange={(event) => setDuration(event.currentTarget.value)}
-                placeholder="4:44"
-                className="h-11 bg-background/70"
-                maxLength={32}
-                disabled={formDisabled}
-              />
-            </div>
-
-            {submitState.kind === "uploading" && (
-              <div className="space-y-2 rounded-md border bg-muted/40 px-4 py-3">
-                <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                  <UploadSimple className="size-4" />
-                  {submitState.label}
+                    <SelectTrigger
+                      id="member-video-visibility"
+                      className="h-11 rounded-2xl bg-background"
+                    >
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="public">전체 공개</SelectItem>
+                      <SelectItem value="members">멤버 공개</SelectItem>
+                      <SelectItem value="private">비공개</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs leading-relaxed text-muted-foreground">
+                    영상은 확인 후 선택한 공개 범위로 보입니다.
+                  </p>
                 </div>
-                <Progress value={sourceMode === "file" ? 66 : 45} />
+
+                <Collapsible open={advancedOpen} onOpenChange={setAdvancedOpen}>
+                  <CollapsibleTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      className="w-full justify-between rounded-2xl border px-4"
+                    >
+                      공연 정보 더 적기
+                      <CaretDown
+                        weight="light"
+                        className={cn(
+                          "size-4 transition-transform",
+                          advancedOpen && "rotate-180",
+                        )}
+                      />
+                    </Button>
+                  </CollapsibleTrigger>
+                  <CollapsibleContent className="mt-4 space-y-4">
+                    <div className="grid gap-4 sm:grid-cols-2">
+                      <div className="space-y-2">
+                        <Label htmlFor="member-video-artist">Artist</Label>
+                        <Input
+                          id="member-video-artist"
+                          value={artist}
+                          onChange={(event) => setArtist(event.currentTarget.value)}
+                          placeholder="쏜애플"
+                          className="h-11 rounded-2xl bg-background"
+                          maxLength={120}
+                          disabled={formDisabled}
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="member-video-song">Song</Label>
+                        <Input
+                          id="member-video-song"
+                          value={song}
+                          onChange={(event) => setSong(event.currentTarget.value)}
+                          placeholder="빨간 피터"
+                          className="h-11 rounded-2xl bg-background"
+                          maxLength={160}
+                          disabled={formDisabled}
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="member-video-team">Team</Label>
+                        <Input
+                          id="member-video-team"
+                          value={team}
+                          onChange={(event) => setTeam(event.currentTarget.value)}
+                          placeholder="팀명 또는 무대"
+                          className="h-11 rounded-2xl bg-background"
+                          maxLength={120}
+                          disabled={formDisabled}
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="member-video-event">Event</Label>
+                        <Input
+                          id="member-video-event"
+                          value={eventTitle}
+                          onChange={(event) => setEventTitle(event.currentTarget.value)}
+                          placeholder="2026 신환공"
+                          className="h-11 rounded-2xl bg-background"
+                          maxLength={140}
+                          disabled={formDisabled}
+                        />
+                      </div>
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="member-video-duration">Duration</Label>
+                      <Input
+                        id="member-video-duration"
+                        value={duration}
+                        onChange={(event) => setDuration(event.currentTarget.value)}
+                        placeholder="4:44"
+                        className="h-11 rounded-2xl bg-background"
+                        maxLength={32}
+                        disabled={formDisabled}
+                      />
+                    </div>
+                  </CollapsibleContent>
+                </Collapsible>
+
+                {file && sourceMode === "file" && (
+                  <div className="flex items-center justify-between gap-3 rounded-2xl border bg-muted/35 px-4 py-3">
+                    <p className="min-w-0 truncate text-sm text-muted-foreground">
+                      {file.name} · {formatBytes(file.size)}
+                    </p>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-sm"
+                      className="shrink-0 rounded-full"
+                      aria-label="Clear selected video"
+                      onClick={clearFile}
+                      disabled={isUploading}
+                    >
+                      <X weight="light" className="size-4" />
+                    </Button>
+                  </div>
+                )}
+
+                {submitState.kind === "uploading" && (
+                  <div className="space-y-2 rounded-2xl border bg-muted/40 px-4 py-3">
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <UploadSimple className="size-4" />
+                      {submitState.label}
+                    </div>
+                    <Progress value={sourceMode === "file" ? 66 : 45} />
+                  </div>
+                )}
+
+                {submitState.kind === "success" && (
+                  <div className="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-950">
+                    <div className="flex items-start gap-2">
+                      <CheckCircle
+                        weight="fill"
+                        className="mt-0.5 size-4 shrink-0 text-emerald-700"
+                      />
+                      <p className="font-medium">{submitState.message}</p>
+                    </div>
+                  </div>
+                )}
+
+                {submitState.kind === "error" && (
+                  <p className="rounded-2xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+                    {submitState.message}
+                  </p>
+                )}
               </div>
-            )}
-
-            {submitState.kind === "success" && (
-              <p className="rounded-md border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-950">
-                {submitState.message}
-              </p>
-            )}
-
-            {submitState.kind === "error" && (
-              <p className="rounded-md border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-                {submitState.message}
-              </p>
-            )}
-
-            <Button
-              type="submit"
-              size="lg"
-              className="w-full"
-              disabled={formDisabled}
-            >
-              {isUploading ? "Submitting..." : "Submit clip"}
-            </Button>
-          </form>
-        </div>
+            </div>
+          </div>
+        </form>
       </DialogContent>
     </Dialog>
   )


### PR DESCRIPTION
## Summary

- Replaces the photo upload dialog with a preview-first gallery compose modal.
- Replaces the video upload dialog with the same compose shell, URL/file tabs, URL thumbnail preview, and collapsed advanced performance metadata.
- Keeps auth checks, storage paths, validation limits, action payloads, visibility semantics, and moderation behavior unchanged.

Closes #204

## Supabase impact

- No schema, RLS, Auth, Storage policy, or migration change.
- Existing `member-media` upload flow and server actions are preserved.

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `pnpm run qa:cms-native-controls`
- `git diff --check`
- `pnpm run build`
- Local `/photos` returned 200.
- cmux browser opened photo and video compose dialogs.
- Video URL preview and wide modal dimensions verified by screenshot/DOM box checks.

## Not tested

- Real file picker upload was not submitted end-to-end to Supabase Storage in this commit.