### PR TITLE
Improve public and PONIX visual design

### DIFF
--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -14,7 +14,7 @@ export default async function SiteLayout({
   }
 
   return (
-    <div className="flex min-h-screen flex-col bg-background">
+    <div className="site-shell flex min-h-screen flex-col">
       <Navigation config={siteChrome.navigation} />
       <main className="flex-1 pt-20">{children}</main>
       <Footer config={siteChrome.footer} />

--- a/app/globals.css
+++ b/app/globals.css
@@ -5,48 +5,58 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  --background: oklch(0.978 0.008 80);
-  --foreground: oklch(0.18 0.012 60);
-  --card: oklch(0.985 0.006 80);
-  --card-foreground: oklch(0.18 0.012 60);
-  --popover: oklch(0.985 0.006 80);
-  --popover-foreground: oklch(0.18 0.012 60);
-  --primary: oklch(0.22 0.014 60);
-  --primary-foreground: oklch(0.97 0.008 80);
-  --secondary: oklch(0.95 0.01 80);
-  --secondary-foreground: oklch(0.22 0.014 60);
-  --muted: oklch(0.95 0.01 80);
-  --muted-foreground: oklch(0.50 0.012 65);
-  --accent: oklch(0.45 0.16 30);
-  --accent-foreground: oklch(0.97 0.008 80);
+  --background: oklch(0.965 0.01 126);
+  --foreground: oklch(0.17 0.018 154);
+  --card: oklch(0.982 0.006 112);
+  --card-foreground: oklch(0.17 0.018 154);
+  --popover: oklch(0.982 0.006 112);
+  --popover-foreground: oklch(0.17 0.018 154);
+  --primary: oklch(0.20 0.024 158);
+  --primary-foreground: oklch(0.97 0.01 118);
+  --secondary: oklch(0.92 0.016 116);
+  --secondary-foreground: oklch(0.20 0.024 158);
+  --muted: oklch(0.92 0.016 116);
+  --muted-foreground: oklch(0.47 0.024 150);
+  --accent: oklch(0.55 0.16 25);
+  --accent-foreground: oklch(0.98 0.012 105);
   --destructive: oklch(0.50 0.20 28);
-  --destructive-foreground: oklch(0.97 0.008 80);
-  --border: oklch(0.86 0.014 75);
-  --input: oklch(0.88 0.012 75);
-  --ring: oklch(0.45 0.16 30);
+  --destructive-foreground: oklch(0.98 0.012 105);
+  --border: oklch(0.80 0.022 126);
+  --input: oklch(0.84 0.018 126);
+  --ring: oklch(0.55 0.16 25);
+  --stage-ink: oklch(0.17 0.018 154);
+  --stage-brass: oklch(0.70 0.11 82);
+  --stage-oxide: oklch(0.44 0.07 176);
+  --stage-paper: oklch(0.955 0.014 118);
+  --stage-line: color-mix(in oklch, var(--stage-ink) 12%, transparent);
   --radius: 0.25rem;
 }
 
 .dark {
-  --background: oklch(0.13 0.012 60);
-  --foreground: oklch(0.94 0.008 80);
-  --card: oklch(0.16 0.012 60);
-  --card-foreground: oklch(0.94 0.008 80);
-  --popover: oklch(0.16 0.012 60);
-  --popover-foreground: oklch(0.94 0.008 80);
-  --primary: oklch(0.94 0.008 80);
-  --primary-foreground: oklch(0.16 0.012 60);
-  --secondary: oklch(0.22 0.012 60);
-  --secondary-foreground: oklch(0.94 0.008 80);
-  --muted: oklch(0.22 0.012 60);
-  --muted-foreground: oklch(0.66 0.012 70);
-  --accent: oklch(0.78 0.13 80);
-  --accent-foreground: oklch(0.16 0.012 60);
+  --background: oklch(0.13 0.018 160);
+  --foreground: oklch(0.94 0.01 112);
+  --card: oklch(0.17 0.02 160);
+  --card-foreground: oklch(0.94 0.01 112);
+  --popover: oklch(0.17 0.02 160);
+  --popover-foreground: oklch(0.94 0.01 112);
+  --primary: oklch(0.94 0.01 112);
+  --primary-foreground: oklch(0.17 0.02 160);
+  --secondary: oklch(0.22 0.026 160);
+  --secondary-foreground: oklch(0.94 0.01 112);
+  --muted: oklch(0.22 0.026 160);
+  --muted-foreground: oklch(0.70 0.02 132);
+  --accent: oklch(0.70 0.13 62);
+  --accent-foreground: oklch(0.16 0.018 160);
   --destructive: oklch(0.50 0.20 28);
-  --destructive-foreground: oklch(0.94 0.008 80);
-  --border: oklch(0.28 0.012 60);
-  --input: oklch(0.28 0.012 60);
-  --ring: oklch(0.78 0.13 80);
+  --destructive-foreground: oklch(0.94 0.01 112);
+  --border: oklch(0.30 0.026 160);
+  --input: oklch(0.30 0.026 160);
+  --ring: oklch(0.70 0.13 62);
+  --stage-ink: oklch(0.94 0.01 112);
+  --stage-brass: oklch(0.76 0.12 82);
+  --stage-oxide: oklch(0.58 0.08 176);
+  --stage-paper: oklch(0.16 0.018 160);
+  --stage-line: color-mix(in oklch, var(--stage-ink) 14%, transparent);
 }
 
 @theme inline {
@@ -101,12 +111,12 @@
   .font-serif-kr {
     font-family: var(--font-serif-kr);
     font-weight: 600;
-    letter-spacing: -0.02em;
+    letter-spacing: 0;
   }
   /* Latin display italic */
   .font-serif {
     font-family: var(--font-serif);
-    letter-spacing: -0.02em;
+    letter-spacing: 0;
     font-feature-settings: 'liga', 'dlig';
   }
   /* Tiny uppercase caption — sans, just spaced */
@@ -124,6 +134,156 @@
 }
 
 @layer components {
+  .site-shell {
+    position: relative;
+    isolation: isolate;
+    overflow-x: clip;
+    background:
+      linear-gradient(
+        115deg,
+        color-mix(in oklch, var(--stage-oxide) 8%, transparent) 0%,
+        transparent 34%
+      ),
+      repeating-linear-gradient(
+        180deg,
+        transparent 0,
+        transparent 5.2rem,
+        color-mix(in oklch, var(--stage-ink) 5%, transparent) 5.25rem,
+        transparent 5.32rem
+      ),
+      var(--background);
+  }
+
+  .site-shell::before {
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    pointer-events: none;
+    content: '';
+    background:
+      linear-gradient(
+        90deg,
+        transparent 0,
+        transparent calc(50% - 1px),
+        color-mix(in oklch, var(--stage-ink) 5%, transparent) calc(50% - 1px),
+        color-mix(in oklch, var(--stage-ink) 5%, transparent) calc(50% + 1px),
+        transparent calc(50% + 1px)
+      ),
+      repeating-linear-gradient(
+        90deg,
+        transparent 0,
+        transparent 6.5rem,
+        color-mix(in oklch, var(--stage-brass) 10%, transparent) 6.55rem,
+        transparent 6.62rem
+      );
+    mask-image: linear-gradient(to bottom, black 0%, black 55%, transparent 100%);
+  }
+
+  .hero-score {
+    position: relative;
+    overflow: hidden;
+    border-block: 1px solid var(--border);
+    background:
+      linear-gradient(
+        135deg,
+        color-mix(in oklch, var(--card) 92%, transparent),
+        color-mix(in oklch, var(--stage-paper) 86%, transparent)
+      );
+  }
+
+  .hero-score::before {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    content: '';
+    background:
+      repeating-linear-gradient(
+        180deg,
+        transparent 0,
+        transparent 1.05rem,
+        color-mix(in oklch, var(--stage-ink) 7%, transparent) 1.09rem,
+        transparent 1.16rem
+      ),
+      linear-gradient(
+        90deg,
+        color-mix(in oklch, var(--accent) 14%, transparent),
+        transparent 26%,
+        transparent 72%,
+        color-mix(in oklch, var(--stage-oxide) 13%, transparent)
+      );
+    opacity: 0.62;
+  }
+
+  .hero-score > * {
+    position: relative;
+  }
+
+  .stage-card {
+    position: relative;
+    overflow: hidden;
+    background:
+      linear-gradient(180deg, color-mix(in oklch, var(--card) 94%, transparent), var(--card)),
+      repeating-linear-gradient(
+        180deg,
+        transparent 0,
+        transparent 1.1rem,
+        color-mix(in oklch, var(--stage-ink) 4%, transparent) 1.14rem,
+        transparent 1.2rem
+      );
+  }
+
+  .stage-card::after {
+    position: absolute;
+    inset: auto 0 0;
+    height: 3px;
+    content: '';
+    background: linear-gradient(
+      90deg,
+      var(--accent),
+      var(--stage-brass),
+      color-mix(in oklch, var(--stage-oxide) 75%, var(--accent))
+    );
+    opacity: 0;
+    transform: scaleX(0.35);
+    transform-origin: left center;
+    transition:
+      opacity 500ms cubic-bezier(0.22, 1, 0.36, 1),
+      transform 500ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  .stage-card:hover::after,
+  .stage-card:focus-within::after {
+    opacity: 1;
+    transform: scaleX(1);
+  }
+
+  .media-frame {
+    box-shadow:
+      inset 0 0 0 1px color-mix(in oklch, var(--stage-ink) 12%, transparent),
+      0 18px 50px color-mix(in oklch, var(--stage-ink) 13%, transparent);
+  }
+
+  .setlist-panel {
+    background:
+      linear-gradient(180deg, color-mix(in oklch, var(--card) 86%, transparent), var(--card)),
+      repeating-linear-gradient(
+        180deg,
+        transparent 0,
+        transparent 2.35rem,
+        color-mix(in oklch, var(--stage-ink) 7%, transparent) 2.4rem,
+        transparent 2.47rem
+      );
+  }
+
+  .accent-rule {
+    background: linear-gradient(
+      90deg,
+      var(--accent),
+      var(--stage-brass),
+      color-mix(in oklch, var(--stage-oxide) 85%, white)
+    );
+  }
+
   .lift-card {
     transform: translateZ(0) translateY(0) scale(1);
     transform-origin: center center;
@@ -164,12 +324,24 @@
     outline-color: var(--accent);
     outline-width: 3px;
     outline-offset: 6px;
-    box-shadow: 0 0 0 10px color-mix(in_oklch, var(--accent) 16%, transparent);
+    box-shadow: 0 0 0 10px color-mix(in oklch, var(--accent) 16%, transparent);
   }
 
   [data-composer-entity-id][data-composer-entity-state='selected'] {
     border-color: var(--accent);
-    box-shadow: 0 0 0 4px color-mix(in_oklch, var(--accent) 14%, transparent);
+    box-shadow: 0 0 0 4px color-mix(in oklch, var(--accent) 14%, transparent);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  @layer components {
+    .lift-card,
+    .tilt-card,
+    .lift-card:hover,
+    .tilt-card:hover {
+      transform: none;
+      transition-duration: 1ms;
+    }
   }
 }
 

--- a/app/ponix/_components/cms-audit-card.tsx
+++ b/app/ponix/_components/cms-audit-card.tsx
@@ -22,7 +22,7 @@ export function CmsAuditTrailCard({
   emptyMessage?: string
 }) {
   return (
-    <Card className="rounded-[1.5rem] border bg-card/95 shadow-sm">
+    <Card className="stage-card rounded-md border bg-card/95 shadow-sm">
       <CardHeader>
         <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
           <div>

--- a/app/ponix/_components/cms-detail.tsx
+++ b/app/ponix/_components/cms-detail.tsx
@@ -62,15 +62,14 @@ export async function CmsDetailPage({
 
   return (
     <section className="mx-auto flex w-full max-w-[92rem] flex-col gap-6">
-      <div className="relative overflow-hidden rounded-[1.75rem] border bg-card/95 p-5 shadow-sm md:p-7">
-        <div className="pointer-events-none absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-primary via-accent to-transparent" />
-        <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(135deg,color-mix(in_oklch,var(--muted)_72%,transparent),transparent_48%)]" />
+      <div className="hero-score rounded-md p-5 shadow-sm md:p-7">
+        <div className="pointer-events-none absolute inset-x-0 top-0 h-1 accent-rule" />
         <div className="relative flex flex-col gap-5 md:flex-row md:items-start md:justify-between">
           <div className="min-w-0">
             <p className="caps mb-3 text-muted-foreground">
               관리자 / {detail.kind}
             </p>
-            <h1 className="font-serif text-[clamp(2.5rem,4vw,4.75rem)] italic leading-[0.9] tracking-tight">
+            <h1 className="font-serif text-[clamp(2.5rem,4vw,4.75rem)] italic leading-[0.9]">
               {detail.title}
             </h1>
             {detail.subtitle && (
@@ -102,7 +101,7 @@ export async function CmsDetailPage({
       </div>
 
       {!schema && (
-        <Alert variant="destructive" className="rounded-2xl">
+        <Alert variant="destructive" className="rounded-md">
           <AlertTitle>수정 화면을 만들 스키마가 없습니다</AlertTitle>
           <AlertDescription>
             이 항목은 저장되어 있지만 아직 관리자 화면에서 안전하게 수정할
@@ -112,7 +111,7 @@ export async function CmsDetailPage({
       )}
 
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_22rem]">
-        <Card className="overflow-hidden rounded-[1.5rem] bg-card/95 shadow-sm">
+        <Card className="setlist-panel overflow-hidden rounded-md bg-card/95 shadow-sm">
           <CardHeader className="border-b bg-muted/20">
             <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
               <div>
@@ -138,7 +137,7 @@ export async function CmsDetailPage({
         </Card>
 
         <div className="space-y-6">
-          <Card className="rounded-[1.5rem] bg-card/95 shadow-sm">
+          <Card className="stage-card rounded-md bg-card/95 shadow-sm">
             <CardHeader>
               <CardTitle className="font-serif text-2xl italic md:text-3xl">
                 기본 정보
@@ -173,7 +172,7 @@ export async function CmsDetailPage({
             />
           )}
 
-          <Card className="rounded-[1.5rem] bg-card/95 shadow-sm">
+          <Card className="stage-card rounded-md bg-card/95 shadow-sm">
             <CardHeader>
               <CardTitle className="font-serif text-2xl italic md:text-3xl">
                 원본 데이터

--- a/app/ponix/_components/cms-entity-create-form.tsx
+++ b/app/ponix/_components/cms-entity-create-form.tsx
@@ -36,17 +36,12 @@ export function CmsEntityCreatePage({
   const semanticKind = semanticKindForSchema(schema)
 
   return (
-    <main className="relative min-h-screen overflow-hidden">
-      <div className="pointer-events-none absolute inset-0 -z-10">
-        <div className="absolute right-[-10rem] top-10 h-96 w-96 rounded-full bg-accent/10 blur-3xl" />
-        <div className="absolute left-[-8rem] bottom-0 h-80 w-80 rounded-full bg-muted blur-3xl" />
-      </div>
-
+    <main className="min-h-screen">
       <section className="mx-auto max-w-5xl px-1 py-4 md:py-8">
-        <div className="mb-10 flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+        <div className="hero-score mb-6 flex flex-col gap-6 rounded-md p-5 shadow-sm md:flex-row md:items-start md:justify-between md:p-7">
           <div>
             <p className="caps mb-5">콘텐츠 추가</p>
-            <h1 className="font-serif text-[clamp(2.5rem,5vw,5rem)] italic leading-[0.9] tracking-tight">
+            <h1 className="font-serif text-[clamp(2.5rem,5vw,5rem)] italic leading-[0.9]">
               {schema.label}
             </h1>
             <p className="mt-5 max-w-2xl text-sm leading-relaxed text-muted-foreground md:text-base">
@@ -70,13 +65,13 @@ export function CmsEntityCreatePage({
           <input type="hidden" name="schema_id" value={schema.schemaId ?? ""} />
 
           {error && (
-            <Alert variant="destructive">
+            <Alert variant="destructive" className="rounded-md">
               <AlertTitle>콘텐츠를 만들지 못했습니다</AlertTitle>
               <AlertDescription>{error}</AlertDescription>
             </Alert>
           )}
 
-          <Card className="rounded-[1.5rem] bg-card/95 shadow-sm">
+          <Card className="stage-card rounded-md bg-card/95 shadow-sm">
             <CardHeader className="border-b">
               <CardTitle className="font-serif text-3xl italic">
                 고정된 식별 정보
@@ -106,7 +101,7 @@ export function CmsEntityCreatePage({
             fields={dataFields}
           />
 
-          <div className="flex flex-col gap-3 rounded-[1.25rem] border bg-card/95 p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+          <div className="setlist-panel flex flex-col gap-3 rounded-md border bg-card/95 p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
             <p className="text-sm text-muted-foreground">
               저장 후 섹션에 배치하거나 다른 콘텐츠와 연결할 수 있습니다.
             </p>
@@ -125,7 +120,7 @@ export function CmsEntityCreatePage({
 
 function ThumbnailCard() {
   return (
-    <Card className="rounded-[1.5rem] bg-card/95 shadow-sm">
+    <Card className="stage-card rounded-md bg-card/95 shadow-sm">
       <CardHeader className="border-b">
         <CardTitle className="font-serif text-3xl italic">
           대표 이미지
@@ -157,7 +152,7 @@ function CreateEditorCard({
   fields: CmsEditableEntityField[]
 }) {
   return (
-    <Card className="rounded-[1.5rem] bg-card/95 shadow-sm">
+    <Card className="stage-card rounded-md bg-card/95 shadow-sm">
       <CardHeader className="border-b">
         <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
           <div>

--- a/app/ponix/_components/cms-entity-form.tsx
+++ b/app/ponix/_components/cms-entity-form.tsx
@@ -50,17 +50,12 @@ export async function CmsEntityEditorPage({
   const formId = `cms-entity-form-${detail.row.id}`
 
   return (
-    <main className="relative min-h-screen overflow-hidden">
-      <div className="pointer-events-none absolute inset-0 -z-10">
-        <div className="absolute right-[-10rem] top-10 h-96 w-96 rounded-full bg-accent/10 blur-3xl" />
-        <div className="absolute left-[-8rem] bottom-0 h-80 w-80 rounded-full bg-muted blur-3xl" />
-      </div>
-
+    <main className="min-h-screen">
       <section className="mx-auto max-w-6xl px-1 py-4 md:py-8">
-        <div className="mb-10 flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+        <div className="hero-score mb-6 flex flex-col gap-6 rounded-md p-5 shadow-sm md:flex-row md:items-start md:justify-between md:p-7">
           <div>
             <p className="caps mb-5">콘텐츠 수정</p>
-            <h1 className="font-serif text-[clamp(2.5rem,5vw,5rem)] italic leading-[0.9] tracking-tight">
+            <h1 className="font-serif text-[clamp(2.5rem,5vw,5rem)] italic leading-[0.9]">
               {detail.title}
             </h1>
             <p className="mt-5 max-w-2xl text-sm leading-relaxed text-muted-foreground md:text-base">
@@ -81,7 +76,7 @@ export async function CmsEntityEditorPage({
         </div>
 
         {!schema ? (
-          <Alert variant="destructive">
+          <Alert variant="destructive" className="rounded-md">
             <AlertTitle>수정할 수 없는 콘텐츠입니다</AlertTitle>
             <AlertDescription>
               이 콘텐츠에 맞는 입력 양식이 아직 등록되지 않았습니다.
@@ -107,7 +102,7 @@ export async function CmsEntityEditorPage({
                 savedDescription="데이터 항목이 저장되었습니다."
               />
 
-              <Card className="rounded-[1.5rem] bg-card/95 shadow-sm">
+              <Card className="stage-card rounded-md bg-card/95 shadow-sm">
                 <CardHeader className="border-b">
                   <CardTitle className="font-serif text-3xl italic">
                     고정된 식별 정보
@@ -139,7 +134,7 @@ export async function CmsEntityEditorPage({
                 detail={detail}
               />
 
-              <div className="flex flex-col gap-3 rounded-[1.25rem] border bg-card/95 p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+              <div className="setlist-panel flex flex-col gap-3 rounded-md border bg-card/95 p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
                 <p className="text-sm text-muted-foreground">
                   저장하면 이 콘텐츠의 정보만 바뀝니다. 배치된 섹션과 순서는 그대로 둡니다.
                 </p>
@@ -166,7 +161,7 @@ export async function CmsEntityEditorPage({
 
 function ThumbnailCard({ detail }: { detail: CmsEntityDetail }) {
   return (
-    <Card className="rounded-[1.5rem] bg-card/95 shadow-sm">
+    <Card className="stage-card rounded-md bg-card/95 shadow-sm">
       <CardHeader className="border-b">
         <CardTitle className="font-serif text-3xl italic">
           대표 이미지
@@ -214,7 +209,7 @@ function EditorCard({
   detail: CmsEntityDetail
 }) {
   return (
-    <Card className="rounded-[1.5rem] bg-card/95 shadow-sm">
+    <Card className="stage-card rounded-md bg-card/95 shadow-sm">
       <CardHeader className="border-b">
         <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
           <div>

--- a/app/ponix/_components/cms-list.tsx
+++ b/app/ponix/_components/cms-list.tsx
@@ -26,13 +26,12 @@ export function CmsListPage({
 }) {
   return (
     <section className="mx-auto flex w-full max-w-[92rem] flex-col gap-6">
-      <div className="relative overflow-hidden rounded-[1.75rem] border bg-card/95 p-5 shadow-sm md:p-7">
-        <div className="pointer-events-none absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-primary via-accent to-transparent" />
-        <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(135deg,color-mix(in_oklch,var(--muted)_72%,transparent),transparent_48%)]" />
+      <div className="hero-score rounded-md p-5 shadow-sm md:p-7">
+        <div className="pointer-events-none absolute inset-x-0 top-0 h-1 accent-rule" />
         <div className="relative flex flex-col gap-5 md:flex-row md:items-start md:justify-between">
           <div className="min-w-0">
             <p className="caps mb-3 text-muted-foreground">{eyebrow}</p>
-            <h1 className="font-serif text-[clamp(2.5rem,4vw,4.75rem)] italic leading-[0.9] tracking-tight">
+            <h1 className="font-serif text-[clamp(2.5rem,4vw,4.75rem)] italic leading-[0.9]">
               {title}
             </h1>
             <p className="mt-4 max-w-3xl text-sm leading-relaxed text-muted-foreground md:text-base">
@@ -61,7 +60,7 @@ export function CmsTableCard({
   children: ReactNode
 }) {
   return (
-    <Card className="overflow-hidden rounded-[1.5rem] border bg-card/95 shadow-sm">
+    <Card className="setlist-panel overflow-hidden rounded-md border bg-card/95 shadow-sm">
       <CardHeader className="border-b bg-muted/20">
         <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
           <CardTitle className="font-serif text-2xl italic md:text-3xl">
@@ -93,7 +92,7 @@ export function CmsStatTile({
   return (
     <Card
       className={cn(
-        "rounded-[1.5rem] border bg-card/95 shadow-sm",
+        "stage-card rounded-md border bg-card/95 shadow-sm",
         accent && "border-transparent bg-primary text-primary-foreground",
       )}
     >
@@ -143,10 +142,10 @@ export function CmsRecordCard({
   return (
     <Link
       href={href}
-      className="group flex min-h-56 flex-col overflow-hidden rounded-[1.5rem] border bg-card/95 shadow-sm outline-none transition-all hover:-translate-y-0.5 hover:border-accent/35 hover:shadow-xl focus-visible:ring-[3px] focus-visible:ring-ring/50"
+      className="stage-card group flex min-h-56 flex-col overflow-hidden rounded-md border bg-card/95 shadow-sm outline-none transition-all hover:-translate-y-0.5 hover:border-accent/35 hover:shadow-xl focus-visible:ring-[3px] focus-visible:ring-ring/50"
     >
       {media && (
-        <div className="relative h-28 overflow-hidden border-b bg-muted/40">
+        <div className="media-frame relative h-28 overflow-hidden border-b bg-muted/40">
           {media}
         </div>
       )}

--- a/app/ponix/_components/cms-live-preview.tsx
+++ b/app/ponix/_components/cms-live-preview.tsx
@@ -253,7 +253,7 @@ function PreviewShell({
 }) {
   return (
     <div className="xl:sticky xl:top-24">
-      <Card className="overflow-hidden rounded-[1.5rem] bg-card/95 shadow-sm">
+      <Card className="stage-card overflow-hidden rounded-md bg-card/95 shadow-sm">
         <CardHeader className="border-b">
           <p className="caps text-muted-foreground">{eyebrow}</p>
           <CardTitle className="font-serif text-3xl italic">{title}</CardTitle>

--- a/app/ponix/_components/cms-page-form.tsx
+++ b/app/ponix/_components/cms-page-form.tsx
@@ -45,17 +45,12 @@ export async function CmsPageEditorPage({
   const propsFields = editableFields.filter((field) => field.source === "props")
 
   return (
-    <main className="relative min-h-screen overflow-hidden">
-      <div className="pointer-events-none absolute inset-0 -z-10">
-        <div className="absolute right-[-10rem] top-10 h-96 w-96 rounded-full bg-accent/10 blur-3xl" />
-        <div className="absolute left-[-8rem] bottom-0 h-80 w-80 rounded-full bg-muted blur-3xl" />
-      </div>
-
+    <main className="min-h-screen">
       <section className="mx-auto max-w-5xl px-1 py-4 md:py-8">
-        <div className="mb-10 flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+        <div className="hero-score mb-6 flex flex-col gap-6 rounded-md p-5 shadow-sm md:flex-row md:items-start md:justify-between md:p-7">
           <div>
             <p className="caps mb-5">페이지 편집</p>
-            <h1 className="font-serif text-[clamp(2.5rem,5vw,5rem)] italic leading-[0.9] tracking-tight">
+            <h1 className="font-serif text-[clamp(2.5rem,5vw,5rem)] italic leading-[0.9]">
               {detail.title}
             </h1>
             <p className="mt-5 max-w-2xl text-sm leading-relaxed text-muted-foreground md:text-base">
@@ -77,7 +72,7 @@ export async function CmsPageEditorPage({
         </div>
 
         {!schema ? (
-          <Alert variant="destructive">
+          <Alert variant="destructive" className="rounded-md">
             <AlertTitle>수정할 수 없는 페이지입니다</AlertTitle>
             <AlertDescription>
               이 페이지에 맞는 입력 양식이 아직 등록되지 않았습니다.
@@ -98,7 +93,7 @@ export async function CmsPageEditorPage({
               savedDescription="페이지 기본 정보가 저장되었습니다."
             />
 
-            <Card className="rounded-[1.5rem] bg-card/95 shadow-sm">
+            <Card className="stage-card rounded-md bg-card/95 shadow-sm">
               <CardHeader className="border-b">
                 <CardTitle className="font-serif text-3xl italic">
                     고정된 주소
@@ -127,7 +122,7 @@ export async function CmsPageEditorPage({
               detail={detail}
             />
 
-            <div className="flex flex-col gap-3 rounded-[1.25rem] border bg-card/95 p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+            <div className="setlist-panel flex flex-col gap-3 rounded-md border bg-card/95 p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
               <p className="text-sm text-muted-foreground">
                 저장하면 페이지 제목, 설명, 공개 상태만 바뀝니다. 섹션 구성은 그대로 둡니다.
               </p>
@@ -157,7 +152,7 @@ function EditorCard({
   detail: CmsPageDetail
 }) {
   return (
-    <Card className="rounded-[1.5rem] bg-card/95 shadow-sm">
+    <Card className="stage-card rounded-md bg-card/95 shadow-sm">
       <CardHeader className="border-b">
         <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
           <div>

--- a/app/ponix/_components/cms-relations.tsx
+++ b/app/ponix/_components/cms-relations.tsx
@@ -80,7 +80,7 @@ export function RelationMutationNotice({
   return (
     <Alert
       variant={error ? "destructive" : "default"}
-      className="rounded-[1.25rem] bg-card/95 shadow-sm"
+      className="rounded-md bg-card/95 shadow-sm"
     >
       <AlertDescription>{error ?? message}</AlertDescription>
     </Alert>
@@ -551,7 +551,7 @@ function RelationCard({
   children: ReactNode
 }) {
   return (
-    <Card className="rounded-[1.5rem] bg-card/95 shadow-sm">
+    <Card className="stage-card rounded-md bg-card/95 shadow-sm">
       <CardHeader className="border-b">
         <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
           <div>

--- a/app/ponix/_components/cms-save-controls.tsx
+++ b/app/ponix/_components/cms-save-controls.tsx
@@ -47,7 +47,7 @@ export function CmsSaveNotice({
     return (
       <Alert
         variant="destructive"
-        className="rounded-xl shadow-sm"
+        className="rounded-md shadow-sm"
         data-cms-save-feedback="error"
       >
         <AlertTitle>{errorTitle}</AlertTitle>
@@ -62,7 +62,7 @@ export function CmsSaveNotice({
 
   return (
     <Alert
-      className="rounded-xl border-emerald-200 bg-emerald-50 text-emerald-950 shadow-sm"
+      className="rounded-md border-emerald-200 bg-emerald-50 text-emerald-950 shadow-sm"
       data-cms-save-feedback="saved"
     >
       <CheckCircle2 className="size-4 text-emerald-700" />

--- a/app/ponix/_components/cms-section-create-form.tsx
+++ b/app/ponix/_components/cms-section-create-form.tsx
@@ -36,17 +36,12 @@ export function CmsSectionCreatePage({
   const sectionType = sectionTypeFromSchemaKey(schema.schemaKey) ?? "unregistered"
 
   return (
-    <main className="relative min-h-screen overflow-hidden">
-      <div className="pointer-events-none absolute inset-0 -z-10">
-        <div className="absolute right-[-10rem] top-10 h-96 w-96 rounded-full bg-accent/10 blur-3xl" />
-        <div className="absolute left-[-8rem] bottom-0 h-80 w-80 rounded-full bg-muted blur-3xl" />
-      </div>
-
+    <main className="min-h-screen">
       <section className="mx-auto max-w-5xl px-1 py-4 md:py-8">
-        <div className="mb-10 flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+        <div className="hero-score mb-6 flex flex-col gap-6 rounded-md p-5 shadow-sm md:flex-row md:items-start md:justify-between md:p-7">
           <div>
             <p className="caps mb-5">섹션 추가</p>
-            <h1 className="font-serif text-[clamp(2.5rem,5vw,5rem)] italic leading-[0.9] tracking-tight">
+            <h1 className="font-serif text-[clamp(2.5rem,5vw,5rem)] italic leading-[0.9]">
               {schema.label}
             </h1>
             <p className="mt-5 max-w-2xl text-sm leading-relaxed text-muted-foreground md:text-base">
@@ -70,13 +65,13 @@ export function CmsSectionCreatePage({
           <input type="hidden" name="schema_id" value={schema.schemaId ?? ""} />
 
           {error && (
-            <Alert variant="destructive">
+            <Alert variant="destructive" className="rounded-md">
               <AlertTitle>섹션을 만들지 못했습니다</AlertTitle>
               <AlertDescription>{error}</AlertDescription>
             </Alert>
           )}
 
-          <Card className="rounded-[1.5rem] bg-card/95 shadow-sm">
+          <Card className="stage-card rounded-md bg-card/95 shadow-sm">
             <CardHeader className="border-b">
               <CardTitle className="font-serif text-3xl italic">
                 섹션 식별 정보
@@ -121,7 +116,7 @@ export function CmsSectionCreatePage({
             fields={propsFields}
           />
 
-          <div className="flex flex-col gap-3 rounded-[1.25rem] border bg-card/95 p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+          <div className="setlist-panel flex flex-col gap-3 rounded-md border bg-card/95 p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
             <p className="text-sm text-muted-foreground">
               섹션을 만든 뒤 페이지에 배치하고 필요한 데이터를 연결합니다.
             </p>
@@ -148,7 +143,7 @@ function CreateEditorCard({
   fields: CmsEditableSectionField[]
 }) {
   return (
-    <Card className="rounded-[1.5rem] bg-card/95 shadow-sm">
+    <Card className="stage-card rounded-md bg-card/95 shadow-sm">
       <CardHeader className="border-b">
         <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
           <div>

--- a/app/ponix/_components/cms-section-form.tsx
+++ b/app/ponix/_components/cms-section-form.tsx
@@ -51,17 +51,12 @@ export async function CmsSectionEditorPage({
   const formId = `cms-section-form-${detail.row.id}`
 
   return (
-    <main className="relative min-h-screen overflow-hidden">
-      <div className="pointer-events-none absolute inset-0 -z-10">
-        <div className="absolute right-[-10rem] top-10 h-96 w-96 rounded-full bg-accent/10 blur-3xl" />
-        <div className="absolute left-[-8rem] bottom-0 h-80 w-80 rounded-full bg-muted blur-3xl" />
-      </div>
-
+    <main className="min-h-screen">
       <section className="mx-auto max-w-[92rem] px-1 py-4 md:py-8">
-        <div className="mb-10 flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+        <div className="hero-score mb-6 flex flex-col gap-6 rounded-md p-5 shadow-sm md:flex-row md:items-start md:justify-between md:p-7">
           <div>
             <p className="caps mb-5">섹션 편집</p>
-            <h1 className="font-serif text-[clamp(2.5rem,5vw,5rem)] italic leading-[0.9] tracking-tight">
+            <h1 className="font-serif text-[clamp(2.5rem,5vw,5rem)] italic leading-[0.9]">
               {detail.title}
             </h1>
             <p className="mt-5 max-w-2xl text-sm leading-relaxed text-muted-foreground md:text-base">
@@ -82,7 +77,7 @@ export async function CmsSectionEditorPage({
         </div>
 
         {!schema ? (
-          <Alert variant="destructive">
+          <Alert variant="destructive" className="rounded-md">
             <AlertTitle>수정할 수 없는 섹션입니다</AlertTitle>
             <AlertDescription>
               이 섹션에 맞는 입력 양식이 아직 등록되지 않았습니다.
@@ -108,7 +103,7 @@ export async function CmsSectionEditorPage({
                 savedDescription="섹션 문구와 설정이 저장되었습니다."
               />
 
-              <Card className="rounded-[1.5rem] bg-card/95 shadow-sm">
+              <Card className="stage-card rounded-md bg-card/95 shadow-sm">
                 <CardHeader className="border-b">
                   <CardTitle className="font-serif text-3xl italic">
                     고정된 식별 정보
@@ -138,7 +133,7 @@ export async function CmsSectionEditorPage({
                 detail={detail}
               />
 
-              <div className="flex flex-col gap-3 rounded-[1.25rem] border bg-card/95 p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+              <div className="setlist-panel flex flex-col gap-3 rounded-md border bg-card/95 p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
                 <p className="text-sm text-muted-foreground">
                   저장하면 이 섹션의 문구와 설정만 바뀝니다. 연결된 데이터는 그대로 둡니다.
                 </p>
@@ -177,7 +172,7 @@ function EditorCard({
   detail: CmsSectionDetail
 }) {
   return (
-    <Card className="rounded-[1.5rem] bg-card/95 shadow-sm">
+    <Card className="stage-card rounded-md bg-card/95 shadow-sm">
       <CardHeader className="border-b">
         <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
           <div>

--- a/app/ponix/_components/page-preview-renderer.tsx
+++ b/app/ponix/_components/page-preview-renderer.tsx
@@ -82,7 +82,7 @@ export function PonixPagePreviewRenderer({
     <section className="mx-auto max-w-6xl px-6 py-16 md:px-8 md:py-24">
       <div className="mb-10">
         <p className="caps mb-5 text-muted-foreground">Generic page preview</p>
-        <h1 className="font-serif text-[clamp(3.25rem,8vw,6.5rem)] italic leading-[0.84] tracking-tight">
+        <h1 className="font-serif text-[clamp(3.25rem,8vw,6.5rem)] italic leading-[0.84]">
           {preview.page.title}
         </h1>
         {preview.page.description && (

--- a/app/ponix/_components/ponix-shell.tsx
+++ b/app/ponix/_components/ponix-shell.tsx
@@ -144,9 +144,8 @@ export function PonixShell({ memberName, children }: PonixShellProps) {
           "--sidebar-width-icon": "3.25rem",
         } as CSSProperties
       }
-      className="min-h-screen bg-[#f7f1e8]"
+      className="site-shell min-h-screen bg-background"
     >
-      <div className="pointer-events-none fixed inset-0 -z-10 bg-[radial-gradient(circle_at_18%_10%,color-mix(in_oklch,var(--accent)_13%,transparent),transparent_32%),linear-gradient(135deg,color-mix(in_oklch,var(--secondary)_82%,transparent),transparent_46%)]" />
       <Sidebar
         variant="floating"
         collapsible="icon"
@@ -157,7 +156,7 @@ export function PonixShell({ memberName, children }: PonixShellProps) {
             <SidebarMenuItem>
               <SidebarMenuButton asChild size="lg" tooltip="PONIX">
                 <Link href="/ponix">
-                  <div className="flex size-10 items-center justify-center rounded-xl bg-sidebar-primary text-sidebar-primary-foreground shadow-sm">
+                  <div className="flex size-10 items-center justify-center rounded-md bg-sidebar-primary text-sidebar-primary-foreground shadow-sm">
                     <Activity className="size-4" />
                   </div>
                   <div className="min-w-0">
@@ -175,7 +174,7 @@ export function PonixShell({ memberName, children }: PonixShellProps) {
         </SidebarHeader>
 
         <SidebarContent className="px-2 py-2">
-          <div className="mx-1 mb-3 rounded-2xl border bg-sidebar-accent/45 p-3 group-data-[collapsible=icon]:hidden">
+          <div className="setlist-panel mx-1 mb-3 rounded-md border bg-sidebar-accent/45 p-3 group-data-[collapsible=icon]:hidden">
             <div className="mb-3 flex items-center justify-between">
               <p className="caps text-sidebar-foreground/55">Today</p>
               <CheckCircle2 className="size-4 text-emerald-700" />
@@ -184,8 +183,8 @@ export function PonixShell({ memberName, children }: PonixShellProps) {
               공개 사이트에 보이는 화면과 데이터를 이곳에서 관리합니다.
             </p>
             <div className="mt-3 grid grid-cols-2 gap-2 text-xs text-sidebar-foreground/60">
-              <span className="rounded-lg bg-sidebar/70 px-2 py-1">화면 구성</span>
-              <span className="rounded-lg bg-sidebar/70 px-2 py-1">콘텐츠 관리</span>
+              <span className="rounded-sm bg-sidebar/70 px-2 py-1">화면 구성</span>
+              <span className="rounded-sm bg-sidebar/70 px-2 py-1">콘텐츠 관리</span>
             </div>
           </div>
 
@@ -205,7 +204,7 @@ export function PonixShell({ memberName, children }: PonixShellProps) {
                           isActive={active}
                           tooltip={item.label}
                           className={cn(
-                            "h-11 rounded-xl",
+                            "h-11 rounded-md",
                             active && "bg-sidebar-primary text-sidebar-primary-foreground shadow-sm hover:bg-sidebar-primary hover:text-sidebar-primary-foreground",
                           )}
                         >
@@ -228,7 +227,7 @@ export function PonixShell({ memberName, children }: PonixShellProps) {
 
         <SidebarSeparator />
         <SidebarFooter className="p-3">
-          <div className="rounded-2xl border bg-sidebar-accent/50 p-3 group-data-[collapsible=icon]:hidden">
+          <div className="setlist-panel rounded-md border bg-sidebar-accent/50 p-3 group-data-[collapsible=icon]:hidden">
             <p className="caps text-sidebar-foreground/60">Signed in</p>
             <p className="mt-1 truncate text-sm font-medium">{memberName}</p>
           </div>
@@ -237,9 +236,9 @@ export function PonixShell({ memberName, children }: PonixShellProps) {
       </Sidebar>
 
       <div className="flex min-w-0 flex-1 flex-col">
-        <div className="sticky top-0 z-20 flex h-16 items-center gap-3 border-b bg-background/85 px-4 backdrop-blur-xl md:px-6">
+        <div className="sticky top-0 z-20 flex h-16 items-center gap-3 border-b bg-background/85 px-4 shadow-[0_10px_30px_color-mix(in_oklch,var(--stage-ink)_8%,transparent)] backdrop-blur-xl md:px-6">
           <SidebarTrigger className="size-8 md:hidden" />
-          <div className="hidden size-9 items-center justify-center rounded-xl border bg-card shadow-sm md:flex">
+          <div className="hidden size-9 items-center justify-center rounded-md border bg-card shadow-sm md:flex">
             <LayoutDashboard className="size-4" />
           </div>
           <div className="min-w-0 flex-1">

--- a/app/ponix/entities/new/page.tsx
+++ b/app/ponix/entities/new/page.tsx
@@ -75,17 +75,12 @@ function SchemaPickerPage({
   error?: string
 }) {
   return (
-    <main className="relative min-h-screen overflow-hidden">
-      <div className="pointer-events-none absolute inset-0 -z-10">
-        <div className="absolute right-[-10rem] top-10 h-96 w-96 rounded-full bg-accent/10 blur-3xl" />
-        <div className="absolute left-[-8rem] bottom-0 h-80 w-80 rounded-full bg-muted blur-3xl" />
-      </div>
-
+    <main className="min-h-screen">
       <section className="mx-auto max-w-6xl px-1 py-4 md:py-8">
-        <div className="mb-10 flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+        <div className="hero-score mb-6 flex flex-col gap-6 rounded-md p-5 shadow-sm md:flex-row md:items-start md:justify-between md:p-7">
           <div>
             <p className="caps mb-5">콘텐츠 추가</p>
-            <h1 className="font-serif text-[clamp(2.5rem,5vw,5rem)] italic leading-[0.9] tracking-tight">
+            <h1 className="font-serif text-[clamp(2.5rem,5vw,5rem)] italic leading-[0.9]">
               형식 선택
             </h1>
             <p className="mt-5 max-w-2xl text-sm leading-relaxed text-muted-foreground md:text-base">
@@ -99,7 +94,7 @@ function SchemaPickerPage({
 
         <div className="space-y-6">
           {error && (
-            <Alert variant="destructive">
+            <Alert variant="destructive" className="rounded-md">
               <AlertTitle>선택할 수 없는 형식입니다</AlertTitle>
               <AlertDescription>{error}</AlertDescription>
             </Alert>
@@ -109,7 +104,7 @@ function SchemaPickerPage({
             {schemas.map((schema) => (
               <Card
                 key={schema.schemaKey}
-                className="rounded-[1.5rem] bg-card/95 shadow-sm transition-transform hover:-translate-y-1"
+                className="stage-card rounded-md bg-card/95 shadow-sm transition-transform hover:-translate-y-0.5"
               >
                 <CardHeader className="border-b">
                   <div className="mb-3 flex flex-wrap items-center gap-2">

--- a/app/ponix/guestbook/guestbook-moderation-list.tsx
+++ b/app/ponix/guestbook/guestbook-moderation-list.tsx
@@ -206,7 +206,7 @@ function DeleteEntryDialog({ entry }: { entry: CmsGuestbookEntry }) {
             삭제하면 멤버 프로필에서 바로 사라집니다. 복구 기능은 아직 없습니다.
           </AlertDialogDescription>
         </AlertDialogHeader>
-        <div className="rounded-xl border bg-muted/30 p-4 text-sm leading-relaxed text-muted-foreground">
+        <div className="setlist-panel rounded-md border bg-muted/30 p-4 text-sm leading-relaxed text-muted-foreground">
           {entry.body}
         </div>
         <AlertDialogFooter>

--- a/app/ponix/loading.tsx
+++ b/app/ponix/loading.tsx
@@ -3,7 +3,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 export default function PonixLoading() {
   return (
     <section className="mx-auto flex w-full max-w-[104rem] flex-col gap-5">
-      <div className="rounded-xl border bg-card/90 p-5 shadow-sm md:p-6">
+      <div className="hero-score rounded-md p-5 shadow-sm md:p-6">
         <Skeleton className="h-3 w-28" />
         <Skeleton className="mt-5 h-16 w-72 max-w-full" />
         <div className="mt-5 flex gap-2">
@@ -14,7 +14,7 @@ export default function PonixLoading() {
       </div>
 
       <div className="grid min-h-[calc(100svh-13rem)] gap-5 xl:grid-cols-[minmax(0,1fr)_24rem]">
-        <div className="overflow-hidden rounded-xl border bg-card/95 shadow-sm">
+        <div className="setlist-panel overflow-hidden rounded-md border bg-card/95 shadow-sm">
           <div className="border-b bg-muted/20 p-6">
             <Skeleton className="h-3 w-24" />
             <Skeleton className="mt-4 h-10 w-64" />
@@ -28,12 +28,12 @@ export default function PonixLoading() {
         </div>
 
         <aside className="space-y-4">
-          <div className="rounded-xl border bg-card/95 p-5 shadow-sm">
+          <div className="stage-card rounded-md border bg-card/95 p-5 shadow-sm">
             <Skeleton className="h-3 w-24" />
             <Skeleton className="mt-4 h-10 w-56" />
             <Skeleton className="mt-5 h-24 w-full" />
           </div>
-          <div className="rounded-xl border bg-card/95 p-5 shadow-sm">
+          <div className="stage-card rounded-md border bg-card/95 p-5 shadow-sm">
             <Skeleton className="h-8 w-44" />
             <Skeleton className="mt-5 h-10 w-full" />
             <Skeleton className="mt-3 h-10 w-full" />

--- a/app/ponix/members/[id]/edit/page.tsx
+++ b/app/ponix/members/[id]/edit/page.tsx
@@ -60,9 +60,9 @@ export default async function PonixMemberEditPage({
 
   return (
     <section className="mx-auto flex w-full max-w-5xl flex-col gap-6">
-      <div className="rounded-xl border bg-card/90 p-5 shadow-sm md:p-6">
+      <div className="hero-score rounded-md p-5 shadow-sm md:p-6">
         <p className="caps mb-3 text-muted-foreground">멤버 관리</p>
-        <h1 className="font-serif-kr text-[clamp(2.25rem,6vw,4.25rem)] leading-tight tracking-tight">
+        <h1 className="font-serif-kr text-[clamp(2.25rem,6vw,4.25rem)] leading-tight">
           {member.name}
         </h1>
         <p className="mt-3 max-w-2xl text-sm leading-relaxed text-muted-foreground md:text-base">
@@ -84,7 +84,7 @@ export default async function PonixMemberEditPage({
           value={`/ponix/members/${member.id}/edit`}
         />
 
-        <Card className="overflow-hidden rounded-xl bg-card/95 shadow-sm">
+        <Card className="stage-card overflow-hidden rounded-md bg-card/95 shadow-sm">
           <CardHeader className="border-b bg-muted/20">
             <CardTitle className="font-serif text-3xl italic">
               멤버 권한
@@ -127,7 +127,7 @@ export default async function PonixMemberEditPage({
           </CardContent>
         </Card>
 
-        <Card className="mt-6 overflow-hidden rounded-xl bg-card/95 shadow-sm">
+        <Card className="stage-card mt-6 overflow-hidden rounded-md bg-card/95 shadow-sm">
           <CardHeader className="border-b bg-muted/20">
             <CardTitle className="font-serif text-3xl italic">
               공개 프로필

--- a/app/ponix/pages/[id]/compose/composer-relation-list.tsx
+++ b/app/ponix/pages/[id]/compose/composer-relation-list.tsx
@@ -132,7 +132,7 @@ export function ComposerRelationList({
     <div className="space-y-3" data-composer-relation-list>
       <div
         className={cn(
-          "flex items-center justify-between rounded-xl border px-3 py-2 text-xs",
+          "flex items-center justify-between rounded-md border px-3 py-2 text-xs",
           saveState.status === "error"
             ? "border-destructive/40 bg-destructive/10 text-destructive"
             : "bg-muted/30 text-muted-foreground",
@@ -246,7 +246,7 @@ function SectionEntityRelationEditor({
       <Drawer direction="right">
         <div
           className={cn(
-            "group flex items-stretch gap-2 rounded-xl border bg-background/70 p-2 shadow-xs transition",
+            "group flex items-stretch gap-2 rounded-md border bg-background/70 p-2 shadow-xs transition",
             "hover:border-accent/60 hover:bg-muted/30",
             dragging && "scale-[0.99] opacity-60",
             dropTarget && "border-accent bg-accent/10",
@@ -665,7 +665,7 @@ function EntityFieldGroup({
   return (
     <AccordionItem
       value={value}
-      className="overflow-hidden rounded-xl border bg-background/70 px-4"
+      className="overflow-hidden rounded-md border bg-background/70 px-4"
       data-composer-entity-field-group={value}
     >
       <AccordionTrigger className="hover:no-underline">
@@ -730,7 +730,7 @@ function SaveFeedbackBar({
   return (
     <div
       className={cn(
-        "flex flex-col gap-3 rounded-xl border bg-card/70 p-3 sm:flex-row sm:items-center sm:justify-between",
+        "setlist-panel flex flex-col gap-3 rounded-md border bg-card/70 p-3 sm:flex-row sm:items-center sm:justify-between",
         state.status === "saved" && "border-emerald-300 bg-emerald-50",
         state.status === "error" && "border-destructive/40 bg-destructive/10",
       )}

--- a/app/ponix/pages/[id]/compose/composer-workspace.tsx
+++ b/app/ponix/pages/[id]/compose/composer-workspace.tsx
@@ -192,7 +192,7 @@ export function PonixComposerWorkspace({
       />
 
       <div className="grid min-h-[calc(100svh-13rem)] gap-5 xl:grid-cols-[minmax(0,1fr)_25rem]">
-        <Card className="overflow-hidden rounded-2xl bg-card/95 shadow-sm">
+        <Card className="setlist-panel overflow-hidden rounded-md bg-card/95 shadow-sm">
           <CardHeader className="border-b bg-muted/20 px-5 py-5 md:px-6">
             <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
               <div>
@@ -218,7 +218,7 @@ export function PonixComposerWorkspace({
               onSelect={selectSection}
             />
           </CardHeader>
-          <CardContent className="bg-[#f7f1e8] p-0">
+          <CardContent className="bg-background p-0">
             <iframe
               ref={iframeRef}
               title={`${title} live canvas`}
@@ -251,13 +251,12 @@ function ComposerHeader({
   sectionCount: number
 }) {
   return (
-    <div className="relative overflow-hidden rounded-2xl border bg-card/95 p-5 shadow-sm md:p-7">
-      <div className="pointer-events-none absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-primary via-accent to-transparent" />
-      <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(135deg,color-mix(in_oklch,var(--secondary)_78%,transparent),transparent_46%)]" />
+    <div className="hero-score rounded-md p-5 shadow-sm md:p-7">
+      <div className="pointer-events-none absolute inset-x-0 top-0 h-1 accent-rule" />
       <div className="relative flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
         <div>
           <p className="caps mb-3 text-muted-foreground">페이지 구성</p>
-          <h1 className="font-serif text-[clamp(2.5rem,4vw,4.75rem)] italic leading-[0.9] tracking-tight">
+          <h1 className="font-serif text-[clamp(2.5rem,4vw,4.75rem)] italic leading-[0.9]">
             {title}
           </h1>
           <div className="mt-4 flex flex-wrap items-center gap-2">

--- a/app/ponix/pages/[id]/compose/page.tsx
+++ b/app/ponix/pages/[id]/compose/page.tsx
@@ -214,7 +214,7 @@ function SectionInspector({
         relationMessage={relationMessage}
         relationError={relationError}
       />
-      <Card className="overflow-hidden rounded-2xl bg-card/95 shadow-sm">
+      <Card className="stage-card overflow-hidden rounded-md bg-card/95 shadow-sm">
         <CardHeader className="border-b bg-muted/20">
           <p className="caps text-muted-foreground">선택한 섹션</p>
           <CardTitle className="font-serif text-3xl italic">
@@ -300,7 +300,7 @@ function SectionQuickEditCard({
   redirectTo: string
 }) {
   return (
-    <Card className="overflow-hidden rounded-2xl bg-card/95 shadow-sm">
+    <Card className="stage-card overflow-hidden rounded-md bg-card/95 shadow-sm">
       <Accordion type="single" collapsible>
         <AccordionItem value="copy" className="border-0">
           <CardHeader className="border-b bg-muted/20 p-0">
@@ -382,7 +382,7 @@ function SectionEntityWorkspace({
   ])
 
   return (
-    <Card className="overflow-hidden rounded-2xl bg-card/95 shadow-sm">
+    <Card className="stage-card overflow-hidden rounded-md bg-card/95 shadow-sm">
       <CardHeader className="border-b bg-muted/20">
         <div className="flex items-center gap-2">
           <Database className="size-4 text-muted-foreground" />
@@ -421,7 +421,7 @@ function SectionEntityWorkspace({
         <Accordion type="single" collapsible>
           <AccordionItem
             value="add-entity"
-            className="overflow-hidden rounded-xl border"
+            className="overflow-hidden rounded-md border"
           >
             <AccordionTrigger
               className="bg-muted/20 px-4 py-3 text-left hover:no-underline"
@@ -508,7 +508,7 @@ function SectionEntityWorkspace({
 
 function SectionAdvancedSettingsCard({ section }: { section: GraphSection }) {
   return (
-    <Card className="overflow-hidden rounded-2xl bg-card/95 shadow-sm">
+    <Card className="stage-card overflow-hidden rounded-md bg-card/95 shadow-sm">
       <Accordion type="single" collapsible>
         <AccordionItem value="advanced" className="border-0">
           <CardHeader className="border-b bg-muted/20 p-0">

--- a/app/ponix/photos/photo-operations-list.tsx
+++ b/app/ponix/photos/photo-operations-list.tsx
@@ -150,7 +150,7 @@ export function PhotoOperationsList({ photos }: { photos: CmsMemberPhoto[] }) {
                 <TableRow key={photo.id}>
                   <TableCell className="min-w-[22rem]">
                     <div className="flex items-center gap-4">
-                      <div className="relative h-20 w-24 shrink-0 overflow-hidden rounded-xl border bg-muted">
+                      <div className="media-frame relative h-20 w-24 shrink-0 overflow-hidden rounded-md border bg-muted">
                         {photo.thumbnailUrl ? (
                           // eslint-disable-next-line @next/next/no-img-element
                           <img
@@ -350,7 +350,7 @@ function DeletePhotoDialog({ photo }: { photo: CmsMemberPhoto }) {
             사진 탭의 기록과 연결된 업로드 파일을 함께 정리합니다. 복구 기능은 아직 없습니다.
           </AlertDialogDescription>
         </AlertDialogHeader>
-        <div className="flex gap-4 rounded-xl border bg-muted/30 p-4">
+        <div className="setlist-panel flex gap-4 rounded-md border bg-muted/30 p-4">
           <div className="relative h-24 w-28 shrink-0 overflow-hidden rounded-lg border bg-muted">
             {photo.thumbnailUrl ? (
               // eslint-disable-next-line @next/next/no-img-element

--- a/app/ponix/sections/new/page.tsx
+++ b/app/ponix/sections/new/page.tsx
@@ -77,17 +77,12 @@ function SchemaPickerPage({
   error?: string
 }) {
   return (
-    <main className="relative min-h-screen overflow-hidden">
-      <div className="pointer-events-none absolute inset-0 -z-10">
-        <div className="absolute right-[-10rem] top-10 h-96 w-96 rounded-full bg-accent/10 blur-3xl" />
-        <div className="absolute left-[-8rem] bottom-0 h-80 w-80 rounded-full bg-muted blur-3xl" />
-      </div>
-
+    <main className="min-h-screen">
       <section className="mx-auto max-w-6xl px-1 py-4 md:py-8">
-        <div className="mb-10 flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+        <div className="hero-score mb-6 flex flex-col gap-6 rounded-md p-5 shadow-sm md:flex-row md:items-start md:justify-between md:p-7">
           <div>
             <p className="caps mb-5">섹션 추가</p>
-            <h1 className="font-serif text-[clamp(2.5rem,5vw,5rem)] italic leading-[0.9] tracking-tight">
+            <h1 className="font-serif text-[clamp(2.5rem,5vw,5rem)] italic leading-[0.9]">
               형식 선택
             </h1>
             <p className="mt-5 max-w-2xl text-sm leading-relaxed text-muted-foreground md:text-base">
@@ -101,7 +96,7 @@ function SchemaPickerPage({
 
         <div className="space-y-6">
           {error && (
-            <Alert variant="destructive">
+            <Alert variant="destructive" className="rounded-md">
               <AlertTitle>선택할 수 없는 형식입니다</AlertTitle>
               <AlertDescription>{error}</AlertDescription>
             </Alert>
@@ -111,7 +106,7 @@ function SchemaPickerPage({
             {schemas.map((schema) => (
               <Card
                 key={schema.schemaKey}
-                className="rounded-[1.5rem] bg-card/95 shadow-sm transition-transform hover:-translate-y-1"
+                className="stage-card rounded-md bg-card/95 shadow-sm transition-transform hover:-translate-y-0.5"
               >
                 <CardHeader className="border-b">
                   <div className="mb-3 flex flex-wrap items-center gap-2">

--- a/app/ponix/videos/video-operations-list.tsx
+++ b/app/ponix/videos/video-operations-list.tsx
@@ -171,7 +171,7 @@ export function VideoOperationsList({ videos }: { videos: CmsMemberVideo[] }) {
                 <TableRow key={video.id}>
                   <TableCell className="min-w-[25rem]">
                     <div className="flex items-center gap-4">
-                      <div className="relative grid h-20 w-28 shrink-0 place-items-center overflow-hidden rounded-xl border bg-muted">
+                      <div className="media-frame relative grid h-20 w-28 shrink-0 place-items-center overflow-hidden rounded-md border bg-muted">
                         {video.thumbnailUrl ? (
                           // eslint-disable-next-line @next/next/no-img-element
                           <img
@@ -396,7 +396,7 @@ function DeleteVideoDialog({ video }: { video: CmsMemberVideo }) {
             영상 기록과 연결된 업로드 파일을 함께 정리합니다. 복구 기능은 아직 없습니다.
           </AlertDialogDescription>
         </AlertDialogHeader>
-        <div className="flex gap-4 rounded-xl border bg-muted/30 p-4">
+        <div className="setlist-panel flex gap-4 rounded-md border bg-muted/30 p-4">
           <div className="grid h-24 w-32 shrink-0 place-items-center overflow-hidden rounded-lg border bg-muted">
             {video.thumbnailUrl ? (
               // eslint-disable-next-line @next/next/no-img-element

--- a/components/editorial.tsx
+++ b/components/editorial.tsx
@@ -21,11 +21,14 @@ export function PageHero({
   className,
 }: PageHeroProps) {
   return (
-    <header className={cn("mb-24 md:mb-28 xl:mb-32", className)}>
-      <p className="caps mb-6">{eyebrow}</p>
+    <header className={cn("hero-score -mx-6 mb-24 px-6 py-10 md:-mx-8 md:mb-28 md:px-8 md:py-12 xl:mb-32", className)}>
+      <div className="mb-8 flex items-center gap-4">
+        <p className="caps shrink-0">{eyebrow}</p>
+        <span aria-hidden className="accent-rule h-px min-w-12 flex-1 opacity-70" />
+      </div>
       <div className="grid grid-cols-12 gap-8 items-end">
         <div className="col-span-12 lg:col-span-8">
-          <h1 className="font-serif italic text-[clamp(2.4rem,13vw,6.5rem)] leading-[0.92] tracking-tight">
+          <h1 className="font-serif italic text-[clamp(2.4rem,13vw,6.5rem)] leading-[0.92]">
             {titleEn}
           </h1>
           <p className="mt-3 font-serif-kr text-[clamp(1.9rem,9vw,3rem)] text-muted-foreground">
@@ -69,8 +72,11 @@ export function EditorialSectionHead({
   return (
     <div className={cn("mb-12 md:mb-14 grid grid-cols-12 gap-8 items-end", className)}>
       <div className="col-span-12 md:col-span-8">
-        <p className="caps mb-3">{eyebrow}</p>
-        <h2 className="font-serif italic text-4xl md:text-5xl tracking-tight leading-none">
+        <div className="mb-3 flex items-center gap-3">
+          <p className="caps shrink-0">{eyebrow}</p>
+          <span aria-hidden className="accent-rule h-px w-12 opacity-70" />
+        </div>
+        <h2 className="font-serif italic text-4xl leading-none md:text-5xl">
           {en}
         </h2>
         <p className="mt-2 font-serif-kr text-lg md:text-xl text-muted-foreground">
@@ -130,7 +136,7 @@ export function EditorialMetricCard({
     <article
       style={tilt === "0deg" ? undefined : style}
       className={cn(
-        "rounded-md border p-6 md:p-7 shadow-sm hover:shadow-xl",
+        "stage-card rounded-md border p-6 shadow-sm hover:shadow-xl md:p-7",
         motionClass,
         isAccent
           ? "border-transparent bg-accent text-accent-foreground shadow-md"
@@ -204,7 +210,7 @@ export function EditorialFeatureCard({
     <article
       style={tilt === "0deg" ? undefined : style}
       className={cn(
-        "rounded-md border p-6 md:p-7 shadow-sm hover:shadow-xl",
+        "stage-card rounded-md border p-6 shadow-sm hover:shadow-xl md:p-7",
         motionClass,
         toneClass,
         className,
@@ -215,7 +221,7 @@ export function EditorialFeatureCard({
           {eyebrow}
         </p>
       )}
-      <h3 className="font-serif italic text-3xl md:text-4xl tracking-tight leading-tight">
+      <h3 className="font-serif italic text-3xl leading-tight md:text-4xl">
         {title}
       </h3>
       {subtitle && (

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -34,14 +34,14 @@ export type FooterConfig = {
 
 function ContactIcon({ kind }: { kind: FooterContactItem["kind"] }) {
   if (kind === "location") {
-    return <MapPin weight="light" className="w-4 h-4 mt-0.5 shrink-0 text-muted-foreground" />
+    return <MapPin weight="light" className="w-4 h-4 mt-0.5 shrink-0 text-primary-foreground/60" />
   }
 
   if (kind === "time") {
-    return <Clock weight="light" className="w-4 h-4 mt-0.5 shrink-0 text-muted-foreground" />
+    return <Clock weight="light" className="w-4 h-4 mt-0.5 shrink-0 text-primary-foreground/60" />
   }
 
-  return <LinkIcon weight="light" className="w-4 h-4 mt-0.5 shrink-0 text-muted-foreground" />
+  return <LinkIcon weight="light" className="w-4 h-4 mt-0.5 shrink-0 text-primary-foreground/60" />
 }
 
 function SocialIcon({ kind }: { kind: FooterSocialItem["kind"] }) {
@@ -60,7 +60,7 @@ export function Footer({ config }: { config: FooterConfig }) {
   const currentYear = new Date().getFullYear()
 
   return (
-    <footer className="border-t mt-32">
+    <footer className="mt-32 border-t bg-primary text-primary-foreground">
       <div className="max-w-6xl mx-auto px-6 md:px-8 py-16">
         <div className="grid grid-cols-1 md:grid-cols-12 gap-12">
           <div className="md:col-span-5">
@@ -70,14 +70,14 @@ export function Footer({ config }: { config: FooterConfig }) {
                 {config.titleEn}
               </span>
             </h3>
-            <p className="caps mt-3">{config.eyebrow}</p>
-            <p className="mt-6 text-sm text-muted-foreground max-w-md leading-relaxed">
+            <p className="caps mt-3 text-primary-foreground/60">{config.eyebrow}</p>
+            <p className="mt-6 max-w-md text-sm leading-relaxed text-primary-foreground/70">
               {config.description}
             </p>
           </div>
 
           <div className="md:col-span-3">
-            <p className="caps mb-4">{config.contactTitle}</p>
+            <p className="caps mb-4 text-primary-foreground/60">{config.contactTitle}</p>
             <ul className="space-y-3 text-sm">
               {config.contacts.map((contact) => (
                 <li key={`${contact.kind}:${contact.value}`} className="flex items-start gap-2">
@@ -89,7 +89,7 @@ export function Footer({ config }: { config: FooterConfig }) {
           </div>
 
           <div className="md:col-span-4">
-            <p className="caps mb-4">{config.socialTitle}</p>
+            <p className="caps mb-4 text-primary-foreground/60">{config.socialTitle}</p>
             <ul className="space-y-3 text-sm">
               {config.socials.map((social) => (
                 <li key={`${social.kind}:${social.href}`}>
@@ -97,7 +97,7 @@ export function Footer({ config }: { config: FooterConfig }) {
                   href={social.href}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center gap-3 hover:text-accent transition-colors"
+                  className="inline-flex items-center gap-3 text-primary-foreground/80 transition-colors hover:text-accent"
                 >
                   <SocialIcon kind={social.kind} />
                   <span>{social.label}</span>
@@ -110,11 +110,11 @@ export function Footer({ config }: { config: FooterConfig }) {
 
         <Separator className="my-10" />
 
-        <div className="flex flex-wrap items-center justify-between gap-4 text-sm text-muted-foreground">
+        <div className="flex flex-wrap items-center justify-between gap-4 text-sm text-primary-foreground/60">
           <span className="tabular-nums">
             © {config.foundingYear} — {currentYear} {config.copyrightName}
           </span>
-          <span className="caps">{config.sinceLabel}</span>
+          <span className="caps text-primary-foreground/60">{config.sinceLabel}</span>
         </div>
       </div>
     </footer>

--- a/components/home-section.tsx
+++ b/components/home-section.tsx
@@ -118,14 +118,14 @@ function AccentText({ text, accent }: { text: string; accent?: string | null }) 
 function StatCardView({ card }: { card: HomeStatCard }) {
   const tiltStyle = { "--card-tilt": card.tilt } as CSSProperties
   const base =
-    "group h-full rounded-md border overflow-hidden " +
+    "stage-card group h-full overflow-hidden rounded-md border " +
     "tilt-card hover:shadow-2xl"
 
   if (card.type === "text") {
     return (
       <div
         style={tiltStyle}
-        className={`${base} bg-card flex flex-col p-6 md:p-7 shadow-sm`}
+        className={`${base} bg-card flex flex-col p-6 shadow-sm md:p-7`}
       >
         <p className="caps">{card.label}</p>
         <div className="mt-auto flex items-baseline gap-1.5">
@@ -147,7 +147,7 @@ function StatCardView({ card }: { card: HomeStatCard }) {
     return (
       <div
         style={tiltStyle}
-        className={`${base} bg-accent text-accent-foreground flex flex-col p-6 md:p-7 shadow-md border-transparent`}
+        className={`${base} flex flex-col border-transparent bg-accent p-6 text-accent-foreground shadow-md md:p-7`}
       >
         <p className="caps text-accent-foreground/80">{card.label}</p>
         <div className="mt-auto flex items-baseline gap-1.5">
@@ -169,7 +169,7 @@ function StatCardView({ card }: { card: HomeStatCard }) {
       style={tiltStyle}
       className={`${base} bg-card flex flex-col shadow-md`}
     >
-      <div className="relative basis-[55%] grow-0 shrink-0 bg-muted overflow-hidden">
+      <div className="media-frame relative basis-[55%] grow-0 shrink-0 overflow-hidden bg-muted">
         {imageSrc && (
           <ContentImage
             src={imageSrc}
@@ -250,13 +250,16 @@ export function HomeSection({
     const title = section.title ?? ""
 
     return (
-      <section className="mb-28">
-        <div className="grid grid-cols-12 gap-8 md:gap-12 items-center">
+      <section className="hero-score -mx-6 mb-28 px-6 py-10 md:-mx-8 md:px-8 md:py-12">
+        <div className="grid grid-cols-12 items-center gap-8 md:gap-12">
           <div className="col-span-12 md:col-span-5 animate-in fade-in-0 slide-in-from-bottom-3 duration-700">
-            <p className="caps mb-6">
-              <AccentText text={eyebrow} accent={section.accentEyebrow} />
-            </p>
-            <h1 className="font-serif italic text-7xl md:text-8xl leading-[0.95] tracking-tight">
+            <div className="mb-6 flex items-center gap-4">
+              <p className="caps shrink-0">
+                <AccentText text={eyebrow} accent={section.accentEyebrow} />
+              </p>
+              <span aria-hidden className="accent-rule h-px min-w-12 flex-1 opacity-70" />
+            </div>
+            <h1 className="font-serif italic text-7xl leading-[0.95] md:text-8xl">
               <AccentText text={title} accent={section.accentTitle} />
             </h1>
             {section.subtitle && (
@@ -303,9 +306,9 @@ export function HomeSection({
             rel="noopener noreferrer"
             data-ponix-entity={homeFeaturedVideo.entityId}
             data-ponix-entity-kind="video"
-            className="col-span-12 md:col-span-7 group flex flex-col gap-4 animate-in fade-in-0 slide-in-from-bottom-3 duration-700 delay-100"
+            className="group col-span-12 flex flex-col gap-4 animate-in fade-in-0 slide-in-from-bottom-3 duration-700 delay-100 md:col-span-7"
           >
-            <div className="relative aspect-video overflow-hidden border bg-muted rounded-md">
+            <div className="media-frame relative aspect-video overflow-hidden rounded-md border bg-muted">
               <ContentImage
                 src={homeFeaturedVideo.thumbnailUrl ?? thumbnailUrl(homeFeaturedVideo.id, "max")}
                 alt={homeFeaturedVideo.title}
@@ -314,6 +317,11 @@ export function HomeSection({
                 sizes="(max-width: 768px) 100vw, 60vw"
                 className="object-cover transition-transform duration-700 group-hover:scale-[1.03]"
               />
+              <div className="absolute inset-0 bg-gradient-to-t from-primary/50 via-transparent to-transparent opacity-80" />
+              <span className="absolute left-3 top-3 inline-flex items-center gap-2 rounded-full border border-background/50 bg-background/80 px-3 py-1 text-xs font-medium backdrop-blur-md">
+                <Play weight="fill" className="size-3 text-accent" />
+                Live cut
+              </span>
               <span className="absolute bottom-2 right-2 caps tabular-nums bg-background/90 backdrop-blur-sm px-2 py-0.5 rounded-sm">
                 {homeFeaturedVideo.duration}
               </span>
@@ -347,7 +355,7 @@ export function HomeSection({
           />
         </Reveal>
 
-        <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-2.5 md:gap-2.5">
+        <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
           {homeStats.map((s, i) => (
             <Reveal key={s.label} as="li" delay={i * 90} className="aspect-[3/4]">
               <StatCardView card={s} />
@@ -391,7 +399,7 @@ export function HomeSection({
                 data-ponix-entity-kind="video"
                 className="group flex flex-col gap-3"
               >
-                <div className="relative aspect-video overflow-hidden border bg-muted rounded-md">
+                <div className="media-frame relative aspect-video overflow-hidden rounded-md border bg-muted">
                   <ContentImage
                     src={v.thumbnailUrl ?? thumbnailUrl(v.id, "max")}
                     alt={`${v.artist ?? "Bremen"} - ${v.song ?? v.title}`}
@@ -442,17 +450,17 @@ export function HomeSection({
           />
         </Reveal>
 
-        <ul className="border-t">
+        <ul className="setlist-panel rounded-md border border-border/80">
           {homeEvents.map((event, i) => (
             <Reveal
               key={event.title}
               as="li"
               delay={i * 70}
-              className="group border-b relative overflow-hidden"
+              className="group relative overflow-hidden border-b last:border-b-0"
             >
               <div
                 aria-hidden
-                className="absolute inset-0 bg-foreground/[0.02] -translate-x-full group-hover:translate-x-0 transition-transform duration-500"
+                className="absolute inset-0 -translate-x-full bg-foreground/[0.035] transition-transform duration-500 group-hover:translate-x-0"
               />
               <div className="relative grid grid-cols-12 gap-6 py-7 items-center">
                 <div className="col-span-3 md:col-span-2">
@@ -504,7 +512,7 @@ export function HomeSection({
           </>
         </Reveal>
 
-        <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-2.5 md:gap-2.5">
+        <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
           {homeActivities.map((area, i) => {
             const isColor = area.variant === "color"
             const tiltStyle = { "--card-tilt": area.tilt } as CSSProperties
@@ -518,7 +526,7 @@ export function HomeSection({
                 <article
                   style={tiltStyle}
                   className={
-                    "group relative h-full rounded-md border overflow-hidden " +
+                    "stage-card group relative h-full overflow-hidden rounded-md border " +
                     "tilt-card hover:shadow-2xl " +
                     (isColor
                       ? "bg-accent text-accent-foreground border-transparent shadow-md"
@@ -578,12 +586,12 @@ export function HomeSection({
     const body = section.body ?? ""
 
     return (
-      <section className="border-t pt-16">
+      <section className="hero-score -mx-6 px-6 py-14 md:-mx-8 md:px-8 md:py-16">
         <Reveal offset={24} blur={10}>
           <div className="grid grid-cols-12 gap-8 items-end">
             <div className="col-span-12 md:col-span-8">
               <p className="caps mb-3">{section.eyebrow}</p>
-              <h2 className="font-serif italic text-4xl md:text-6xl leading-tight tracking-tight">
+              <h2 className="font-serif italic text-4xl leading-tight md:text-6xl">
                 {section.title}
               </h2>
               <p className="mt-2 font-serif-kr text-2xl md:text-3xl text-foreground">
@@ -628,7 +636,7 @@ export function HomeSection({
   }
 
   return (
-    <div className="max-w-6xl mx-auto px-6 md:px-8 py-12 md:py-20">
+    <div className="mx-auto max-w-6xl px-6 py-12 md:px-8 md:py-20">
       {homeSections.map((section) => {
         const renderedSection = renderSection(section)
 

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -78,7 +78,7 @@ export function Navigation({ isSignedIn = false, config }: NavigationProps) {
     : config.accountSignedOutLabel
 
   return (
-    <header className="fixed top-0 left-0 right-0 z-50 bg-background/85 backdrop-blur-md border-b">
+    <header className="fixed left-0 right-0 top-0 z-50 border-b bg-background/80 shadow-[0_1px_0_color-mix(in_oklch,var(--stage-brass)_20%,transparent)] backdrop-blur-xl">
       <div className="max-w-6xl mx-auto px-6 md:px-8">
         <div className="flex items-center justify-between h-16 gap-6">
           <Link href={config.brandHref} aria-label={config.brandAriaLabel} className="flex items-center gap-3 shrink-0">
@@ -116,7 +116,7 @@ export function Navigation({ isSignedIn = false, config }: NavigationProps) {
                       className={
                         isActive
                           ? "text-foreground"
-                          : "text-muted-foreground group-hover:text-foreground transition-colors"
+                          : "text-muted-foreground transition-colors group-hover:text-foreground"
                       }
                     >
                       {tab.label}
@@ -124,7 +124,7 @@ export function Navigation({ isSignedIn = false, config }: NavigationProps) {
                     {isActive && (
                       <span
                         aria-hidden
-                        className="absolute left-3 right-3 md:left-4 md:right-4 -bottom-px h-px bg-foreground"
+                        className="accent-rule absolute -bottom-px left-3 right-3 h-[2px] md:left-4 md:right-4"
                       />
                     )}
                   </Link>

--- a/components/performances-section.tsx
+++ b/components/performances-section.tsx
@@ -77,8 +77,8 @@ function PlaylistCard({
 }) {
   const hasRecordings = playlist.recordingCount > 0
   const body = (
-    <article className="lift-card group flex h-full flex-col overflow-hidden rounded-md border bg-card shadow-sm hover:shadow-xl">
-      <div className="relative aspect-video bg-muted">
+    <article className="stage-card lift-card group flex h-full flex-col overflow-hidden rounded-md border bg-card shadow-sm hover:shadow-xl">
+      <div className="media-frame relative aspect-video bg-muted">
         {playlist.coverUrl ? (
           <ContentImage
             src={playlist.coverUrl}
@@ -92,7 +92,7 @@ function PlaylistCard({
             {playlist.year}
           </div>
         )}
-        <div className="absolute inset-0 bg-gradient-to-t from-background/82 via-background/5 to-transparent" />
+        <div className="absolute inset-0 bg-gradient-to-t from-primary/75 via-background/10 to-transparent" />
         <Badge className="absolute left-4 top-4 border border-background/70 bg-background/90 text-foreground shadow-sm backdrop-blur-sm hover:bg-background/90">
           {playlist.type}
         </Badge>
@@ -205,7 +205,7 @@ export function SeasonIndex({
           <Reveal key={year} delay={yearIndex * 60}>
             <details
               open={yearIndex < 2}
-              className="group rounded-md border bg-card px-5 py-4"
+              className="setlist-panel group rounded-md border px-5 py-4"
             >
               <summary className="flex cursor-pointer list-none items-center justify-between gap-4">
                 <span className="font-serif italic text-4xl leading-none">{year}</span>
@@ -293,9 +293,9 @@ export function StageMoments({
           <Reveal key={photo.id} as="li" delay={index * 50}>
             <Link
               href="/photos"
-              className="group block overflow-hidden rounded-md border bg-card"
+              className="stage-card group block overflow-hidden rounded-md border bg-card"
             >
-              <div className="relative aspect-[3/4] bg-muted">
+              <div className="media-frame relative aspect-[3/4] bg-muted">
                 {photo.thumbnailUrl && (
                   <ContentImage
                     src={photo.thumbnailUrl}
@@ -328,8 +328,8 @@ export function PerformanceUpdateCard({
 }) {
   const meta = updateKindMeta[update.kind]
   const body = (
-    <article className="lift-card group grid h-full grid-cols-1 overflow-hidden rounded-md border bg-card shadow-sm hover:shadow-xl sm:grid-cols-[10rem_1fr]">
-      <div className="relative min-h-52 bg-muted sm:min-h-full">
+    <article className="stage-card lift-card group grid h-full grid-cols-1 overflow-hidden rounded-md border bg-card shadow-sm hover:shadow-xl sm:grid-cols-[10rem_1fr]">
+      <div className="media-frame relative min-h-52 bg-muted sm:min-h-full">
         {update.thumbnailUrl ? (
           <ContentImage
             src={update.thumbnailUrl}

--- a/components/photos-section.tsx
+++ b/components/photos-section.tsx
@@ -129,7 +129,7 @@ export function PhotoGallerySurface({
 
   const filterControls = (
     <Reveal offset={18} blur={8}>
-      <section className="sticky top-20 z-20 mb-8 border-y bg-background/88 py-4 backdrop-blur-md">
+      <section className="sticky top-20 z-20 mb-8 rounded-md border bg-background/88 px-4 py-4 shadow-sm backdrop-blur-xl">
         <div className="flex flex-wrap items-center gap-2">
           <span className="caps mr-2">분류</span>
           {categories.map((category) => {
@@ -187,7 +187,7 @@ export function PhotoGallerySurface({
               (item) => item.id === photo.id,
             )
             const cardClassName = cn(
-              "lift-card group relative block w-full overflow-hidden rounded-md border text-left shadow-sm hover:shadow-xl",
+              "stage-card lift-card group relative block w-full overflow-hidden rounded-md border text-left shadow-sm hover:shadow-xl",
               "bg-gradient-to-br",
               pinHeight(photo, index),
               photoTone[photo.category] ?? "from-stone-100 via-stone-50 to-white",
@@ -211,9 +211,9 @@ export function PhotoGallerySurface({
                   />
                 )}
                 {photo.thumbnailUrl && (
-                  <div className="absolute inset-0 bg-gradient-to-t from-background/88 via-background/8 to-transparent" />
+                  <div className="absolute inset-0 bg-gradient-to-t from-primary/75 via-background/10 to-transparent" />
                 )}
-                <div className="absolute -right-8 -top-8 h-28 w-28 rounded-full bg-background/50 blur-2xl transition-transform duration-700 group-hover:scale-125" />
+                <div className="absolute inset-x-0 top-0 h-1 accent-rule opacity-70" />
                 {isVideo && (
                   <div className="absolute left-4 top-4 z-10 inline-flex items-center gap-2 rounded-full border border-background/60 bg-foreground px-3 py-1 text-xs font-medium text-background shadow-sm">
                     <Play weight="fill" className="size-3" />

--- a/components/videos-section.tsx
+++ b/components/videos-section.tsx
@@ -159,9 +159,9 @@ function VideoCard({
         href={videoWatchUrl(video)}
         target="_blank"
         rel="noopener noreferrer"
-        className="lift-card group flex h-full flex-col overflow-hidden rounded-md border bg-card shadow-sm hover:shadow-xl"
+        className="stage-card lift-card group flex h-full flex-col overflow-hidden rounded-md border bg-card shadow-sm hover:shadow-xl"
       >
-        <div className="relative aspect-video overflow-hidden bg-muted">
+        <div className="media-frame relative aspect-video overflow-hidden bg-muted">
           {thumbnail ? (
             <ContentImage
               src={thumbnail}
@@ -229,9 +229,9 @@ function FeaturedVideoCard({ video }: { video: Video }) {
         target="_blank"
         rel="noopener noreferrer"
         style={{ "--card-tilt": "-1deg" } as CSSProperties}
-        className="tilt-card group flex h-full flex-col overflow-hidden rounded-md border bg-card shadow-sm hover:shadow-xl"
+        className="stage-card tilt-card group flex h-full flex-col overflow-hidden rounded-md border bg-card shadow-sm hover:shadow-xl"
       >
-        <div className="relative aspect-[16/10] overflow-hidden bg-muted">
+        <div className="media-frame relative aspect-[16/10] overflow-hidden bg-muted">
           {thumbnail ? (
             <ContentImage
               src={thumbnail}
@@ -248,7 +248,7 @@ function FeaturedVideoCard({ video }: { video: Video }) {
               />
             </div>
           )}
-          <div className="absolute inset-0 bg-gradient-to-t from-background/90 via-background/20 to-transparent" />
+          <div className="absolute inset-0 bg-gradient-to-t from-primary/80 via-background/20 to-transparent" />
           <span className="absolute bottom-4 right-4 caps tabular-nums rounded-sm bg-background/90 px-2 py-0.5 backdrop-blur-sm">
             {video.duration}
           </span>
@@ -535,7 +535,7 @@ export function FeaturedVideosSurface({
         </div>
         <div className="col-span-12 lg:col-span-5">
           <Reveal offset={18} blur={8}>
-            <div className="mb-4 flex items-center justify-between">
+          <div className="mb-4 flex items-center justify-between border-b pb-3">
               <p className="caps">
                 {popularSection?.title}
               </p>
@@ -628,7 +628,7 @@ export function VideoLibrarySurface({
       </Reveal>
 
       <Reveal offset={18} blur={8}>
-        <div className="mb-8 rounded-md border bg-card/80 p-4 shadow-sm md:p-5">
+        <div className="setlist-panel mb-8 rounded-md border p-4 shadow-sm md:p-5">
           <div className="grid grid-cols-1 gap-3 md:grid-cols-[1fr_16rem_12rem]">
             <label className="relative">
               <span className="sr-only">영상 검색</span>


### PR DESCRIPTION
## Summary
- Reworked the shared public theme around stage ink, brass, oxide, score-line textures, and tighter border radius tokens.
- Applied the same stage/score surface language across public pages and PONIX/CMS management screens without changing the entity graph architecture.
- Removed old cream/radial admin decoration and reduced oversized rounded card treatments in CMS workflows.

## Verification
- /opt/homebrew/bin/pnpm exec tsc --noEmit
- /opt/homebrew/bin/pnpm run lint
- /opt/homebrew/bin/pnpm run qa:content-graph
- /opt/homebrew/bin/pnpm run qa:cms-legacy-bridge-boundary
- /opt/homebrew/bin/pnpm run build
- Browser smoke on /, /videos, /performances, /photos at 1280x860 and 390x844: no horizontal overflow and no console errors

## Notes
- Authenticated PONIX visual smoke was not run because the browser session redirected to /login?next=%2Fponix as expected.
- Closes #218