### PR TITLE
Fix accent stage card contrast

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -232,6 +232,56 @@
       );
   }
 
+  .stage-card.bg-accent {
+    background:
+      repeating-linear-gradient(
+        180deg,
+        transparent 0,
+        transparent 1.1rem,
+        color-mix(in oklch, var(--accent-foreground) 8%, transparent) 1.14rem,
+        transparent 1.2rem
+      ),
+      linear-gradient(
+        180deg,
+        color-mix(in oklch, var(--accent) 90%, var(--stage-brass)),
+        color-mix(in oklch, var(--accent) 96%, var(--primary))
+      );
+  }
+
+  .stage-card.bg-primary {
+    background:
+      repeating-linear-gradient(
+        180deg,
+        transparent 0,
+        transparent 1.1rem,
+        color-mix(in oklch, var(--primary-foreground) 7%, transparent) 1.14rem,
+        transparent 1.2rem
+      ),
+      linear-gradient(
+        180deg,
+        color-mix(in oklch, var(--primary) 94%, var(--stage-oxide)),
+        var(--primary)
+      );
+  }
+
+  .stage-card.bg-accent::after,
+  .stage-card.bg-primary::after {
+    background: linear-gradient(
+      90deg,
+      color-mix(in oklch, var(--accent-foreground) 90%, transparent),
+      var(--stage-brass),
+      color-mix(in oklch, var(--stage-paper) 70%, transparent)
+    );
+  }
+
+  .stage-card.bg-accent .caps {
+    color: color-mix(in oklch, var(--accent-foreground) 78%, transparent);
+  }
+
+  .stage-card.bg-primary .caps {
+    color: color-mix(in oklch, var(--primary-foreground) 72%, transparent);
+  }
+
   .stage-card::after {
     position: absolute;
     inset: auto 0 0;


### PR DESCRIPTION
## Summary
- Restores colored backgrounds for `.stage-card.bg-accent` and `.stage-card.bg-primary` combinations.
- Forces `.caps` text inside those colored cards to use the corresponding foreground color.
- Keeps the stage-card texture centralized in shared CSS instead of removing the component class from individual cards.

## Verification
- /opt/homebrew/bin/pnpm exec tsc --noEmit
- /opt/homebrew/bin/pnpm run lint
- /opt/homebrew/bin/pnpm run build
- /opt/homebrew/bin/pnpm run qa:content-graph
- /opt/homebrew/bin/pnpm run qa:cms-legacy-bridge-boundary
- Local browser smoke on home stat and activity cards, no console errors

Closes #220
