### PR TITLE
Reject the paper memo direction

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,58 +5,56 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  --background: oklch(0.965 0.01 126);
-  --foreground: oklch(0.17 0.018 154);
-  --card: oklch(0.982 0.006 112);
-  --card-foreground: oklch(0.17 0.018 154);
-  --popover: oklch(0.982 0.006 112);
-  --popover-foreground: oklch(0.17 0.018 154);
-  --primary: oklch(0.20 0.024 158);
-  --primary-foreground: oklch(0.97 0.01 118);
-  --secondary: oklch(0.92 0.016 116);
-  --secondary-foreground: oklch(0.20 0.024 158);
-  --muted: oklch(0.92 0.016 116);
-  --muted-foreground: oklch(0.47 0.024 150);
-  --accent: oklch(0.55 0.16 25);
-  --accent-foreground: oklch(0.98 0.012 105);
+  --background: oklch(0.955 0.002 74);
+  --foreground: oklch(0.16 0.01 55);
+  --card: oklch(0.985 0.001 74);
+  --card-foreground: oklch(0.16 0.01 55);
+  --popover: oklch(0.985 0.001 74);
+  --popover-foreground: oklch(0.16 0.01 55);
+  --primary: oklch(0.18 0.01 55);
+  --primary-foreground: oklch(0.975 0.001 74);
+  --secondary: oklch(0.91 0.002 74);
+  --secondary-foreground: oklch(0.18 0.01 55);
+  --muted: oklch(0.91 0.002 74);
+  --muted-foreground: oklch(0.43 0.012 58);
+  --accent: oklch(0.47 0.16 25);
+  --accent-foreground: oklch(0.98 0.001 74);
   --destructive: oklch(0.50 0.20 28);
-  --destructive-foreground: oklch(0.98 0.012 105);
-  --border: oklch(0.80 0.022 126);
-  --input: oklch(0.84 0.018 126);
-  --ring: oklch(0.55 0.16 25);
-  --stage-ink: oklch(0.17 0.018 154);
-  --stage-brass: oklch(0.70 0.11 82);
-  --stage-oxide: oklch(0.44 0.07 176);
-  --stage-paper: oklch(0.955 0.014 118);
-  --stage-line: color-mix(in oklch, var(--stage-ink) 12%, transparent);
+  --destructive-foreground: oklch(0.98 0.001 74);
+  --border: oklch(0.77 0.004 74);
+  --input: oklch(0.82 0.003 74);
+  --ring: oklch(0.47 0.16 25);
+  --stage-ink: oklch(0.16 0.01 55);
+  --stage-brass: oklch(0.66 0.10 78);
+  --stage-shadow: oklch(0.34 0.014 70);
+  --stage-surface: oklch(0.965 0.001 74);
   --radius: 0.25rem;
 }
 
 .dark {
-  --background: oklch(0.13 0.018 160);
-  --foreground: oklch(0.94 0.01 112);
-  --card: oklch(0.17 0.02 160);
-  --card-foreground: oklch(0.94 0.01 112);
-  --popover: oklch(0.17 0.02 160);
-  --popover-foreground: oklch(0.94 0.01 112);
-  --primary: oklch(0.94 0.01 112);
-  --primary-foreground: oklch(0.17 0.02 160);
-  --secondary: oklch(0.22 0.026 160);
-  --secondary-foreground: oklch(0.94 0.01 112);
-  --muted: oklch(0.22 0.026 160);
-  --muted-foreground: oklch(0.70 0.02 132);
-  --accent: oklch(0.70 0.13 62);
-  --accent-foreground: oklch(0.16 0.018 160);
+  --background: oklch(0.13 0.01 55);
+  --foreground: oklch(0.94 0.001 74);
+  --card: oklch(0.17 0.012 55);
+  --card-foreground: oklch(0.94 0.001 74);
+  --popover: oklch(0.17 0.012 55);
+  --popover-foreground: oklch(0.94 0.001 74);
+  --primary: oklch(0.94 0.001 74);
+  --primary-foreground: oklch(0.16 0.012 55);
+  --secondary: oklch(0.22 0.012 55);
+  --secondary-foreground: oklch(0.94 0.001 74);
+  --muted: oklch(0.22 0.012 55);
+  --muted-foreground: oklch(0.70 0.002 74);
+  --accent: oklch(0.66 0.14 34);
+  --accent-foreground: oklch(0.98 0.001 74);
   --destructive: oklch(0.50 0.20 28);
-  --destructive-foreground: oklch(0.94 0.01 112);
-  --border: oklch(0.30 0.026 160);
-  --input: oklch(0.30 0.026 160);
-  --ring: oklch(0.70 0.13 62);
-  --stage-ink: oklch(0.94 0.01 112);
-  --stage-brass: oklch(0.76 0.12 82);
-  --stage-oxide: oklch(0.58 0.08 176);
-  --stage-paper: oklch(0.16 0.018 160);
-  --stage-line: color-mix(in oklch, var(--stage-ink) 14%, transparent);
+  --destructive-foreground: oklch(0.94 0.001 74);
+  --border: oklch(0.30 0.012 55);
+  --input: oklch(0.30 0.012 55);
+  --ring: oklch(0.66 0.14 34);
+  --stage-ink: oklch(0.94 0.001 74);
+  --stage-brass: oklch(0.74 0.10 78);
+  --stage-shadow: oklch(0.50 0.014 70);
+  --stage-surface: oklch(0.16 0.012 55);
 }
 
 @theme inline {
@@ -140,16 +138,14 @@
     overflow-x: clip;
     background:
       linear-gradient(
-        115deg,
-        color-mix(in oklch, var(--stage-oxide) 8%, transparent) 0%,
-        transparent 34%
-      ),
-      repeating-linear-gradient(
         180deg,
-        transparent 0,
-        transparent 5.2rem,
-        color-mix(in oklch, var(--stage-ink) 5%, transparent) 5.25rem,
-        transparent 5.32rem
+        color-mix(in oklch, var(--card) 72%, transparent) 0%,
+        transparent 20rem
+      ),
+      linear-gradient(
+        115deg,
+        color-mix(in oklch, var(--stage-brass) 4%, transparent) 0%,
+        transparent 32%
       ),
       var(--background);
   }
