### PR TITLE
Keep account navigation in sync

### DIFF
--- a/app/auth/actions.ts
+++ b/app/auth/actions.ts
@@ -163,6 +163,13 @@ function safeNextPath(raw: string) {
   return raw
 }
 
+function revalidateAuthShell(targetPath: string) {
+  revalidatePath("/", "layout")
+  revalidatePath("/login")
+  revalidatePath("/mypage")
+  revalidatePath(targetPath)
+}
+
 export async function signInAction(formData: FormData) {
   const email = stringField(formData, "email")
   const password = stringField(formData, "password")
@@ -185,6 +192,7 @@ export async function signInAction(formData: FormData) {
     })
   }
 
+  revalidateAuthShell(next)
   redirect(next)
 }
 
@@ -319,6 +327,7 @@ export async function signUpAction(formData: FormData) {
     })
   }
 
+  revalidateAuthShell("/mypage")
   redirectWithParams("/mypage", {
     message: "Member Room이 열렸습니다. Profile을 확인해 주세요.",
   })
@@ -370,5 +379,6 @@ export async function updateProfileAction(formData: FormData) {
 export async function signOutAction() {
   const supabase = await createClient()
   await supabase.auth.signOut()
+  revalidateAuthShell("/")
   redirect("/")
 }

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -41,21 +41,30 @@ export function Navigation({ isSignedIn = false, config }: NavigationProps) {
   const [hasSession, setHasSession] = useState(isSignedIn)
 
   useEffect(() => {
-    let mounted = true
+    let cancelled = false
     const supabase = createClient()
 
     supabase.auth.getUser().then(({ data }) => {
-      if (mounted) setHasSession(Boolean(data.user))
+      if (!cancelled) setHasSession(Boolean(data.user))
     })
+
+    return () => {
+      cancelled = true
+    }
+  }, [pathname])
+
+  useEffect(() => {
+    let cancelled = false
+    const supabase = createClient()
 
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((_event, session) => {
-      if (mounted) setHasSession(Boolean(session?.user))
+      if (!cancelled) setHasSession(Boolean(session?.user))
     })
 
     return () => {
-      mounted = false
+      cancelled = true
       subscription.unsubscribe()
     }
   }, [])

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
+    "qa:auth-navigation-sync": "node scripts/qa-auth-navigation-sync.mjs",
     "qa:content-graph": "node scripts/qa-content-graph-integrity.mjs",
     "qa:cms-db-first-loaders": "node scripts/qa-cms-db-first-loaders.mjs",
     "qa:cms-schema-registry": "node scripts/qa-cms-schema-registry.mjs",

--- a/scripts/qa-auth-navigation-sync.mjs
+++ b/scripts/qa-auth-navigation-sync.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs"
+
+const files = {
+  navigation: "components/navigation.tsx",
+  authActions: "app/auth/actions.ts",
+}
+
+const sources = Object.fromEntries(
+  Object.entries(files).map(([key, file]) => {
+    if (!existsSync(file)) {
+      throw new Error(`Missing required file: ${file}`)
+    }
+
+    return [key, readFileSync(file, "utf8")]
+  }),
+)
+
+const checks = []
+
+function addCheck(area, label, passed, detail) {
+  checks.push({
+    area,
+    label,
+    status: passed ? "ok" : "fail",
+    detail,
+  })
+}
+
+function includes(area, source, needle, label) {
+  addCheck(area, label, source.includes(needle), `expected ${JSON.stringify(needle)}`)
+}
+
+function matches(area, source, pattern, label) {
+  addCheck(area, label, pattern.test(source), `expected ${pattern}`)
+}
+
+function appearsBefore(area, source, first, second, label) {
+  const firstIndex = source.indexOf(first)
+  const secondIndex = source.indexOf(second)
+
+  addCheck(
+    area,
+    label,
+    firstIndex >= 0 && secondIndex >= 0 && firstIndex < secondIndex,
+    `expected ${JSON.stringify(first)} before ${JSON.stringify(second)}`,
+  )
+}
+
+function runSelfTest() {
+  const sample = "useEffect(() => {}, [pathname]); revalidateAuthShell('/'); redirect('/')"
+  const beforeChecks = checks.length
+
+  includes("self-test", sample, "[pathname]", "include guard")
+  matches("self-test", sample, /revalidateAuthShell\(['"]\/['"]\)/, "regex guard")
+  appearsBefore("self-test", sample, "revalidateAuthShell('/')", "redirect('/')", "ordering guard")
+
+  const selfTestChecks = checks.splice(beforeChecks)
+  if (selfTestChecks.some((check) => check.status !== "ok")) {
+    throw new Error("Self-test failed for auth navigation sync guard.")
+  }
+}
+
+runSelfTest()
+
+const { navigation, authActions } = sources
+
+includes("navigation", navigation, "usePathname", "reads current route")
+includes("navigation", navigation, "supabase.auth.getUser()", "rechecks browser session")
+includes("navigation", navigation, "}, [pathname])", "rechecks session on route changes")
+includes("navigation", navigation, "supabase.auth.onAuthStateChange", "keeps direct auth event listener")
+includes("navigation", navigation, "subscription.unsubscribe()", "cleans auth listener")
+
+includes("auth actions", authActions, "function revalidateAuthShell", "has shared auth shell revalidation")
+includes("auth actions", authActions, 'revalidatePath("/", "layout")', "invalidates site layout shell")
+includes("auth actions", authActions, 'revalidatePath("/login")', "invalidates login route")
+includes("auth actions", authActions, 'revalidatePath("/mypage")', "invalidates account route")
+appearsBefore("auth actions", authActions, "revalidateAuthShell(next)", "redirect(next)", "sign-in revalidates before redirect")
+matches(
+  "auth actions",
+  authActions,
+  /revalidateAuthShell\("\/mypage"\)\s+redirectWithParams\("\/mypage"/,
+  "session sign-up revalidates before account redirect",
+)
+appearsBefore("auth actions", authActions, 'revalidateAuthShell("/")', 'redirect("/")', "sign-out revalidates before redirect")
+
+console.log("Auth navigation sync guard")
+console.table(
+  checks.map((check) => ({
+    area: check.area,
+    check: check.label,
+    status: check.status,
+  })),
+)
+
+const failures = checks.filter((check) => check.status !== "ok")
+
+if (failures.length) {
+  console.error("\nAuth navigation sync regressions found:")
+  for (const failure of failures) {
+    console.error(`- ${failure.area}: ${failure.label} (${failure.detail})`)
+  }
+  process.exitCode = 1
+}


### PR DESCRIPTION
Closes #212

## Summary
- Re-check the browser Supabase session whenever the pathname changes, so the persistent site navigation updates after server-action redirects.
- Keep the direct Supabase auth state listener for client-side auth events.
- Revalidate the auth-sensitive shell after sign-in, session sign-up, and sign-out server actions.
- Add `qa:auth-navigation-sync` to prevent this regression.

## Supabase impact
None. No schema, RLS, Storage, Auth config, or production data changes.

## Validation
- pnpm run qa:auth-navigation-sync
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm run qa:cms-native-controls
- git diff --check
- git diff --cached --check
- pnpm run build

## Not tested
- Browser end-to-end login/logout with real credentials was not executed in this session.