### PR TITLE
Avoid account sign-in flicker on protected routes

### DIFF
--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -30,6 +30,18 @@ export type NavigationConfig = {
 }
 
 const accountPaths = ["/mypage", "/login", "/signup"]
+const authenticatedAccountPaths = ["/members/media"]
+
+function matchesPathPrefix(pathname: string, href: string) {
+  if (!href.startsWith("/")) return false
+  return pathname === href || pathname.startsWith(`${href}/`)
+}
+
+function isAuthenticatedAccountRoute(pathname: string, signedInHref: string) {
+  return [signedInHref, ...authenticatedAccountPaths].some((href) =>
+    matchesPathPrefix(pathname, href),
+  )
+}
 
 type NavigationProps = {
   isSignedIn?: boolean
@@ -38,7 +50,12 @@ type NavigationProps = {
 
 export function Navigation({ isSignedIn = false, config }: NavigationProps) {
   const pathname = usePathname()
+  const hasAuthenticatedRouteHint = isAuthenticatedAccountRoute(
+    pathname,
+    config.accountSignedInHref,
+  )
   const [hasSession, setHasSession] = useState(isSignedIn)
+  const displayHasSession = hasSession || hasAuthenticatedRouteHint
 
   useEffect(() => {
     let cancelled = false
@@ -51,7 +68,7 @@ export function Navigation({ isSignedIn = false, config }: NavigationProps) {
     return () => {
       cancelled = true
     }
-  }, [pathname])
+  }, [hasAuthenticatedRouteHint, pathname])
 
   useEffect(() => {
     let cancelled = false
@@ -70,10 +87,10 @@ export function Navigation({ isSignedIn = false, config }: NavigationProps) {
   }, [])
 
   const isAccountActive = accountPaths.some((path) => pathname.startsWith(path))
-  const accountHref = hasSession
+  const accountHref = displayHasSession
     ? config.accountSignedInHref
     : config.accountSignedOutHref
-  const accountLabel = hasSession
+  const accountLabel = displayHasSession
     ? config.accountSignedInLabel
     : config.accountSignedOutLabel
 

--- a/scripts/qa-auth-navigation-sync.mjs
+++ b/scripts/qa-auth-navigation-sync.mjs
@@ -67,8 +67,12 @@ runSelfTest()
 const { navigation, authActions } = sources
 
 includes("navigation", navigation, "usePathname", "reads current route")
+includes("navigation", navigation, "authenticatedAccountPaths", "defines authenticated route hint list")
+includes("navigation", navigation, "isAuthenticatedAccountRoute", "uses authenticated route hint helper")
+includes("navigation", navigation, "hasAuthenticatedRouteHint", "derives optimistic signed-in state from route")
+includes("navigation", navigation, "displayHasSession = hasSession || hasAuthenticatedRouteHint", "shows signed-in account state on authenticated routes while checking")
 includes("navigation", navigation, "supabase.auth.getUser()", "rechecks browser session")
-includes("navigation", navigation, "}, [pathname])", "rechecks session on route changes")
+includes("navigation", navigation, "pathname])", "rechecks session on route changes")
 includes("navigation", navigation, "supabase.auth.onAuthStateChange", "keeps direct auth event listener")
 includes("navigation", navigation, "subscription.unsubscribe()", "cleans auth listener")
 


### PR DESCRIPTION
Closes #215

## Summary
- Add a small authenticated-route display hint for the account button on `/mypage` and `/members/media`.
- Keep `supabase.auth.getUser()` as the final source of truth after the route renders.
- Preserve public route ISR/static behavior by avoiding server auth reads in `app/(site)/layout.tsx`.
- Extend `qa:auth-navigation-sync` for the route hint contract.

## Supabase impact
None. Client UI state only; no schema, policy, Storage, Auth config, or production data changes.

## Validation
- pnpm run qa:auth-navigation-sync
- pnpm exec tsc --noEmit
- pnpm run lint
- git diff --check
- git diff --cached --check
- pnpm run build

## Build evidence
- Public pages remain static/ISR in build output: `/`, `/photos`, `/videos`, `/performances`, `/history`.

## Not tested
- Browser end-to-end login/logout with real credentials was not executed.