### PR TITLE
Publish member-only photo uploads

### DIFF
--- a/app/(site)/photos/actions.ts
+++ b/app/(site)/photos/actions.ts
@@ -29,6 +29,8 @@ type CreateMemberPhotoSubmissionResult =
   | {
       ok: true
       entityId: string
+      published: boolean
+      visibility: PhotoVisibility
     }
   | {
       ok: false
@@ -191,7 +193,7 @@ export async function createMemberPhotoSubmissionAction(
   const { data: entity, error: entityError } = await supabase
     .from("entities")
     .insert(insert)
-    .select("id")
+    .select("id, published, visibility")
     .single()
 
   if (entityError || !entity) {
@@ -208,5 +210,7 @@ export async function createMemberPhotoSubmissionAction(
   return {
     ok: true,
     entityId: entity.id,
+    published: entity.published,
+    visibility: entity.visibility as PhotoVisibility,
   }
 }

--- a/components/member-photo-upload-dialog.tsx
+++ b/components/member-photo-upload-dialog.tsx
@@ -138,6 +138,7 @@ export function MemberPhotoUploadDialog({
     entityId: string
     title: string
     visibility: string
+    published: boolean
   } | null>(null)
 
   const isUploading = uploadState.kind === "uploading"
@@ -322,7 +323,8 @@ export function MemberPhotoUploadDialog({
     const published = {
       entityId: result.entityId,
       title: cleanTitle,
-      visibility,
+      visibility: result.visibility,
+      published: result.published,
     }
 
     resetForm()
@@ -330,7 +332,9 @@ export function MemberPhotoUploadDialog({
     setUploadState({
       kind: "success",
       message:
-        visibility === "members"
+        !result.published
+          ? `"${cleanTitle}"이 제출되었습니다. 확인이 끝나면 선택한 공개 범위로 보입니다.`
+          : result.visibility === "members"
           ? `"${cleanTitle}"이 멤버 공개 기록에 올라갔습니다.`
           : `"${cleanTitle}"이 사진 탭에 올라갔습니다.`,
     })
@@ -586,11 +590,14 @@ export function MemberPhotoUploadDialog({
                       <div className="min-w-0">
                         <p className="font-medium">{uploadState.message}</p>
                         <p className="mt-1 text-xs leading-relaxed text-emerald-900/75">
-                          {publishedPhoto?.visibility === "members"
+                          {!publishedPhoto?.published
+                            ? "관리자가 확인한 뒤 선택한 공개 범위에 맞춰 보입니다."
+                            : publishedPhoto.visibility === "members"
                             ? "멤버 공개 기록에서 방금 올린 사진을 확인할 수 있습니다."
                             : "갤러리 맨 위에서 방금 올린 사진을 확인할 수 있습니다."}
                         </p>
-                        {publishedPhoto?.visibility === "members" ? (
+                        {publishedPhoto?.published &&
+                        publishedPhoto.visibility === "members" ? (
                           <Button
                             asChild
                             variant="outline"
@@ -599,7 +606,7 @@ export function MemberPhotoUploadDialog({
                           >
                             <Link href="/members/media">멤버 공개 기록 열기</Link>
                           </Button>
-                        ) : publishedPhoto ? (
+                        ) : publishedPhoto?.published ? (
                           <Button
                             type="button"
                             variant="outline"

--- a/docs/content-graph.md
+++ b/docs/content-graph.md
@@ -265,10 +265,10 @@ Photo tab uploads use the browser Supabase client for the file transfer and a
 server action only for the entity row. This avoids sending large files through
 Next.js Server Actions while still letting Storage RLS verify the logged-in
 member. Active approved members create `photo/member-upload/v1` entities with
-`published = true`, `visibility = public`, and `gallery_include = true`, so
-their photos enter the public gallery without a manual section relation.
-Post-moderation remains possible in PONIX by hiding, editing, or deleting the
-entity.
+`published = true`, `gallery_include = true`, and either `visibility = public`
+or `visibility = members`. Public photos enter `/photos`; member-only photos
+enter `/members/media`. Post-moderation remains possible in PONIX by hiding,
+editing, or deleting the entity.
 
 ## Members Are Not Generic Entities
 

--- a/docs/supabase-setup.md
+++ b/docs/supabase-setup.md
@@ -208,12 +208,12 @@ Member-facing uploads should use the browser Supabase client for the Storage
 upload, then call a server action to create the entity row. Do not proxy direct
 photo/video file bodies through a Server Action unless the file size is known to
 stay below the configured body limit. Photos submitted from `/photos` are
-published immediately for active approved members; moderation happens afterward
-through the entity's `published` and `visibility` fields. The
-`capture_owned_content()` trigger allows that immediate publish path only for
-`photo/member-upload/v1` inserts with `visibility = 'public'` and
-`gallery_include = true`; other member-owned entities still cannot be
-self-published.
+published immediately for active approved members when they target `public` or
+`members` visibility; moderation happens afterward through the entity's
+`published` and `visibility` fields. The `capture_owned_content()` trigger
+allows that immediate publish path only for `photo/member-upload/v1` inserts
+with `visibility in ('public', 'members')` and `gallery_include = true`; other
+member-owned entities still cannot be self-published.
 
 Public Storage buckets still exist for assets that are meant to be public:
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "qa:legacy-mirror-readiness": "node scripts/qa-legacy-mirror-readiness.mjs",
     "qa:legacy-mirror-stage5-preflight": "node scripts/qa-legacy-mirror-readiness.mjs --fail-before-stage 5",
     "qa:member-media-compose-ui": "node scripts/qa-member-media-compose-ui.mjs",
+    "qa:member-media-publication-guard": "node scripts/qa-member-media-publication-guard.mjs",
     "qa:schema-mirror-removal-readiness": "node scripts/qa-schema-mirror-removal-readiness.mjs",
     "qa:schema-semantic-identity": "node scripts/qa-schema-semantic-identity.mjs"
   },

--- a/scripts/qa-member-media-publication-guard.mjs
+++ b/scripts/qa-member-media-publication-guard.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs"
+
+const files = {
+  migration:
+    "supabase/migrations/20260520000068_allow_member_only_photo_publication.sql",
+  storageMigration:
+    "supabase/migrations/20260515132021_ugc_visibility_storage_guardrails.sql",
+  photoAction: "app/(site)/photos/actions.ts",
+  videoAction: "app/(site)/videos/actions.ts",
+  photoDialog: "components/member-photo-upload-dialog.tsx",
+  supabaseDocs: "docs/supabase-setup.md",
+  contentGraphDocs: "docs/content-graph.md",
+}
+
+const sources = Object.fromEntries(
+  Object.entries(files).map(([key, file]) => {
+    if (!existsSync(file)) {
+      throw new Error(`Missing required file: ${file}`)
+    }
+
+    return [key, readFileSync(file, "utf8")]
+  }),
+)
+
+const checks = []
+
+function addCheck(area, label, passed, detail) {
+  checks.push({
+    area,
+    label,
+    status: passed ? "ok" : "fail",
+    detail,
+  })
+}
+
+function includes(area, source, needle, label) {
+  addCheck(area, label, source.includes(needle), `expected ${JSON.stringify(needle)}`)
+}
+
+function excludes(area, source, needle, label) {
+  addCheck(area, label, !source.includes(needle), `blocked ${JSON.stringify(needle)}`)
+}
+
+function matches(area, source, pattern, label) {
+  addCheck(area, label, pattern.test(source), `expected ${pattern}`)
+}
+
+function runSelfTest() {
+  const sample = "schema_key = 'photo/member-upload/v1' and new.visibility in ('public', 'members')"
+  const beforeChecks = checks.length
+
+  includes("self-test", sample, "photo/member-upload/v1", "include guard")
+  excludes("self-test", sample, "drop table", "exclude guard")
+  matches("self-test", sample, /new\.visibility\s+in \('public', 'members'\)/, "regex guard")
+
+  const selfTestChecks = checks.splice(beforeChecks)
+  if (selfTestChecks.some((check) => check.status !== "ok")) {
+    throw new Error("Self-test failed for member media publication guard.")
+  }
+}
+
+runSelfTest()
+
+const {
+  migration,
+  storageMigration,
+  photoAction,
+  videoAction,
+  photoDialog,
+  supabaseDocs,
+  contentGraphDocs,
+} = sources
+
+const forbiddenSqlPatterns = [
+  /drop\s+schema/i,
+  /drop\s+table/i,
+  /truncate\b/i,
+  /disable\s+row\s+level\s+security/i,
+  /delete\s+from\s+storage\.objects/i,
+  /public\s*=\s*true/i,
+]
+
+for (const pattern of forbiddenSqlPatterns) {
+  addCheck(
+    "migration safety",
+    `does not contain ${pattern}`,
+    !pattern.test(migration),
+    `blocked ${pattern}`,
+  )
+}
+
+includes("migration", migration, "create or replace function public.capture_owned_content()", "updates owned-content trigger function")
+includes("migration", migration, "schema_key = 'photo/member-upload/v1'", "limits self-publish exception to member photos")
+includes("migration", migration, "private.is_active_member()", "requires active approved member")
+includes("migration", migration, "new.visibility in ('public', 'members')", "allows public and member-only photo publication")
+includes("migration", migration, "new.data->>'gallery_include' = 'true'", "requires gallery include flag")
+includes("migration", migration, "new.published := is_publishable_member_photo", "derives publish state from guard")
+includes("migration", migration, "old.published = false and new.published = true", "keeps non-admin publish escalation blocked on update")
+excludes("migration", migration, "video/member-upload/v1", "does not self-publish member video uploads")
+excludes("migration", migration, "'private'", "does not self-publish private visibility")
+
+includes("storage guardrails", storageMigration, "values (\n  'member-media'", "keeps private member media bucket")
+includes("storage guardrails", storageMigration, "set public = false", "keeps member media bucket private")
+includes("storage guardrails", storageMigration, "private.can_read_member_media_object(name)", "reads member media through entity visibility")
+includes("storage guardrails", storageMigration, "private.is_active_member()", "requires active member for uploads")
+includes("storage guardrails", storageMigration, "(storage.foldername(name))[1] = (select auth.uid()::text)", "scopes uploads to user folder")
+includes("storage guardrails", storageMigration, "(storage.foldername(name))[2] in ('photos', 'videos')", "limits member media folders")
+
+includes("photo action", photoAction, 'type PhotoVisibility = "public" | "members"', "photo action allows public/member visibility only")
+includes("photo action", photoAction, "validPhotoPath(input.storagePath, user.id)", "validates photo storage path against auth user")
+includes("photo action", photoAction, "createSignedUrl(input.storagePath, 60)", "verifies uploaded object exists before entity insert")
+includes("photo action", photoAction, "gallery_include: true", "marks photo uploads for gallery/member media surfaces")
+includes("photo action", photoAction, "published: true", "requests immediate photo publish")
+includes("photo action", photoAction, '.select("id, published, visibility")', "reads trigger-adjusted publish state")
+includes("photo action", photoAction, "published: entity.published", "returns persisted publish state")
+includes("photo action", photoAction, "visibility: entity.visibility as PhotoVisibility", "returns persisted visibility")
+
+includes("photo dialog", photoDialog, "!result.published", "handles non-published fallback message")
+includes("photo dialog", photoDialog, "result.visibility === \"members\"", "uses persisted visibility for success copy")
+includes("photo dialog", photoDialog, "멤버 공개 기록 열기", "keeps member-only navigation")
+
+includes("video action", videoAction, "published: false", "keeps member videos moderated")
+includes("video action", videoAction, "visibility_request: visibility", "records requested video visibility")
+includes("video action", videoAction, "validVideoPath(input.storagePath, user.id)", "validates video storage path against auth user")
+includes("video action", videoAction, "createSignedUrl(input.storagePath, 60)", "verifies uploaded video object exists before entity insert")
+
+includes("docs", supabaseDocs, "visibility in ('public', 'members')", "documents photo publish exception")
+includes("docs", contentGraphDocs, "member-only photos", "documents member-only photo destination")
+
+console.log("Member media publication guard")
+console.table(
+  checks.map((check) => ({
+    area: check.area,
+    check: check.label,
+    status: check.status,
+  })),
+)
+
+const failures = checks.filter((check) => check.status !== "ok")
+
+if (failures.length) {
+  console.error("\nMember media publication regressions found:")
+  for (const failure of failures) {
+    console.error(`- ${failure.area}: ${failure.label} (${failure.detail})`)
+  }
+  process.exitCode = 1
+}

--- a/supabase/migrations/20260520000068_allow_member_only_photo_publication.sql
+++ b/supabase/migrations/20260520000068_allow_member_only_photo_publication.sql
@@ -1,0 +1,47 @@
+-- Bremen - allow member-only photo uploads to publish immediately.
+--
+-- The Photos compose UI lets active approved members choose public or
+-- member-only visibility. Both are intentionally safe photo destinations:
+-- public photos enter /photos, while member-only photos enter /members/media.
+-- Video uploads stay moderated and private until reviewed.
+
+create or replace function public.capture_owned_content()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, auth, private
+as $$
+declare
+  schema_key text;
+  is_publishable_member_photo boolean;
+begin
+  if (select auth.uid()) is not null and not private.is_admin() then
+    if tg_op = 'INSERT' then
+      select entity_schemas.schema_key
+        into schema_key
+      from public.entity_schemas
+      where entity_schemas.id = new.schema_id;
+
+      is_publishable_member_photo :=
+        schema_key = 'photo/member-upload/v1'
+        and private.is_active_member()
+        and new.visibility in ('public', 'members')
+        and new.data->>'gallery_include' = 'true';
+
+      new.owner_member_id := coalesce(new.owner_member_id, private.current_member_id());
+      new.published := is_publishable_member_photo;
+    else
+      new.owner_member_id := old.owner_member_id;
+
+      if old.published = false and new.published = true then
+        new.published := false;
+      end if;
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+revoke execute on function public.capture_owned_content()
+  from anon, authenticated, public;


### PR DESCRIPTION
Closes #209

## Summary
- Update `capture_owned_content()` so active approved member photo uploads can self-publish for `public` and `members` visibility when `gallery_include = true`.
- Keep member video submissions moderated with `published = false`.
- Return the trigger-adjusted `published`/`visibility` state from the photo action and make success copy depend on persisted DB state.
- Add `qa:member-media-publication-guard` to lock the migration, Storage guardrails, and action contracts.

## Supabase impact
- Adds migration `supabase/migrations/20260520000068_allow_member_only_photo_publication.sql`.
- Function-only change to `public.capture_owned_content()`.
- No table drop, no broad data update, no RLS disablement, no bucket visibility change.
- Production apply was attempted via MCP/CLI path but is blocked by current Supabase account privileges; migration file is committed for exact apply.

## Validation
- pnpm run qa:member-media-publication-guard
- pnpm run qa:member-media-compose-ui
- pnpm run qa:cms-native-controls
- pnpm run qa:content-graph
- pnpm exec tsc --noEmit
- pnpm run lint
- git diff --check
- git diff --cached --check
- pnpm run build

## Not tested
- Live member photo upload fixture was skipped to avoid creating production UGC rows.
- Production migration is not applied from this session because Supabase remote link/list returned insufficient account privileges.