@@ -163,20 +159,18 @@
     background:
       linear-gradient(
         90deg,
-        transparent 0,
-        transparent calc(50% - 1px),
-        color-mix(in oklch, var(--stage-ink) 5%, transparent) calc(50% - 1px),
-        color-mix(in oklch, var(--stage-ink) 5%, transparent) calc(50% + 1px),
-        transparent calc(50% + 1px)
+        color-mix(in oklch, var(--stage-ink) 5%, transparent),
+        transparent 18%,
+        transparent 82%,
+        color-mix(in oklch, var(--stage-ink) 4%, transparent)
       ),
-      repeating-linear-gradient(
-        90deg,
-        transparent 0,
-        transparent 6.5rem,
-        color-mix(in oklch, var(--stage-brass) 10%, transparent) 6.55rem,
-        transparent 6.62rem
+      linear-gradient(
+        180deg,
+        transparent 0%,
+        color-mix(in oklch, var(--stage-ink) 4%, transparent) 100%
       );
-    mask-image: linear-gradient(to bottom, black 0%, black 55%, transparent 100%);
+    opacity: 0.55;
+    mask-image: linear-gradient(to bottom, black 0%, black 52%, transparent 100%);
   }
 
   .hero-score {
@@ -185,9 +179,9 @@
     border-block: 1px solid var(--border);
     background:
       linear-gradient(
-        135deg,
-        color-mix(in oklch, var(--card) 92%, transparent),
-        color-mix(in oklch, var(--stage-paper) 86%, transparent)
+        180deg,
+        color-mix(in oklch, var(--card) 98%, white),
+        color-mix(in oklch, var(--stage-surface) 96%, var(--background))
       );
   }
 
@@ -197,21 +191,14 @@
     pointer-events: none;
     content: '';
     background:
-      repeating-linear-gradient(
-        180deg,
-        transparent 0,
-        transparent 1.05rem,
-        color-mix(in oklch, var(--stage-ink) 7%, transparent) 1.09rem,
-        transparent 1.16rem
-      ),
       linear-gradient(
         90deg,
-        color-mix(in oklch, var(--accent) 14%, transparent),
-        transparent 26%,
+        color-mix(in oklch, var(--accent) 5%, transparent),
+        transparent 34%,
         transparent 72%,
-        color-mix(in oklch, var(--stage-oxide) 13%, transparent)
+        color-mix(in oklch, var(--stage-brass) 6%, transparent)
       );
-    opacity: 0.62;
+    opacity: 0.45;
   }
 
   .hero-score > * {
@@ -222,44 +209,27 @@
     position: relative;
     overflow: hidden;
     background:
-      linear-gradient(180deg, color-mix(in oklch, var(--card) 94%, transparent), var(--card)),
-      repeating-linear-gradient(
+      linear-gradient(
         180deg,
-        transparent 0,
-        transparent 1.1rem,
-        color-mix(in oklch, var(--stage-ink) 4%, transparent) 1.14rem,
-        transparent 1.2rem
+        color-mix(in oklch, var(--card) 98%, white),
+        color-mix(in oklch, var(--card) 94%, var(--background))
       );
   }
 
   .stage-card.bg-accent {
     background:
-      repeating-linear-gradient(
-        180deg,
-        transparent 0,
-        transparent 1.1rem,
-        color-mix(in oklch, var(--accent-foreground) 8%, transparent) 1.14rem,
-        transparent 1.2rem
-      ),
       linear-gradient(
         180deg,
-        color-mix(in oklch, var(--accent) 90%, var(--stage-brass)),
-        color-mix(in oklch, var(--accent) 96%, var(--primary))
+        color-mix(in oklch, var(--accent) 86%, var(--primary)),
+        color-mix(in oklch, var(--accent) 74%, var(--primary))
       );
   }
 
   .stage-card.bg-primary {
     background:
-      repeating-linear-gradient(
-        180deg,
-        transparent 0,
-        transparent 1.1rem,
-        color-mix(in oklch, var(--primary-foreground) 7%, transparent) 1.14rem,
-        transparent 1.2rem
-      ),
       linear-gradient(
         180deg,
-        color-mix(in oklch, var(--primary) 94%, var(--stage-oxide)),
+        color-mix(in oklch, var(--primary) 92%, var(--stage-shadow)),
         var(--primary)
       );
   }
@@ -270,7 +240,7 @@
       90deg,
       color-mix(in oklch, var(--accent-foreground) 90%, transparent),
       var(--stage-brass),
-      color-mix(in oklch, var(--stage-paper) 70%, transparent)
+      color-mix(in oklch, var(--stage-surface) 70%, transparent)
     );
   }
 
@@ -291,7 +261,7 @@
       90deg,
       var(--accent),
       var(--stage-brass),
-      color-mix(in oklch, var(--stage-oxide) 75%, var(--accent))
+      color-mix(in oklch, var(--stage-shadow) 75%, var(--accent))
     );
     opacity: 0;
     transform: scaleX(0.35);
@@ -310,18 +280,15 @@
   .media-frame {
     box-shadow:
       inset 0 0 0 1px color-mix(in oklch, var(--stage-ink) 12%, transparent),
-      0 18px 50px color-mix(in oklch, var(--stage-ink) 13%, transparent);
+      0 18px 42px color-mix(in oklch, var(--stage-ink) 12%, transparent);
   }
 
   .setlist-panel {
     background:
-      linear-gradient(180deg, color-mix(in oklch, var(--card) 86%, transparent), var(--card)),
-      repeating-linear-gradient(
+      linear-gradient(
         180deg,
-        transparent 0,
-        transparent 2.35rem,
-        color-mix(in oklch, var(--stage-ink) 7%, transparent) 2.4rem,
-        transparent 2.47rem
+        color-mix(in oklch, var(--card) 94%, white),
+        color-mix(in oklch, var(--card) 90%, var(--background))
       );
   }
 
@@ -330,7 +297,7 @@
       90deg,
       var(--accent),
       var(--stage-brass),
-      color-mix(in oklch, var(--stage-oxide) 85%, white)
+      color-mix(in oklch, var(--stage-shadow) 85%, white)
     );
   }
 
@@ -348,7 +315,7 @@
   }
 
   .tilt-card {
-    transform: translateZ(0) rotate(var(--card-tilt, 0deg)) translateY(0) scale(1);
+    transform: translateZ(0) translateY(0) scale(1);
     transform-origin: center center;
     transition:
       transform 700ms cubic-bezier(0.22, 1, 0.36, 1),
@@ -357,7 +324,7 @@
   }
 
   .tilt-card:hover {
-    transform: translateZ(0) rotate(0deg) translateY(-4px) scale(1.02);
+    transform: translateZ(0) translateY(-4px) scale(1.01);
   }
 
   [data-ponix-entity] {

--- a/components/home-section.tsx
+++ b/components/home-section.tsx
@@ -357,7 +357,12 @@ export function HomeSection({
 
         <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
           {homeStats.map((s, i) => (
-            <Reveal key={s.label} as="li" delay={i * 90} className="aspect-[3/4]">
+            <Reveal
+              key={s.label}
+              as="li"
+              delay={i * 90}
+              className="min-h-[16rem] sm:min-h-[18rem] lg:min-h-[20rem]"
+            >
               <StatCardView card={s} />
             </Reveal>
           ))}
@@ -521,7 +526,7 @@ export function HomeSection({
                 key={area.id ?? area.title}
                 as="li"
                 delay={i * 80}
-                className="aspect-[3/4]"
+                className="min-h-[16rem] sm:min-h-[18rem] lg:min-h-[20rem]"
               >
                 <article
                   style={tiltStyle}


### PR DESCRIPTION
## Summary
- Remove the green grid-paper visual treatment from shared public surfaces.
- Replace pink/memo-like card styling with neutral matte cards plus a deeper Bremen red accent.
- Remove default rotated-card presentation and tighten home stat/activity card height so cards do not read as empty paper.

## Verification
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm run build
- pnpm run qa:content-graph
- pnpm run qa:cms-legacy-bridge-boundary
- git diff --check
- Local browser desktop/mobile visual smoke: no repeating grid gradients, no card rotation, no horizontal overflow

Closes #223